### PR TITLE
Set delegate jar scan filter when creating TomEE Jar Scanner

### DIFF
--- a/tomee/tomee-loader/src/main/java/org/apache/tomee/loader/TomcatHelper.java
+++ b/tomee/tomee-loader/src/main/java/org/apache/tomee/loader/TomcatHelper.java
@@ -24,6 +24,8 @@ import org.apache.catalina.Wrapper;
 import org.apache.catalina.core.StandardContext;
 import org.apache.catalina.core.StandardServer;
 import org.apache.openejb.loader.SystemInstance;
+import org.apache.tomcat.JarScanFilter;
+import org.apache.tomcat.JarScanner;
 import org.apache.tomcat.util.scan.StandardJarScanner;
 
 import javax.management.MBeanServer;
@@ -156,9 +158,10 @@ public class TomcatHelper {
 
     public static void configureJarScanner(final Context standardContext) {
         try { // override only if default
+            JarScanner standardJarScanner = standardContext.getJarScanner();
             if ("true".equalsIgnoreCase(SystemInstance.get().getProperty("tomee.tomcat.override.jar-scanner", "true"))
-                    && !TomEEJarScanner.class.isInstance(standardContext.getJarScanner())
-                    && StandardJarScanner.class.isInstance(standardContext.getJarScanner())) {
+                    && !TomEEJarScanner.class.isInstance(standardJarScanner)
+                    && StandardJarScanner.class.isInstance(standardJarScanner)) {
                 final TomEEJarScanner jarScanner = new TomEEJarScanner();
 
                 final Properties properties = SystemInstance.get().getProperties();
@@ -170,6 +173,10 @@ public class TomcatHelper {
                 if (scanBootstrap != null) {
                     jarScanner.setScanBootstrapClassPath(Boolean.parseBoolean(scanBootstrap));
                 }
+
+                JarScanFilter jarScanFilter = standardJarScanner.getJarScanFilter();
+                if (jarScanFilter != null)
+                    jarScanner.setJarScanFilter(jarScanFilter);
 
                 standardContext.setJarScanner(jarScanner);
             }


### PR DESCRIPTION
The TomEE Jar Scanner does not respect the tomcat.util.scan.StandardJarScanFilter.* system properties. 

See [https://tomcat.apache.org/tomcat-8.5-doc/config/jar-scan-filter.html](https://tomcat.apache.org/tomcat-8.5-doc/config/jar-scan-filter.html)

This patch delegates jar scan filtering to the standard jar scan filter as default, without explicitly setting the &lt;JarScanner&gt; className attribute to "org.apache.tomee.loader.TomEEJarScanner" in context.xml
