### PR TITLE
TOMEE-2074: TomcatWebAppBuilder does not correctly set NamingContextListener.setExceptionOnFailedWrite() 

### DIFF
--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/tomcat/contextxml/NamingServlet.java
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/tomcat/contextxml/NamingServlet.java
@@ -1,0 +1,70 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.openejb.arquillian.tests.tomcat.contextxml;
+
+
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.naming.OperationNotSupportedException;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+public class NamingServlet extends HttpServlet {
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        final PrintWriter writer = resp.getWriter();
+        final String testToExecute = req.getParameter("test");
+
+        try {
+            final Method method = this.getClass().getDeclaredMethod(testToExecute);
+            method.invoke(this);
+            writer.println(testToExecute + "=true");
+        } catch (Exception ex) {
+            final Throwable rootCause = ex instanceof InvocationTargetException ? ex.getCause() : ex;
+            writer.println(testToExecute + "=false");
+            rootCause.printStackTrace(writer);
+        }
+    }
+
+    public void closeNamingContextAndExpectNoException() throws Exception {
+        final InitialContext initialContext = new InitialContext();
+        final Context compEnv = (Context) initialContext.lookup("java:comp/env");
+        compEnv.close();
+    }
+
+    public void closeNamingContextAndExpectOperationNotSupportedException() throws Exception {
+        try {
+            final InitialContext initialContext = new InitialContext();
+            final Context compEnv = (Context) initialContext.lookup("java:comp/env");
+            compEnv.close();
+
+            throw new IllegalStateException("Context::close() should have thrown OperationNotSupportedException");
+        } catch (OperationNotSupportedException ex) {
+            //Do nothing, expected
+        } catch (Exception ex) {
+            throw new IllegalStateException("Context::close() should have thrown OperationNotSupportedException instead of " + ex.getClass(), ex);
+        }
+    }
+}

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/tomcat/contextxml/TomcatNamingFailOnWriteConfigurationTest.java
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/tomcat/contextxml/TomcatNamingFailOnWriteConfigurationTest.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.openejb.arquillian.tests.tomcat.contextxml;
+
+import org.apache.openejb.arquillian.tests.Runner;
+import org.apache.openejb.arquillian.tests.datasource.definition.DataSourceBean;
+import org.apache.openejb.arquillian.tests.datasource.definition.DataSourcePojo;
+import org.apache.ziplock.JarLocation;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.ClassLoaderAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.descriptor.api.Descriptors;
+import org.jboss.shrinkwrap.descriptor.api.webapp30.WebAppDescriptor;
+import org.jboss.shrinkwrap.descriptor.api.webcommon30.WebAppVersionType;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(Arquillian.class)
+public class TomcatNamingFailOnWriteConfigurationTest {
+    private static final String TEST_NAME = TomcatNamingFailOnWriteConfigurationTest.class.getSimpleName();
+    private static final String SERVLET_NAME = "TestServlet";
+    private static final String RESOURCE_CONTEXT_XML = "META-INF/context.xml";
+    private static final String CONTENT_LOCATION_CONTEXT_XML_FAIL_ON_WRITE = "org/apache/openejb/arquillian/tests/tomcat/contextxml/fail_on_write.xml";
+    private static final String CONTENT_LOCATION_CONTEXT_XML_DO_NOT_FAIL_ON_WRITE = "org/apache/openejb/arquillian/tests/tomcat/contextxml/do_not_fail_on_write.xml";
+
+    @ArquillianResource
+    private URL url;
+
+    @Deployment(testable = false, name = "fail_on_write")
+    public static WebArchive createDeploymentWhichWillFailOnContextWrite() {
+        return createWebArchive(TEST_NAME + "_failOnWrite", CONTENT_LOCATION_CONTEXT_XML_FAIL_ON_WRITE);
+    }
+
+    @Deployment(testable = false, name = "do_not_fail_on_write")
+    public static WebArchive createDeploymentWhichWillNotFailOnContextWrite() {
+        return createWebArchive(TEST_NAME + "_doNotFailOnWrite", CONTENT_LOCATION_CONTEXT_XML_DO_NOT_FAIL_ON_WRITE);
+    }
+
+    private static WebArchive createWebArchive(String archiveName, String contextXmlLocation) {
+        WebAppDescriptor descriptor = Descriptors.create(WebAppDescriptor.class)
+                .version(WebAppVersionType._3_0)
+                .createServlet()
+                .servletName(SERVLET_NAME)
+                .servletClass(NamingServlet.class.getName()).up()
+                .createServletMapping()
+                .servletName(SERVLET_NAME)
+                .urlPattern("/" + TEST_NAME).up();
+
+        WebArchive archive = ShrinkWrap.create(WebArchive.class, archiveName + ".war")
+                .addClass(TomcatNamingFailOnWriteConfigurationTest.class)
+                .addClass(NamingServlet.class)
+                .addClass(Runner.class)
+                .addAsLibraries(JarLocation.jarLocation(Test.class))
+                .add(new ClassLoaderAsset(contextXmlLocation), RESOURCE_CONTEXT_XML)
+                .setWebXML(new StringAsset(descriptor.exportAsString()));
+
+        return archive;
+    }
+
+    private void validateTest(String testName) throws IOException {
+        final String expectedOutput = testName + "=true";
+
+        try (InputStream is = new URL(url.toExternalForm() + TEST_NAME + "?test=" + testName).openStream()) {
+            final ByteArrayOutputStream os = new ByteArrayOutputStream();
+
+            int bytesRead;
+            byte[] buffer = new byte[8192];
+            while ((bytesRead = is.read(buffer)) > -1) {
+                os.write(buffer, 0, bytesRead);
+            }
+
+            final String output = new String(os.toByteArray(), "UTF-8");
+            assertNotNull("Response shouldn't be null", output);
+            assertTrue("Output should contain: " + expectedOutput
+                    + "\nActual output:\n" + output, output.contains(expectedOutput));
+        }
+    }
+
+    @Test
+    @OperateOnDeployment("fail_on_write")
+    public void testCloseNamingContextAndExpectOperationNotSupportedException() throws IOException {
+        validateTest("closeNamingContextAndExpectOperationNotSupportedException");
+    }
+
+    @Test
+    @OperateOnDeployment("do_not_fail_on_write")
+    public void testCloseNamingContextAndExpectNoException() throws IOException {
+        validateTest("closeNamingContextAndExpectNoException");
+    }
+}

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/resources/org/apache/openejb/arquillian/tests/tomcat/contextxml/do_not_fail_on_write.xml
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/resources/org/apache/openejb/arquillian/tests/tomcat/contextxml/do_not_fail_on_write.xml
@@ -1,0 +1,20 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<Context jndiExceptionOnFailedWrite='false'/>

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/resources/org/apache/openejb/arquillian/tests/tomcat/contextxml/fail_on_write.xml
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/resources/org/apache/openejb/arquillian/tests/tomcat/contextxml/fail_on_write.xml
@@ -1,0 +1,20 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<Context jndiExceptionOnFailedWrite='true'/>

--- a/tomee/tomee-catalina/src/main/java/org/apache/catalina/startup/OpenEJBContextConfig.java
+++ b/tomee/tomee-catalina/src/main/java/org/apache/catalina/startup/OpenEJBContextConfig.java
@@ -20,6 +20,7 @@ import org.apache.catalina.Container;
 import org.apache.catalina.Context;
 import org.apache.catalina.WebResource;
 import org.apache.catalina.Wrapper;
+import org.apache.catalina.core.NamingContextListener;
 import org.apache.catalina.core.StandardContext;
 import org.apache.catalina.core.StandardWrapper;
 import org.apache.catalina.deploy.NamingResourcesImpl;
@@ -271,6 +272,14 @@ public class OpenEJBContextConfig extends ContextConfig {
         super.contextConfig(digester);
         if (resources instanceof OpenEJBNamingResource) {
             ((OpenEJBNamingResource) resources).setTomcatResource(false);
+        }
+
+        if (context instanceof StandardContext) {
+            final StandardContext standardContext = (StandardContext) context;
+            final NamingContextListener namingContextListener = standardContext.getNamingContextListener();
+            if (null != namingContextListener) {
+                namingContextListener.setExceptionOnFailedWrite(standardContext.getJndiExceptionOnFailedWrite());
+            }
         }
     }
 


### PR DESCRIPTION
OpenEjbContextConfig should reconfigure the NamingContextListener after it process the context.xml

----
Execution flow:

1. TomcatWebAppBuilder:890 creates new NamingContextLisener

2. TomcatWebAppBuilder sets the "exceptionOnFailedWrite" property on the NamingContextLisener to the value retrieved from the standard context - at this point in time it's the default value, because the context.xml has not been processed yet.

3. The context.xml is processed -> OpenEJBContextConfig::contextConfig()

4. The Digester sets that property on the StandardContext instance

5. The NamingContextListener configures the naming context

namingContext.setExceptionOnFailedWrite(getExceptionOnFailedWrite());

Where getExceptionOnFailedWrite() returns the value we set in step 2 (i.e. it returns the default value).

6. As a result the naming context is not configured with the user-provided configuration in context.xml