### PR TITLE
Revert "Simplify Test"

### DIFF
--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/naming/IvmContextServlet.java
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/naming/IvmContextServlet.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.openejb.arquillian.tests.naming;
+
+
+import javax.ejb.EJB;
+import javax.naming.NamingException;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+public class IvmContextServlet extends HttpServlet {
+    @EJB
+    NamingBean namingBean;
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        final PrintWriter writer = resp.getWriter();
+        final String testToExecute = req.getParameter("test");
+
+        try {
+            final Method method = this.getClass().getDeclaredMethod(testToExecute, PrintWriter.class);
+            method.invoke(this, writer);
+            writer.println(testToExecute + "=true");
+        } catch (Exception ex) {
+            final Throwable rootCause = ex instanceof InvocationTargetException ? ex.getCause() : ex;
+            writer.println(testToExecute + "=false");
+            rootCause.printStackTrace(writer);
+        }
+    }
+
+    public void testListContextTree(PrintWriter printWriter) throws NamingException {
+        namingBean.verifyListContext(printWriter);
+    }
+
+    public void testContextListBindings(PrintWriter printWriter) throws NamingException {
+        namingBean.verifyContextListBindings(printWriter);
+    }
+}

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/naming/IvmContextTest.java
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/naming/IvmContextTest.java
@@ -21,13 +21,22 @@ import org.apache.openejb.arquillian.tests.Runner;
 import org.apache.ziplock.JarLocation;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.ClassLoaderAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.descriptor.api.Descriptors;
+import org.jboss.shrinkwrap.descriptor.api.webapp30.WebAppDescriptor;
+import org.jboss.shrinkwrap.descriptor.api.webcommon30.WebAppVersionType;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import javax.ejb.EJB;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import static org.junit.Assert.assertNotNull;
@@ -37,31 +46,64 @@ import static org.junit.Assert.assertTrue;
 public class IvmContextTest {
     private static final Logger logger = Logger.getLogger(IvmContextTest.class.getName());
     private static final String TEST_NAME = IvmContextTest.class.getSimpleName();
+    private static final String SERVLET_NAME = "TestServlet";
     private static final String RESOURCE_EJB_JAR_XML = "ejb-jar.xml";
     private static final String CONTENT_LOCATION_EJB_JAR_XML = "org/apache/openejb/arquillian/tests/naming/list-context-ejbjar.xml";
 
-    @EJB
-    private NamingBean namingBean;
+    @ArquillianResource
+    private URL url;
 
     @Deployment(testable = false)
     public static WebArchive createDeployment() {
+        WebAppDescriptor descriptor = Descriptors.create(WebAppDescriptor.class)
+                .version(WebAppVersionType._3_0)
+                .createServlet()
+                .servletName(SERVLET_NAME)
+                .servletClass(IvmContextServlet.class.getName()).up()
+                .createServletMapping()
+                .servletName(SERVLET_NAME)
+                .urlPattern("/" + TEST_NAME).up();
+
         WebArchive archive = ShrinkWrap.create(WebArchive.class, TEST_NAME + ".war")
                 .addClass(IvmContextTest.class)
+                .addClass(IvmContextServlet.class)
                 .addClass(NamingBean.class)
                 .addClass(Runner.class)
                 .addAsLibraries(JarLocation.jarLocation(Test.class))
-                .addAsWebInfResource(new ClassLoaderAsset(CONTENT_LOCATION_EJB_JAR_XML), RESOURCE_EJB_JAR_XML);
+                .addAsWebInfResource(new ClassLoaderAsset(CONTENT_LOCATION_EJB_JAR_XML), RESOURCE_EJB_JAR_XML)
+                .setWebXML(new StringAsset(descriptor.exportAsString()));
+
         return archive;
     }
 
+    private void validateTest(String testName) throws IOException {
+        final String expectedOutput = testName + "=true";
 
-    @Test
-    public void testListContextTree() throws Exception {
-        namingBean.verifyContextList();
+        try (InputStream is = new URL(url.toExternalForm() + TEST_NAME + "?test=" + testName).openStream()) {
+            final ByteArrayOutputStream os = new ByteArrayOutputStream();
+
+            int bytesRead;
+            byte[] buffer = new byte[8192];
+            while ((bytesRead = is.read(buffer)) > -1) {
+                os.write(buffer, 0, bytesRead);
+            }
+
+            final String output = new String(os.toByteArray(), "UTF-8");
+            logger.log(Level.FINE, output);
+
+            assertNotNull("Response shouldn't be null", output);
+            assertTrue("Output should contain: " + expectedOutput
+                    + "\nActual output:\n" + output, output.contains(expectedOutput));
+        }
     }
 
     @Test
-    public void testContextListBindings() throws Exception {
-        namingBean.verifyContextListBindings();
+    public void testListContextTree() throws IOException, InterruptedException {
+        validateTest("testListContextTree");
+    }
+
+    @Test
+    public void testContextListBindings() throws IOException, InterruptedException {
+        validateTest("testContextListBindings");
     }
 }

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/naming/NamingBean.java
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/naming/NamingBean.java
@@ -22,10 +22,7 @@ import org.apache.openejb.core.ivm.naming.SystemComponentReference;
 import javax.ejb.LocalBean;
 import javax.ejb.Stateless;
 import javax.naming.*;
-import java.io.ByteArrayOutputStream;
 import java.io.PrintWriter;
-import java.io.UnsupportedEncodingException;
-import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -36,42 +33,31 @@ public class NamingBean {
         NamingEnumeration<? extends NameClassPair> execute(Context context, String address) throws NamingException;
     }
 
-    public void verifyContextList() throws NamingException {
-        verifyContextListInternal(new ListOperation() {
+    public void verifyListContext(PrintWriter logSink) throws NamingException {
+        verifyContextListOperation(new ListOperation() {
             @Override
             public NamingEnumeration<NameClassPair> execute(Context context, String address) throws NamingException {
                 return context.list(address);
             }
-        });
+        }, logSink);
     }
 
-    public void verifyContextListBindings() throws NamingException {
-        verifyContextListInternal(new ListOperation() {
+    public void verifyContextListBindings(PrintWriter logSink) throws NamingException {
+        verifyContextListOperation(new ListOperation() {
             @Override
             public NamingEnumeration<Binding> execute(Context context, String address) throws NamingException {
                 return context.listBindings(address);
             }
-        });
+        }, logSink);
     }
 
-    private void verifyContextListInternal(ListOperation listOperation) throws NamingException {
-        final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
-        final PrintWriter logSink = new PrintWriter(buffer);
-
+    private void verifyContextListOperation(ListOperation listOperation, PrintWriter logSink) throws NamingException {
         final InitialContext ctx = new InitialContext();
         final boolean hasErrors = listContext(ctx, "", listOperation, logSink);
         logSink.flush();
 
         if (hasErrors) {
-            throw new IllegalStateException("Failed to lookup some of the listed entries:\n" + getPrintedJndiTree(buffer));
-        }
-    }
-
-    private String getPrintedJndiTree(ByteArrayOutputStream buffer) {
-        try {
-            return buffer.toString(StandardCharsets.UTF_8.name());
-        } catch (UnsupportedEncodingException e) {
-            return null; //should never happen
+            throw new IllegalStateException("Failed to lookup some of the listed entries.");
         }
     }
 
@@ -132,4 +118,5 @@ public class NamingBean {
 
         return hasErrors;
     }
+
 }


### PR DESCRIPTION
With the removal of the boiler-plate servlet, the test is not executed
against the correct context and does not test what it was intended
to test.