### PR TITLE
moviefun-rest example was not working with Tomee 7

### DIFF
--- a/examples/moviefun-rest/src/main/java/org/superbiz/moviefun/rest/MoviesRest.java
+++ b/examples/moviefun-rest/src/main/java/org/superbiz/moviefun/rest/MoviesRest.java
@@ -29,6 +29,8 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 import java.util.List;
 
 @Path("movies")
@@ -73,8 +75,9 @@ public class MoviesRest {
 
     @GET
     @Path("count")
-    public int count(@QueryParam("field") String field, @QueryParam("searchTerm") String searchTerm) {
-        return service.count(field, searchTerm);
+    @Produces(MediaType.TEXT_PLAIN)
+    public Response count(@QueryParam("field") String field, @QueryParam("searchTerm") String searchTerm) {
+        return Response.ok(service.count(field, searchTerm)).build();
     }
 
 }

--- a/examples/moviefun-rest/src/main/resources/META-INF/persistence.xml
+++ b/examples/moviefun-rest/src/main/resources/META-INF/persistence.xml
@@ -25,6 +25,7 @@
     <class>org.superbiz.moviefun.Movie</class>
 
     <properties>
+      <property name="eclipselink.ddl-generation" value="drop-and-create-tables"/>
       <property name="openjpa.jdbc.SynchronizeMappings" value="buildSchema(ForeignKeys=true)"/>
     </properties>
   </persistence-unit>

--- a/examples/moviefun-rest/src/main/webapp/app/js/model/movie.js
+++ b/examples/moviefun-rest/src/main/webapp/app/js/model/movie.js
@@ -24,11 +24,6 @@
         return Backbone.Model.extend({
             urlRoot: window.ux.ROOT_URL + 'rest/movies',
             idAttribute: 'id',
-            toJSON: function () {
-                return {
-                    'movie': this.attributes
-                };
-            },
             defaults: {
                 rating: 5,
                 year: new Date().getFullYear()

--- a/examples/moviefun-rest/src/main/webapp/app/js/model/movies.js
+++ b/examples/moviefun-rest/src/main/webapp/app/js/model/movies.js
@@ -25,7 +25,7 @@
             model: Movie,
             url: window.ux.ROOT_URL + 'rest/movies',
             parse: function (response) {
-                return response.movie;
+                return response;
             }
         });
         return new Cls();


### PR DESCRIPTION
Fixed 2 things:
1 - Tables were not being generated automatically 
2 - JSON parsing in JAX-RS was not working as Tomee 1.7.X. The previous version returned a different payload comparing to Tomee 7. I did small adjustments in the front-end so it could work

I should follow up this PR with another change to add documentation for Intellij (dependent on moviefun-rest app) which is not up to date in the previous doc. 
http://tomee.apache.org/tomee-and-intellij.html

