### PR TITLE
Fix the double-check locking

### DIFF
--- a/container/openejb-core/src/main/java/org/apache/openejb/cdi/WebappWebBeansContext.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/cdi/WebappWebBeansContext.java
@@ -27,7 +27,7 @@ import javax.enterprise.inject.spi.Bean;
 
 public class WebappWebBeansContext extends WebBeansContext {
     private final WebBeansContext parent;
-    private BeanManagerImpl bm;
+    private volatile BeanManagerImpl bm;
 
     public WebappWebBeansContext(final Map<Class<?>, Object> services, final Properties properties, final WebBeansContext webBeansContext) {
         super(services, properties);


### PR DESCRIPTION
Due to the java memory model it was
possible to create more than one instance
of the WebappBeanManager. More information
at: http://www.cs.umd.edu/%7Epugh/java/memoryModel/DoubleCheckedLocking.html

Bug: https://issues.apache.org/jira/browse/TOMEE-1934
