### PR TITLE
[WIP] [TOMEE-2042] Force upgrade of bcprov to fix 10 CVEs

### DIFF
--- a/server/openejb-client/pom.xml
+++ b/server/openejb-client/pom.xml
@@ -170,9 +170,8 @@
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcmail-jdk15on</artifactId>
-      <version>1.54</version>
+      <version>1.57</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
 </project>
-

--- a/server/openejb-cxf/pom.xml
+++ b/server/openejb-cxf/pom.xml
@@ -79,6 +79,12 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <!-- Override the bcprov from the previous artifact -->
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcprov-jdk15on</artifactId>
+      <version>1.57</version>
+    </dependency>
     <dependency>
       <groupId>org.apache.wss4j</groupId>
       <artifactId>wss4j-policy</artifactId>
@@ -208,4 +214,3 @@
     </profile>
   </profiles>
 </project>
-

--- a/tomee/tomee-embedded/pom.xml
+++ b/tomee/tomee-embedded/pom.xml
@@ -473,9 +473,8 @@
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcmail-jdk15on</artifactId>
-      <version>1.54</version>
+      <version>1.57</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
 </project>
-


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TOMEE-2042

bcprov is included as a transient dependency for `openejb-cxf` module. This forces a secure version. I plan on logging bugs for wss4j and opensaml to upgrade the dependency.

```
[INFO] +- org.apache.wss4j:wss4j-ws-security-dom:jar:2.1.9:compile
[INFO] |  \- org.apache.wss4j:wss4j-ws-security-common:jar:2.1.9:compile
[INFO] |     +- org.apache.santuario:xmlsec:jar:2.0.6:compile
[INFO] |     |  \- commons-codec:commons-codec:jar:1.10:compile
[INFO] |     +- org.opensaml:opensaml-saml-impl:jar:3.1.1:compile
[INFO] |     |  +- org.opensaml:opensaml-profile-api:jar:3.1.1:compile
[INFO] |     |  |  \- org.opensaml:opensaml-core:jar:3.1.1:compile
[INFO] |     |  +- org.opensaml:opensaml-saml-api:jar:3.1.1:compile
[INFO] |     |  |  +- org.opensaml:opensaml-xmlsec-api:jar:3.1.1:compile
[INFO] |     |  |  \- org.opensaml:opensaml-soap-api:jar:3.1.1:compile
[INFO] |     |  +- org.opensaml:opensaml-security-impl:jar:3.1.1:compile
[INFO] |     |  |  \- org.opensaml:opensaml-security-api:jar:3.1.1:compile
[INFO] |     |  |     +- org.cryptacular:cryptacular:jar:1.0:compile
[INFO] |     |  |     \- org.bouncycastle:bcprov-jdk15on:jar:1.51:compile
```

It contains the following CVEs:
CVE-2016-1000341
CVE-2016-1000346
CVE-2016-1000340
CVE-2016-1000344
CVE-2016-1000352
CVE-2016-1000338
CVE-2016-1000339
CVE-2016-1000342
CVE-2016-1000343
CVE-2016-1000345

