### PR TITLE
Avoid NPE in RemoteTomEEContainer.start()

### DIFF
--- a/arquillian/arquillian-tomee-remote/src/main/java/org/apache/tomee/arquillian/remote/RemoteTomEEContainer.java
+++ b/arquillian/arquillian-tomee-remote/src/main/java/org/apache/tomee/arquillian/remote/RemoteTomEEContainer.java
@@ -129,7 +129,9 @@ public class RemoteTomEEContainer extends TomEEContainer<RemoteTomEEConfiguratio
                 }
             }
         } catch (final Exception e) {
-            container.destroy();
+            if (container != null) {
+                container.destroy();
+            }
             logger.log(Level.SEVERE, "Unable to start remote container", e);
             throw new LifecycleException("Unable to start remote container:" + e.getMessage(), e);
         } finally {


### PR DESCRIPTION
If the Arquillian configuration contains errors or some other problems occur during configuration processing a NullPointerException occurs in the catch block in `RemoteTomEEConfiguration.start()` because the container might not be initialized yet.

In this case the user will not get any feedback about the real error, because logging is done afterwards.

This PR simply only invokes `container.destroy()` if the container is not null.
