### PR TITLE
When in EAR, the web app doc base is a directory ending with .war do not handle it as a file

### DIFF
--- a/arquillian/arquillian-tomee-webapp-remote/src/test/java/org/apache/openejb/arquillian/TomEEContainerEarWithExplodedWarTest.java
+++ b/arquillian/arquillian-tomee-webapp-remote/src/test/java/org/apache/openejb/arquillian/TomEEContainerEarWithExplodedWarTest.java
@@ -1,0 +1,105 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.openejb.arquillian;
+
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Properties;
+
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+
+import org.apache.openejb.arquillian.common.Files;
+import org.apache.openejb.arquillian.common.IO;
+import org.apache.openejb.assembler.Deployer;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ExplodedExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.descriptor.api.Descriptors;
+import org.jboss.shrinkwrap.descriptor.api.application7.ApplicationDescriptor;
+import org.jboss.shrinkwrap.descriptor.api.webapp30.WebAppDescriptor;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(Arquillian.class)
+@RunAsClient
+public class TomEEContainerEarWithExplodedWarTest {
+    private static final String TARGET_FOLDER = "target";
+    private static final String EAR_FILE = "test-ear.ear";
+    private static final String WAR_FILE = "test-web.war";
+    private static final String CONTEXT_PATH = "hello";
+    private static final String SERVLET_NAME = "servlet-ejb";
+    private static final String URL_PATTERN = "/ejb";
+    private static final String EXPECTED_CONTENT = "Hello";
+    private static final String INITIAL_CONTEXT_FACTORY_VALUE = "org.apache.openejb.client.RemoteInitialContextFactory";
+    private static final String DEPLOYER_LOOKUP_NAME = "openejb/DeployerBusinessRemote";
+
+    @Deployment
+    public static WebArchive createDeployment() throws Exception {
+        final WebArchive web = ShrinkWrap.create(WebArchive.class, WAR_FILE)
+                .addClass(TestServlet.class)
+                .addClass(TestEjb.class)
+                .setWebXML(new StringAsset(Descriptors.create(WebAppDescriptor.class)
+                        .createServlet().servletName(SERVLET_NAME).servletClass(TestServlet.class.getName()).up()
+                        .createServletMapping().servletName(SERVLET_NAME).urlPattern(URL_PATTERN).up()
+                        .exportAsString()));
+        ShrinkWrap.create(EnterpriseArchive.class, EAR_FILE).addAsModule(web)
+                .setApplicationXML(new StringAsset(Descriptors.create(ApplicationDescriptor.class)
+                        .createModule().getOrCreateWeb().contextRoot(CONTEXT_PATH).webUri(WAR_FILE).up().up()
+                        .exportAsString()))
+                .as(ExplodedExporter.class).exportExploded(new File(TARGET_FOLDER));
+        return ShrinkWrap.create(WebArchive.class);
+    }
+
+    @ArquillianResource
+    private URL url;
+
+    @Test
+    public void testShouldBeAbleToAccessWebApp() throws Exception {
+        final Deployer deployer = lookupDeployer();
+        final File earFolder = new File(TARGET_FOLDER, EAR_FILE);
+        deployer.deploy(earFolder.getAbsolutePath());
+        Assert.assertTrue(IO.slurp(getUrl()).contains(EXPECTED_CONTENT));
+        Files.deleteOnExit(earFolder);
+    }
+
+    private Deployer lookupDeployer() {
+        Deployer deployer = null;
+        final Properties properties = new Properties();
+        properties.setProperty(Context.INITIAL_CONTEXT_FACTORY, INITIAL_CONTEXT_FACTORY_VALUE);
+        try {
+            deployer = (Deployer) new InitialContext(properties).lookup(DEPLOYER_LOOKUP_NAME);
+        } catch (NamingException e) {
+            Assert.fail("Cannot lookup deployer " + e.getMessage());
+        }
+        return deployer;
+    }
+
+    private URL getUrl() throws MalformedURLException {
+        return new URL(url.getProtocol() + "://" + url.getHost() + ":" + url.getPort() + "/"
+                + CONTEXT_PATH + URL_PATTERN);
+    }
+}

--- a/tomee/tomee-catalina/src/main/java/org/apache/tomee/catalina/TomcatWebAppBuilder.java
+++ b/tomee/tomee-catalina/src/main/java/org/apache/tomee/catalina/TomcatWebAppBuilder.java
@@ -541,14 +541,16 @@ public class TomcatWebAppBuilder implements WebAppBuilder, ContextListener, Pare
                     if (standardContext.getDocBase() == null) {
                         standardContext.setDocBase(webApp.path);
                     }
-                    if (standardContext.getDocBase() != null && standardContext.getDocBase().endsWith(".war")) {
-                        DeploymentLoader.unpack(new File(standardContext.getDocBase()));
+                    String docBase = standardContext.getDocBase();
+                    File docBaseFile = new File(docBase);
+                    if (docBase != null && docBaseFile.isFile() && docBase.endsWith(".war")) {
+                        DeploymentLoader.unpack(docBaseFile);
                         if (standardContext.getPath().endsWith(".war")) {
                             standardContext.setPath(removeFirstSlashAndWar("/" + standardContext.getPath()));
                             standardContext.setName(standardContext.getPath());
                             webApp.contextRoot = standardContext.getPath();
                         }
-                        standardContext.setDocBase(standardContext.getDocBase().substring(0, standardContext.getDocBase().length() - 4));
+                        standardContext.setDocBase(docBase.substring(0, docBase.length() - 4));
                     }
                     if (isRoot(standardContext.getName())) {
                         standardContext.setName("");


### PR DESCRIPTION
When in the EAR file, the web application's binaries are a directory
and the directory name ends with .war, do not handle it as a file.

With the current implementation the exception below is thrown. Note that the name of the directory inside of EAR file is `test.war` and not `test`.

```
07-Jun-2017 23:33:34.961 SEVERE [ContainerBackgroundProcessor[StandardEngine[Catalina]]] sun.reflect.NativeMethodAccessorImpl.invoke ContainerBase.addChild: start: 
 org.apache.catalina.LifecycleException: Failed to start component [StandardEngine[Catalina].StandardHost[localhost].StandardContext[/test]]
	at org.apache.catalina.util.LifecycleBase.start(LifecycleBase.java:167)
	at org.apache.catalina.core.ContainerBase.addChildInternal(ContainerBase.java:752)
	at org.apache.catalina.core.ContainerBase.addChild(ContainerBase.java:728)
	at org.apache.catalina.core.StandardHost.addChild(StandardHost.java:734)
	at org.apache.tomee.catalina.TomcatWebAppBuilder.deployWar(TomcatWebAppBuilder.java:651)
	at org.apache.tomee.catalina.TomcatWebAppBuilder.deployWebApps(TomcatWebAppBuilder.java:589)
	at org.apache.openejb.assembler.classic.Assembler.createApplication(Assembler.java:997)
	at org.apache.openejb.assembler.classic.Assembler.createApplication(Assembler.java:718)
	at org.apache.openejb.assembler.classic.Assembler.createApplication(Assembler.java:714)
	at org.apache.tomee.catalina.TomcatWebAppBuilder.checkHost(TomcatWebAppBuilder.java:2223)
	at org.apache.tomee.catalina.GlobalListenerSupport.lifecycleEvent(GlobalListenerSupport.java:141)
	at org.apache.catalina.util.LifecycleBase.fireLifecycleEvent(LifecycleBase.java:94)
	at org.apache.catalina.core.ContainerBase.backgroundProcess(ContainerBase.java:1164)
	at org.apache.catalina.core.ContainerBase$ContainerBackgroundProcessor.processChildren(ContainerBase.java:1388)
	at org.apache.catalina.core.ContainerBase$ContainerBackgroundProcessor.processChildren(ContainerBase.java:1392)
	at org.apache.catalina.core.ContainerBase$ContainerBackgroundProcessor.run(ContainerBase.java:1360)
	at java.lang.Thread.run(Thread.java:748)
Caused by: org.apache.catalina.LifecycleException: Failed to start component [org.apache.catalina.webresources.StandardRoot@71ffc4f4]
	at org.apache.catalina.util.LifecycleBase.start(LifecycleBase.java:167)
	at org.apache.catalina.core.StandardContext.resourcesStart(StandardContext.java:4842)
	at org.apache.catalina.core.StandardContext.startInternal(StandardContext.java:4974)
	at org.apache.catalina.util.LifecycleBase.start(LifecycleBase.java:150)
	... 16 more
Caused by: java.lang.IllegalArgumentException: The main resource set specified [/<path-to-ear>/test] is not valid
	at org.apache.catalina.webresources.StandardRoot.createMainResourceSet(StandardRoot.java:732)
	at org.apache.catalina.webresources.StandardRoot.startInternal(StandardRoot.java:690)
	at org.apache.catalina.util.LifecycleBase.start(LifecycleBase.java:150)
	... 19 more
```