### PR TITLE
Fix property name

### DIFF
--- a/maven/tomee-embedded-maven-plugin/src/main/java/org/apache/openejb/maven/plugins/TomEEEmbeddedMojo.java
+++ b/maven/tomee-embedded-maven-plugin/src/main/java/org/apache/openejb/maven/plugins/TomEEEmbeddedMojo.java
@@ -88,7 +88,7 @@ public class TomEEEmbeddedMojo extends AbstractMojo {
     /**
      * HTTP port.
      */
-    @Parameter(property = "tomee-embedded-plugin.http", defaultValue = "8080")
+    @Parameter(property = "tomee-embedded-plugin.httpPort", defaultValue = "8080")
     protected int httpPort;
 
     /**


### PR DESCRIPTION
In tomee-embedded-maven-plugin configuration, property with tag <httpPort> ignored.