### PR TITLE
walkmod cfg

### DIFF
--- a/walkmod.xml
+++ b/walkmod.xml
@@ -1,0 +1,18 @@
+<!DOCTYPE walkmod PUBLIC "-//WALKMOD//DTD"  "http://www.walkmod.com/dtd/walkmod-1.1.dtd" >
+<walkmod>
+    <chain name="main-chain">
+      <reader path="." >
+	  <exclude wildcard=".git" />
+          <exclude wildcard="*.bat"/>
+          <exclude wildcard="*.png"/>
+          <exclude wildcard="*.exe"/>
+          <exclude wildcard="*.gif"/>
+          <exclude wildcard="*.ser"/>
+          <exclude wildcard="*.jpg"/>
+       </reader>
+       <walker type="rawfiles:walker" />
+       <writer path="." type="rawfiles:writer" >
+           <param name="platform">unix</param>
+       </writer>
+    </chain>
+</walkmod>


### PR DESCRIPTION
I have upgraded walkmod to allow executions without code transformations (just writing files). You need to donwload the 2.1.0 version. To analyze the results, you just need to execute:

```
walkmod apply
```

If you want to execute walkmod and you have not changes into the plugins you are using, is faster to execute:

```
walkmod apply --offline
```

If it is ok for you, I can proceed to:

1) Create the checkstyle plugin to automatically correct checkstyle problems.
2) Upgrade the pom.xml file to launch walkmod from the build process.
