### PR TITLE
Use Locale.ENGLISH to do proper toLower/UpperCase

### DIFF
--- a/container/openejb-core/src/main/java/org/apache/openejb/assembler/classic/ImportSql.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/assembler/classic/ImportSql.java
@@ -33,6 +33,7 @@ import java.sql.SQLException;
 import java.sql.SQLWarning;
 import java.sql.Statement;
 import java.util.Enumeration;
+import java.util.Locale;
 
 public class ImportSql {
     private static final Logger LOGGER = Logger.getInstance(LogCategory.OPENEJB, EntityManagerFactoryCallable.class.getName());
@@ -125,7 +126,7 @@ public class ImportSql {
                 }
 
                 try {
-                    if (!trimmedSql.toLowerCase().startsWith("select")) {
+                    if (!trimmedSql.toLowerCase(Locale.ENGLISH).startsWith("select")) {
                         statement.executeUpdate(trimmedSql);
                     } else { // why could it be the case?
                         statement.executeQuery(trimmedSql);

--- a/container/openejb-core/src/main/java/org/apache/openejb/config/CleanEnvEntries.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/config/CleanEnvEntries.java
@@ -32,6 +32,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
+import java.util.Locale;
 
 /**
  * @version $Rev$ $Date$
@@ -250,13 +251,13 @@ public class CleanEnvEntries implements DynamicDeployer {
 
             // TODO Technically we should match by case
             final String bestName = "set" + StringUtils.capitalize(target.getInjectionTargetName());
-            final String name = "set" + target.getInjectionTargetName().toLowerCase();
+            final String name = "set" + target.getInjectionTargetName().toLowerCase(Locale.ENGLISH);
             Class<?> found = null;
             for (final Method method : clazz.getDeclaredMethods()) {
                 if (method.getParameterTypes().length == 1) {
                     if (method.getName().equals(bestName)) {
                         return method.getParameterTypes()[0];
-                    } else if (method.getName().toLowerCase().equals(name)) {
+                    } else if (method.getName().toLowerCase(Locale.ENGLISH).equals(name)) {
                         found = method.getParameterTypes()[0];
                     }
                 }

--- a/container/openejb-core/src/main/java/org/apache/openejb/config/DeploymentLoader.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/config/DeploymentLoader.java
@@ -89,6 +89,7 @@ import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.jar.Manifest;
 import java.util.zip.ZipEntry;
+import java.util.Locale;
 
 import static java.util.Arrays.asList;
 
@@ -2003,7 +2004,7 @@ public class DeploymentLoader implements DeploymentFilterable {
     private static boolean containsWebAssets(final File[] files) {
         if (files != null) {
             for (final File file : files) {
-                final String fn = file.getName().toLowerCase();
+                final String fn = file.getName().toLowerCase(Locale.ENGLISH);
                 if (fn.endsWith(".jsp")) {
                     return true;
                 }
@@ -2018,7 +2019,7 @@ public class DeploymentLoader implements DeploymentFilterable {
     private static boolean containsEarAssets(final File[] files) {
         if (files != null) {
             for (final File file : files) {
-                final String fn = file.getName().toLowerCase();
+                final String fn = file.getName().toLowerCase(Locale.ENGLISH);
                 if (fn.endsWith(".jar")) {
                     return true;
                 }

--- a/container/openejb-core/src/main/java/org/apache/openejb/config/DeploymentsResolver.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/config/DeploymentsResolver.java
@@ -42,6 +42,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.Locale;
 
 import static org.apache.openejb.util.URLs.toFile;
 import static org.apache.openejb.util.URLs.toFileUrl;
@@ -461,7 +462,7 @@ public class DeploymentsResolver implements DeploymentFilterable {
                     }
                 }
 
-                final boolean isWindows = System.getProperty("os.name", "unknown").toLowerCase().startsWith("windows");
+                final boolean isWindows = System.getProperty("os.name", "unknown").toLowerCase(Locale.ENGLISH).startsWith("windows");
                 if (!isWindows) {
                     urls = urlSet.getUrls();
                 } else {

--- a/container/openejb-core/src/main/java/org/apache/openejb/config/RemoteServer.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/config/RemoteServer.java
@@ -41,6 +41,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.Locale;
 
 /**
  * NOTE: Do not add inner or anonymous classes or a dependency without updating ExecMojo
@@ -182,7 +183,7 @@ public class RemoteServer {
         if (ok) {
             try {
                 if (verbose) {
-                    System.out.println("[] " + cmd.toUpperCase() + " SERVER");
+                    System.out.println("[] " + cmd.toUpperCase(Locale.ENGLISH) + " SERVER");
                 }
 
                 final File home = getHome();
@@ -211,7 +212,7 @@ public class RemoteServer {
                 //File openejbJar = new File(lib, "openejb-core-" + version + ".jar");
 
                 final String java;
-                final boolean isWindows = System.getProperty("os.name", "unknown").toLowerCase().startsWith("windows");
+                final boolean isWindows = System.getProperty("os.name", "unknown").toLowerCase(Locale.ENGLISH).startsWith("windows");
                 if (isWindows && START.equals(cmd) && options.get("server.windows.fork", false)) {
                     // run and forget
                     java = new File(System.getProperty("java.home"), "bin/javaw").getAbsolutePath();
@@ -422,7 +423,7 @@ public class RemoteServer {
     }
 
     public void kill3UNIX() { // debug purpose only
-        if (System.getProperty("os.name", "unknown").toLowerCase().startsWith("windows")) {
+        if (System.getProperty("os.name", "unknown").toLowerCase(Locale.ENGLISH).startsWith("windows")) {
             return;
         }
 

--- a/container/openejb-core/src/main/java/org/apache/openejb/config/sys/JSonConfigReader.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/config/sys/JSonConfigReader.java
@@ -30,6 +30,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Locale;
 
 public class JSonConfigReader {
     private static final String COMMENT_KEY = "__";
@@ -76,9 +77,9 @@ public class JSonConfigReader {
             for (final String root : roots) {
                 final String currentRoot;
                 if (root.endsWith("s")) {
-                    currentRoot = root.toLowerCase();
+                    currentRoot = root.toLowerCase(Locale.ENGLISH);
                 } else {
-                    currentRoot = root.toLowerCase() + "s";
+                    currentRoot = root.toLowerCase(Locale.ENGLISH) + "s";
                 }
 
                 final Map<String, Map<String, Map<String, String>>> resources = map(jsConfig.get(currentRoot));

--- a/container/openejb-core/src/main/java/org/apache/openejb/config/typed/util/ProviderGenerator.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/config/typed/util/ProviderGenerator.java
@@ -38,6 +38,7 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.Locale;
 
 /**
  * @version $Rev$ $Date$
@@ -254,7 +255,7 @@ public class ProviderGenerator extends Resource {
                     );
                 }
 
-                final String s = lcFirstKey.toLowerCase();
+                final String s = lcFirstKey.toLowerCase(Locale.ENGLISH);
                 if ("long".equals(type) && s.contains("time")) {
                     TimeUnit unit = null;
                     if (s.endsWith("millis")) {
@@ -391,7 +392,7 @@ public class ProviderGenerator extends Resource {
             return "boolean";
         }
 
-        if (key.toLowerCase().endsWith("timeout")) {
+        if (key.toLowerCase(Locale.ENGLISH).endsWith("timeout")) {
             return Duration.class.getName();
         }
 
@@ -400,7 +401,7 @@ public class ProviderGenerator extends Resource {
         }
 
 
-        if (key.toLowerCase().contains("time")) {
+        if (key.toLowerCase(Locale.ENGLISH).contains("time")) {
             try {
                 Long.parseLong(value);
                 return "long";
@@ -416,11 +417,11 @@ public class ProviderGenerator extends Resource {
             // no-op
         }
 
-        if (key.toLowerCase().endsWith("url")) {
+        if (key.toLowerCase(Locale.ENGLISH).endsWith("url")) {
             return URI.class.getName();
         }
 
-        if (key.toLowerCase().endsWith("uri")) {
+        if (key.toLowerCase(Locale.ENGLISH).endsWith("uri")) {
             return URI.class.getName();
         }
 
@@ -466,11 +467,11 @@ public class ProviderGenerator extends Resource {
 
                 String value = map.get(key);
 
-                if (key.toLowerCase().endsWith(".lc")) {
-                    value = map.get(key.substring(0, key.length() - 3)).toLowerCase();
-                } else if (key.toLowerCase().endsWith(".uc")) {
-                    value = map.get(key.substring(0, key.length() - 3)).toUpperCase();
-                } else if (key.toLowerCase().endsWith(".cc")) {
+                if (key.toLowerCase(Locale.ENGLISH).endsWith(".lc")) {
+                    value = map.get(key.substring(0, key.length() - 3)).toLowerCase(Locale.ENGLISH);
+                } else if (key.toLowerCase(Locale.ENGLISH).endsWith(".uc")) {
+                    value = map.get(key.substring(0, key.length() - 3)).toUpperCase(Locale.ENGLISH);
+                } else if (key.toLowerCase(Locale.ENGLISH).endsWith(".cc")) {
                     value = Strings.camelCase(map.get(key.substring(0, key.length() - 3)));
                 }
 

--- a/container/openejb-core/src/main/java/org/apache/openejb/core/timer/EJBCronTrigger.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/core/timer/EJBCronTrigger.java
@@ -159,7 +159,7 @@ public class EJBCronTrigger extends CronTriggerImpl {
         }
 
         // Get rid of whitespace and convert to uppercase
-        expr = expr.replaceAll("\\s+", "").toUpperCase();
+        expr = expr.replaceAll("\\s+", "").toUpperCase(Locale.ENGLISH);
 
 
         if (expr.length() > 1 && expr.indexOf(",") > 0) {

--- a/container/openejb-core/src/main/java/org/apache/openejb/resource/activemq/ActiveMQ5Factory.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/resource/activemq/ActiveMQ5Factory.java
@@ -109,7 +109,7 @@ public class ActiveMQ5Factory implements BrokerFactoryHandler {
                 broker.setPersistent(true);
                 tomeeConfig(broker);
             } else {
-                final boolean notXbean = !uri.getScheme().toLowerCase().startsWith("xbean");
+                final boolean notXbean = !uri.getScheme().toLowerCase(Locale.ENGLISH).startsWith("xbean");
                 if (notXbean) {
 
                     Object value = properties.get("datasource");

--- a/container/openejb-core/src/main/java/org/apache/openejb/resource/activemq/ActiveMQResourceAdapter.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/resource/activemq/ActiveMQResourceAdapter.java
@@ -34,6 +34,7 @@ import java.lang.reflect.Method;
 import java.net.URISyntaxException;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.Locale;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
@@ -115,7 +116,7 @@ public class ActiveMQResourceAdapter extends org.apache.activemq.ra.ActiveMQReso
                     }
 
                     setBrokerXmlConfig(ActiveMQFactory.getBrokerMetaFile() + compositeData.toURI());
-                } else if (brokerXmlConfig.toLowerCase().startsWith("xbean:")) {
+                } else if (brokerXmlConfig.toLowerCase(Locale.ENGLISH).startsWith("xbean:")) {
                     setBrokerXmlConfig(ActiveMQFactory.getBrokerMetaFile() + brokerXmlConfig);
                 }
 

--- a/container/openejb-core/src/main/java/org/apache/openejb/util/Logger.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/util/Logger.java
@@ -418,30 +418,32 @@ public class Logger {
 
     @SuppressWarnings("UnusedDeclaration")
     public boolean isLevelEnable(final String level) {
-        if ("info".equals(level.toLowerCase(Locale.ENGLISH))) {
+        final String levelLowerCase = level.toLowerCase(Locale.ENGLISH);
+        if ("info".equals(levelLowerCase)) {
             return isInfoEnabled();
-        } else if ("debug".equals(level.toLowerCase(Locale.ENGLISH))) {
+        } else if ("debug".equals(levelLowerCase)) {
             return isDebugEnabled();
-        } else if ("warning".equals(level.toLowerCase(Locale.ENGLISH))) {
+        } else if ("warning".equals(levelLowerCase)) {
             return isWarningEnabled();
-        } else if ("fatal".equals(level.toLowerCase(Locale.ENGLISH))) {
+        } else if ("fatal".equals(levelLowerCase)) {
             return isFatalEnabled();
-        } else if ("error".equals(level.toLowerCase(Locale.ENGLISH))) {
+        } else if ("error".equals(levelLowerCase)) {
             return isErrorEnabled();
         }
         return false;
     }
 
     public void log(final String level, final String message) {
-        if ("info".equals(level.toLowerCase(Locale.ENGLISH))) {
+        final String levelLowerCase = level.toLowerCase(Locale.ENGLISH);
+        if ("info".equals(levelLowerCase)) {
             info(message);
-        } else if ("debug".equals(level.toLowerCase(Locale.ENGLISH))) {
+        } else if ("debug".equals(levelLowerCase)) {
             debug(message);
-        } else if ("warning".equals(level.toLowerCase(Locale.ENGLISH))) {
+        } else if ("warning".equals(levelLowerCase)) {
             warning(message);
-        } else if ("fatal".equals(level.toLowerCase(Locale.ENGLISH))) {
+        } else if ("fatal".equals(levelLowerCase)) {
             fatal(message);
-        } else if ("error".equals(level.toLowerCase(Locale.ENGLISH))) {
+        } else if ("error".equals(levelLowerCase)) {
             error(message);
         }
     }

--- a/container/openejb-core/src/main/java/org/apache/openejb/util/Logger.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/util/Logger.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import java.util.MissingResourceException;
 import java.util.Properties;
 import java.util.ResourceBundle;
+import java.util.Locale;
 
 public class Logger {
     private static final String SUFFIX = ".Messages";
@@ -417,30 +418,30 @@ public class Logger {
 
     @SuppressWarnings("UnusedDeclaration")
     public boolean isLevelEnable(final String level) {
-        if ("info".equals(level.toLowerCase())) {
+        if ("info".equals(level.toLowerCase(Locale.ENGLISH))) {
             return isInfoEnabled();
-        } else if ("debug".equals(level.toLowerCase())) {
+        } else if ("debug".equals(level.toLowerCase(Locale.ENGLISH))) {
             return isDebugEnabled();
-        } else if ("warning".equals(level.toLowerCase())) {
+        } else if ("warning".equals(level.toLowerCase(Locale.ENGLISH))) {
             return isWarningEnabled();
-        } else if ("fatal".equals(level.toLowerCase())) {
+        } else if ("fatal".equals(level.toLowerCase(Locale.ENGLISH))) {
             return isFatalEnabled();
-        } else if ("error".equals(level.toLowerCase())) {
+        } else if ("error".equals(level.toLowerCase(Locale.ENGLISH))) {
             return isErrorEnabled();
         }
         return false;
     }
 
     public void log(final String level, final String message) {
-        if ("info".equals(level.toLowerCase())) {
+        if ("info".equals(level.toLowerCase(Locale.ENGLISH))) {
             info(message);
-        } else if ("debug".equals(level.toLowerCase())) {
+        } else if ("debug".equals(level.toLowerCase(Locale.ENGLISH))) {
             debug(message);
-        } else if ("warning".equals(level.toLowerCase())) {
+        } else if ("warning".equals(level.toLowerCase(Locale.ENGLISH))) {
             warning(message);
-        } else if ("fatal".equals(level.toLowerCase())) {
+        } else if ("fatal".equals(level.toLowerCase(Locale.ENGLISH))) {
             fatal(message);
-        } else if ("error".equals(level.toLowerCase())) {
+        } else if ("error".equals(level.toLowerCase(Locale.ENGLISH))) {
             error(message);
         }
     }

--- a/container/openejb-jee/src/main/java/org/apache/openejb/jee/JaxbJavaee.java
+++ b/container/openejb-jee/src/main/java/org/apache/openejb/jee/JaxbJavaee.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.Stack;
 import java.util.TreeSet;
+import java.util.Locale;
 
 import javax.xml.XMLConstants;
 import javax.xml.bind.JAXBContext;
@@ -114,7 +115,7 @@ public class JaxbJavaee {
         unmarshaller.setEventHandler(new ValidationEventHandler() {
             public boolean handleEvent(final ValidationEvent validationEvent) {
                 final String verbose = System.getProperty("openejb.validation.output.level");
-                if (verbose != null && "VERBOSE".equals(verbose.toUpperCase())) {
+                if (verbose != null && "VERBOSE".equals(verbose.toUpperCase(Locale.ENGLISH))) {
                     System.err.println(validationEvent);
                 }
                 return false;

--- a/container/openejb-loader/src/main/java/org/apache/openejb/loader/BasicURLClassPath.java
+++ b/container/openejb-loader/src/main/java/org/apache/openejb/loader/BasicURLClassPath.java
@@ -24,6 +24,7 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import java.util.Locale;
 
 public abstract class BasicURLClassPath implements ClassPath {
     public static ClassLoader getContextClassLoader() {
@@ -70,13 +71,13 @@ public abstract class BasicURLClassPath implements ClassPath {
         final String[] jarNames = dir.list(new java.io.FilenameFilter() {
             @Override
             public boolean accept(final File dir, String name) {
-                name = name.toLowerCase();
+                name = name.toLowerCase(Locale.ENGLISH);
                 return name.endsWith(".jar") || name.endsWith(".zip");
             }
         });
 
         final URL[] jars = new URL[jarNames.length];
-        final boolean isWindows = System.getProperty("os.name", "unknown").toLowerCase().startsWith("win");
+        final boolean isWindows = System.getProperty("os.name", "unknown").toLowerCase(Locale.ENGLISH).startsWith("win");
 
         for (int j = 0; j < jarNames.length; j++) {
             final String name = isWindows ? jarNames[j].toLowerCase() : jarNames[j];

--- a/container/openejb-loader/src/main/java/org/apache/openejb/loader/Files.java
+++ b/container/openejb-loader/src/main/java/org/apache/openejb/loader/Files.java
@@ -44,7 +44,7 @@ import static org.apache.openejb.loader.JarLocation.decode;
  */
 public class Files {
     private static final Map<String, MessageDigest> DIGESTS = new HashMap<String, MessageDigest>();
-    private static final boolean IS_WINDOWS = System.getProperty("os.name", "unknown").toLowerCase().startsWith("win");
+    private static final boolean IS_WINDOWS = System.getProperty("os.name", "unknown").toLowerCase(Locale.ENGLISH).startsWith("win");
 
     public static File path(final String... parts) {
         File dir = null;

--- a/server/openejb-http/src/main/java/org/apache/openejb/server/httpd/BasicAuthHttpListenerWrapper.java
+++ b/server/openejb-http/src/main/java/org/apache/openejb/server/httpd/BasicAuthHttpListenerWrapper.java
@@ -22,6 +22,7 @@ import org.apache.openejb.spi.SecurityService;
 import org.apache.openejb.util.Base64;
 
 import javax.security.auth.login.LoginException;
+import java.util.Locale;
 
 public class BasicAuthHttpListenerWrapper implements HttpListener {
 
@@ -40,7 +41,7 @@ public class BasicAuthHttpListenerWrapper implements HttpListener {
 
         String auth = request.getHeader("Authorization");
         if (auth != null && auth.length() > 0) {
-            if (auth.toUpperCase().startsWith("BASIC ")) {
+            if (auth.toUpperCase(Locale.ENGLISH).startsWith("BASIC ")) {
                 auth = auth.substring(6);
                 final String decoded = new String(Base64.decodeBase64(auth.getBytes()));
                 final String[] parts = decoded.split(":");

--- a/server/openejb-server/src/main/java/org/apache/openejb/server/ServiceManager.java
+++ b/server/openejb-server/src/main/java/org/apache/openejb/server/ServiceManager.java
@@ -41,6 +41,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Locale;
 
 import static org.apache.openejb.util.PropertyPlaceHolderHelper.holdsWithUpdate;
 
@@ -231,7 +232,7 @@ public abstract class ServiceManager {
                 final File[] files = conf.listFiles(new FilenameFilter() {
                     @Override
                     public boolean accept(final File dir, String name) {
-                        name = name.toLowerCase();
+                        name = name.toLowerCase(Locale.ENGLISH);
                         return name.equals("ejbd.properties")
                             || name.equals("ejbds.properties")
                             || name.equals("admin.properties")


### PR DESCRIPTION
In several places TomEE does not use proper toLower()/toUpper(). The issue is that if the server relies on the default locale and if the process was started with some non English compatible locale such as Turkish, toUpper/Lower will yield an incorrect result. For instance "URI".toLowerCase() will result in "urı" instead of "uri". The same applies to toUpperCase -> "uri".toUpperCase() will become "URİ" and checks like "string.toUpperCase().equals(someConstant)" will fail. 

In some places I left the usage of the default locale, because IMO using a fixed locale is equally incorrect. Those places are: 
MultivaluedMap:144 
ProviderManager:78 
DeploymentResolver:186/464 
ConfigurationFactory:1554
BasicURLClassPath:83
ActiveMQ5Factory:409


Bug: https://issues.apache.org/jira/browse/TOMEE-1946