### PR TITLE
Fix intermittent test errors in singleton.DependsOnTest.

### DIFF
--- a/container/openejb-core/src/test/java/org/apache/openejb/core/singleton/DependsOnTest.java
+++ b/container/openejb-core/src/test/java/org/apache/openejb/core/singleton/DependsOnTest.java
@@ -31,10 +31,7 @@ import org.apache.openejb.config.ValidationFailure;
 import org.apache.openejb.core.ivm.naming.InitContextFactory;
 import org.apache.openejb.jee.EjbJar;
 import org.apache.openejb.jee.SingletonBean;
-import org.apache.openejb.jee.StatelessBean;
 import org.junit.AfterClass;
-import org.junit.FixMethodOrder;
-import org.junit.runners.MethodSorters;
 
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
@@ -87,10 +84,10 @@ public class DependsOnTest extends TestCase {
 
         final EjbJar ejbJar = new EjbJar();
 
-        ejbJar.addEnterpriseBean(new StatelessBean(Two.class));
+        ejbJar.addEnterpriseBean(new SingletonBean(Two.class));
         ejbJar.addEnterpriseBean(new SingletonBean(One.class));
         ejbJar.addEnterpriseBean(new SingletonBean(Four.class));
-        ejbJar.addEnterpriseBean(new StatelessBean(Three.class));
+        ejbJar.addEnterpriseBean(new SingletonBean(Three.class));
 
         // startup and trigger @PostConstruct
         assembler.createApplication(config.configureApplication(ejbJar));


### PR DESCRIPTION
For me the `org.apache.openejb.core.singleton.DependsOnTest.test()` fails in ~9 of 10 attempts, I think because somehow stateless session beans are used while the startup and destroy behavior of singleton EJBs should be tested.

My observation was that the destroy order was sometimes `[one, two, two, three, three, four]`.
Exact order differed between multiple runs, but it was always that the stateless session beans two and three appeared multiple times.