### PR TITLE
Fix TOMEE-2053: Override data source definitions from ejb-jar.xml

### DIFF
--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/datasource/definition/DataSourceBean.java
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/datasource/definition/DataSourceBean.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.openejb.arquillian.tests.datasource.definition;
+
+import javax.annotation.Resource;
+import javax.annotation.sql.DataSourceDefinition;
+import javax.ejb.LocalBean;
+import javax.ejb.Stateless;
+import javax.naming.InitialContext;
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.SQLException;
+
+@Stateless
+@LocalBean
+@DataSourceDefinition(name = "jdbc/database", className = "org.hsqldb.jdbcDriver", url = "jdbc:hsqldb:mem:unexpected")
+public class DataSourceBean {
+    @Resource(name = "jdbc/database")
+    private DataSource dataSource;
+
+    public String getUrlFromInjectedDataSource() throws SQLException {
+        return getDataSourceUrl(dataSource);
+    }
+
+    public String getUrlFromLookedUpDataSource() throws Exception {
+        final InitialContext initialContext = new InitialContext();
+        final DataSource ds = (DataSource) initialContext.lookup("java:comp/env/jdbc/database");
+
+        return getDataSourceUrl(ds);
+    }
+
+    private String getDataSourceUrl(DataSource dataSource) throws SQLException {
+        try (Connection connection = dataSource.getConnection()) {
+            return connection.getMetaData().getURL();
+        }
+    }
+}

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/datasource/definition/DataSourceDefinitionTest.java
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/datasource/definition/DataSourceDefinitionTest.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.openejb.arquillian.tests.datasource.definition;
+
+import org.apache.openejb.arquillian.tests.Runner;
+import org.apache.openejb.arquillian.tests.persistence.ejb.SessionSynchronizationCallbackTest;
+import org.apache.ziplock.JarLocation;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.ClassLoaderAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.descriptor.api.Descriptors;
+import org.jboss.shrinkwrap.descriptor.api.webapp30.WebAppDescriptor;
+import org.jboss.shrinkwrap.descriptor.api.webcommon30.WebAppVersionType;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(Arquillian.class)
+public class DataSourceDefinitionTest {
+    private static final String TEST_NAME = SessionSynchronizationCallbackTest.class.getSimpleName();
+    private static final String SERVLET_NAME = "TestServlet";
+    private static final java.lang.String RESOURCE_EJB_JAR_XML = "ejb-jar.xml";
+    private static final java.lang.String CONTENT_LOCATION_EJB_JAR_XML = "org/apache/openejb/arquillian/tests/datasource/ds_definition/ejb-jar.xml";
+
+    @ArquillianResource
+    private URL url;
+
+    @Deployment(testable = false)
+    public static WebArchive createDeployment() {
+        WebAppDescriptor descriptor = Descriptors.create(WebAppDescriptor.class)
+                .version(WebAppVersionType._3_0)
+                .createServlet()
+                .servletName(SERVLET_NAME)
+                .servletClass(DataSourceServlet.class.getName()).up()
+                .createServletMapping()
+                .servletName(SERVLET_NAME)
+                .urlPattern("/" + TEST_NAME).up();
+
+        WebArchive archive = ShrinkWrap.create(WebArchive.class, TEST_NAME + ".war")
+                .addClass(DataSourceDefinitionTest.class)
+                .addClass(DataSourceServlet.class)
+                .addClass(DataSourceBean.class)
+                .addClass(Runner.class)
+                .addAsLibraries(JarLocation.jarLocation(Test.class))
+                .addAsWebInfResource(new ClassLoaderAsset(CONTENT_LOCATION_EJB_JAR_XML), RESOURCE_EJB_JAR_XML)
+                .setWebXML(new StringAsset(descriptor.exportAsString()));
+
+        return archive;
+    }
+
+    @Test
+    public void testDataSourceInjectionInServlet() throws IOException {
+        validateTest("testDataSourceInjectionInServlet");
+    }
+
+    @Test
+    public void testDataSourceInjectionInEjb() throws IOException {
+        validateTest("testDataSourceInjectionInEjb");
+    }
+
+    @Test
+    public void testDataSourceLookUpFromServlet() throws IOException {
+        validateTest("testDataSourceLookUpFromServlet");
+    }
+
+    @Test
+    public void testDataSourceLookUpFromEjb() throws IOException {
+        validateTest("testDataSourceLookUpFromEjb");
+    }
+
+    private void validateTest(String testName) throws IOException {
+        final String expectedOutput = testName + "=true";
+
+        try (InputStream is = new URL(url.toExternalForm() + TEST_NAME + "?test=" + testName).openStream()) {
+            final ByteArrayOutputStream os = new ByteArrayOutputStream();
+
+            int bytesRead;
+            byte[] buffer = new byte[8192];
+            while ((bytesRead = is.read(buffer)) > -1) {
+                os.write(buffer, 0, bytesRead);
+            }
+
+            final String output = new String(os.toByteArray(), "UTF-8");
+            assertNotNull("Response shouldn't be null", output);
+            assertTrue("Output should contain: " + expectedOutput
+                    + "\nActual output:\n" + output, output.contains(expectedOutput));
+        }
+    }
+
+}

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/datasource/definition/DataSourceDefinitionTest.java
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/datasource/definition/DataSourceDefinitionTest.java
@@ -18,7 +18,6 @@
 package org.apache.openejb.arquillian.tests.datasource.definition;
 
 import org.apache.openejb.arquillian.tests.Runner;
-import org.apache.openejb.arquillian.tests.persistence.ejb.SessionSynchronizationCallbackTest;
 import org.apache.ziplock.JarLocation;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
@@ -43,7 +42,7 @@ import static org.junit.Assert.assertTrue;
 
 @RunWith(Arquillian.class)
 public class DataSourceDefinitionTest {
-    private static final String TEST_NAME = SessionSynchronizationCallbackTest.class.getSimpleName();
+    private static final String TEST_NAME = DataSourceDefinitionTest.class.getSimpleName();
     private static final String SERVLET_NAME = "TestServlet";
     private static final java.lang.String RESOURCE_EJB_JAR_XML = "ejb-jar.xml";
     private static final java.lang.String CONTENT_LOCATION_EJB_JAR_XML = "org/apache/openejb/arquillian/tests/datasource/ds_definition/ejb-jar.xml";

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/datasource/definition/DataSourceServlet.java
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/datasource/definition/DataSourceServlet.java
@@ -1,0 +1,97 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.openejb.arquillian.tests.datasource.definition;
+
+
+import javax.annotation.Resource;
+import javax.ejb.EJB;
+import javax.naming.InitialContext;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.sql.DataSource;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.sql.Connection;
+import java.sql.SQLException;
+
+public class DataSourceServlet extends HttpServlet {
+    private static final String EXPECTED_URL = "jdbc:hsqldb:mem:expected";
+
+    @Resource(name = "jdbc/database")
+    DataSource dataSource;
+
+    @EJB
+    DataSourceBean dataSourceBean;
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        final PrintWriter writer = resp.getWriter();
+        final String testToExecute = req.getParameter("test");
+
+        try {
+            final Method method = this.getClass().getDeclaredMethod(testToExecute);
+            method.invoke(this);
+            writer.println(testToExecute + "=true");
+        } catch (Exception ex) {
+            final Throwable rootCause = ex instanceof InvocationTargetException ? ex.getCause() : ex;
+            writer.println(testToExecute + "=false");
+            rootCause.printStackTrace(writer);
+        }
+    }
+
+    public void testDataSourceInjectionInEjb() throws SQLException {
+        final String dataSourceUrl = dataSourceBean.getUrlFromInjectedDataSource();
+        if (!EXPECTED_URL.equals(dataSourceUrl)) {
+            throw new IllegalStateException("[BEAN - INJECTION] Unexpected URL: " + dataSourceUrl);
+        }
+    }
+
+    public void testDataSourceLookUpFromEjb() throws SQLException {
+        final String dataSourceUrl = dataSourceBean.getUrlFromInjectedDataSource();
+        if (!EXPECTED_URL.equals(dataSourceUrl)) {
+            throw new IllegalStateException("[BEAN - LOOKUP] Unexpected URL: " + dataSourceUrl);
+        }
+    }
+
+    public void testDataSourceInjectionInServlet() throws SQLException {
+        final String dataSourceUrl = getDataSourceUrl(dataSource);
+        if (!EXPECTED_URL.equals(dataSourceUrl)) {
+            throw new IllegalStateException("[SERVLET - INJECTION] Unexpected URL: " + dataSourceUrl);
+        }
+    }
+
+    public void testDataSourceLookUpFromServlet() throws Exception {
+        final InitialContext initialContext = new InitialContext();
+        final DataSource ds = (DataSource) initialContext.lookup("java:comp/env/jdbc/database");
+
+        final String dataSourceUrl = getDataSourceUrl(ds);
+        if (!EXPECTED_URL.equals(dataSourceUrl)) {
+            throw new IllegalStateException("[SERVLET - LOOKUP] Unexpected URL: " + dataSourceUrl);
+        }
+    }
+
+    private String getDataSourceUrl(DataSource dataSource) throws SQLException {
+        try (Connection connection = dataSource.getConnection()) {
+            return connection.getMetaData().getURL();
+        }
+    }
+}

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/datasource/definition/DataSourceServlet.java
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/datasource/definition/DataSourceServlet.java
@@ -65,8 +65,8 @@ public class DataSourceServlet extends HttpServlet {
         }
     }
 
-    public void testDataSourceLookUpFromEjb() throws SQLException {
-        final String dataSourceUrl = dataSourceBean.getUrlFromInjectedDataSource();
+    public void testDataSourceLookUpFromEjb() throws Exception {
+        final String dataSourceUrl = dataSourceBean.getUrlFromLookedUpDataSource();
         if (!EXPECTED_URL.equals(dataSourceUrl)) {
             throw new IllegalStateException("[BEAN - LOOKUP] Unexpected URL: " + dataSourceUrl);
         }

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/resources/org/apache/openejb/arquillian/tests/datasource/ds_definition/ejb-jar.xml
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/resources/org/apache/openejb/arquillian/tests/datasource/ds_definition/ejb-jar.xml
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
 <ejb-jar xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          version="3.1"
          xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/ejb-jar_3_1.xsd">

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/resources/org/apache/openejb/arquillian/tests/datasource/ds_definition/ejb-jar.xml
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/resources/org/apache/openejb/arquillian/tests/datasource/ds_definition/ejb-jar.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ejb-jar xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         version="3.1"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/ejb-jar_3_1.xsd">
+    <enterprise-beans>
+        <session>
+            <ejb-name>DataSourceBean</ejb-name>
+            <ejb-class>org.apache.openejb.arquillian.tests.datasource.definition.DataSourceBean</ejb-class>
+            <data-source>
+                <name>java:comp/env/jdbc/database</name>
+                <class-name>org.hsqldb.jdbcDriver</class-name>
+                <url>jdbc:hsqldb:mem:expected</url>
+                <user>sa</user>
+                <password>sa</password>
+            </data-source>
+        </session>
+    </enterprise-beans>
+</ejb-jar>

--- a/container/openejb-core/src/main/java/org/apache/openejb/config/ConvertDataSourceDefinitions.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/config/ConvertDataSourceDefinitions.java
@@ -48,6 +48,13 @@ public class ConvertDataSourceDefinitions extends BaseConvertDefinitions {
                 continue;
             }
 
+            if (consumer instanceof org.apache.openejb.config.CompManagedBean) {
+                /*
+                 * TOMEE-2053: It may contain invalid datasource definitions
+                 * because it is never updated with content from the ejb-jar.xml
+                 */
+                continue;
+            }
             dataSources.addAll(consumer.getDataSource());
         }
 

--- a/container/openejb-core/src/test/java/org/apache/openejb/assembler/classic/DataSourceDefinitionWithEjbJarXmlTest.java
+++ b/container/openejb-core/src/test/java/org/apache/openejb/assembler/classic/DataSourceDefinitionWithEjbJarXmlTest.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *
+ */
+
 package org.apache.openejb.assembler.classic;
 
 import org.apache.openejb.jee.EjbJar;

--- a/container/openejb-core/src/test/java/org/apache/openejb/assembler/classic/DataSourceDefinitionWithEjbJarXmlTest.java
+++ b/container/openejb-core/src/test/java/org/apache/openejb/assembler/classic/DataSourceDefinitionWithEjbJarXmlTest.java
@@ -1,0 +1,73 @@
+package org.apache.openejb.assembler.classic;
+
+import org.apache.openejb.jee.EjbJar;
+import org.apache.openejb.jee.StatelessBean;
+import org.apache.openejb.junit.ApplicationComposer;
+import org.apache.openejb.testing.Module;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.annotation.Resource;
+import javax.annotation.sql.DataSourceDefinition;
+import javax.ejb.EJB;
+import javax.ejb.Stateless;
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(ApplicationComposer.class)
+public class DataSourceDefinitionWithEjbJarXmlTest {
+    private static final String DATASOURCE_NAME = "jdbc/database";
+    private static final String EXPECTED_USER_NAME = "expected_user_name";
+    private static final String DRIVER_CLASS = "org.hsqldb.jdbcDriver";
+
+    @Resource(name = DATASOURCE_NAME)
+    private javax.sql.DataSource dataSource;
+
+    @EJB
+    private DataSourceBean dataSourceBean;
+
+    @Test
+    public void testCorrectDefinitionFromEjb() throws Exception {
+        final String userName = dataSourceBean.getDataSourceUserName();
+        assertEquals(EXPECTED_USER_NAME, userName);
+    }
+
+    @Test
+    public void testCorrectDefinitionInjected() throws Exception {
+        final String userName;
+        try (Connection connection = dataSource.getConnection()) {
+            userName = connection.getMetaData().getUserName();
+        }
+        assertEquals(EXPECTED_USER_NAME, userName);
+    }
+
+    @Module
+    public EjbJar initModule() throws Exception {
+        final EjbJar ejbJar = new EjbJar();
+        final StatelessBean statelessBean = ejbJar.addEnterpriseBean(new StatelessBean(DataSourceBean.class));
+        final org.apache.openejb.jee.DataSource ds = new org.apache.openejb.jee.DataSource();
+        ds.setUser(EXPECTED_USER_NAME);
+        ds.setName("java:comp/env/" + DATASOURCE_NAME);
+        ds.setUrl("jdbc:hsqldb:mem:test");
+        ds.setClassName(DRIVER_CLASS);
+        statelessBean.getDataSourceMap().put(DATASOURCE_NAME, ds);
+        return ejbJar;
+    }
+
+
+    @Stateless
+    @DataSourceDefinition(name = DATASOURCE_NAME, className = DRIVER_CLASS, user = "replace_me_from_ejbjar_xml")
+    public static class DataSourceBean {
+        @Resource(name = "jdbc/database")
+        private javax.sql.DataSource dataSource;
+
+        public String getDataSourceUserName() throws SQLException {
+            try (Connection connection = dataSource.getConnection()) {
+                return connection.getMetaData().getUserName();
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
CompManagedBean "aggregates" the annotations from the
other beans, but as it's artificially added to the ejb-jar by openejb, it
does not have an entry in the ejb-jar.xml. Hence when the
AnnotationDeployer processes the DataSourceDefinition annotation,
if neverfinds an existing data source definition in the ejb-jar.xml for it. 
This inturn makes the annotation deployer to add a datas ource with 
wrong configuration to the AppModule's ejb-jar. 
ConvertDataSourceDefinitions deployer collects all data sources from 
all JndiConsumers, so it collects the invalid definition as well and adds 
it to the AppModule's resources. Because the invalid definition has the 
same ID as the original, correct one, it overwrites is.