### PR TITLE
HTTP(s) basic auth failed if password contained ampersand passed via …

### DIFF
--- a/server/openejb-client/src/main/java/org/apache/openejb/client/MulticastConnectionFactory.java
+++ b/server/openejb-client/src/main/java/org/apache/openejb/client/MulticastConnectionFactory.java
@@ -133,7 +133,7 @@ public class MulticastConnectionFactory implements ConnectionFactory {
         }
 
         public static Map<String, String> parseParamters(final URI uri) throws URISyntaxException {
-            return uri.getQuery() == null ? new HashMap<String, String>(0) : parseQuery(stripPrefix(uri.getQuery(), "?"));
+            return uri.getRawQuery() == null ? new HashMap<String, String>(0) : parseQuery(stripPrefix(uri.getRawQuery(), "?"));
         }
 
         public static String stripPrefix(final String value, final String prefix) {

--- a/server/openejb-client/src/test/java/org/apache/openejb/client/HttpConnectionTest.java
+++ b/server/openejb-client/src/test/java/org/apache/openejb/client/HttpConnectionTest.java
@@ -168,6 +168,38 @@ public class HttpConnectionTest {
     }
 
     @Test
+    public void httpBasicSpecificConfigAmpersand() throws URISyntaxException, IOException {
+        final HttpConnectionFactory factory = new HttpConnectionFactory();
+        final String url = "http://localhost:" + server.getAddress().getPort() + "/e?basic.password=pwd&basic.username=te%26st&authorizationHeader=AltAuthorization";
+        for (int i = 0; i < 3; i++) {
+            final Connection connection = factory.getConnection(new URI(url));
+
+            BufferedReader br = null;
+            final StringBuilder sb = new StringBuilder();
+            String line;
+            try {
+                br = new BufferedReader(new InputStreamReader(connection.getInputStream()));
+                while ((line = br.readLine()) != null) {
+                    sb.append(line);
+                }
+            } catch (final IOException e) {
+                e.printStackTrace();
+            } finally {
+                if (br != null) {
+                    try {
+                        br.close();
+                    } catch (final IOException e) {
+                        e.printStackTrace();
+                    }
+                }
+                connection.close();
+            }
+
+            Assert.assertTrue("should contain", sb.toString().contains("secure pagealtBasic dGUmc3Q6cHdk"));
+        }
+    }
+
+    @Test
     public void complexURIAuthorization() throws IOException, URISyntaxException {
         final String baseHttp = "http://localhost:" + server.getAddress().getPort() + "/e?authorization=";
         final String uri = "failover:sticky+random:" + baseHttp + "Basic%20ABCD&" + baseHttp + "Basic%20EFG";


### PR DESCRIPTION
…basic.password URL parameter

A double-decode bug caused URLDecode to be applied twice to parameters passed in
via URL including basic.username and basic.password.  The parameters were automatically
decoded by the call to URI.getQuery() then again as each parameter was parsed and added
to the returned Map in MulticastConnectionFactory.URIs.parseQuery().  parseQuery() splits the
query string on the ampersand character then explictly URLDecode's each value.  Since
URI.getQuery() had already decoded the basic.password parameter, the splitting process
in parseQuery truncated the password at the first ampersand character.

Instead, URI.getRawQuery() should be called to get the still URLEncoded query string.  The
splitting and subsequent decoding in parseQuery() then correctly extracts the full password
from the query string.

PR contains failing unit test & fix.