### PR TITLE
Java9 compatibility

### DIFF
--- a/arquillian/arquillian-tomee-common/pom.xml
+++ b/arquillian/arquillian-tomee-common/pom.xml
@@ -151,7 +151,7 @@
           <groupId>org.apache.geronimo.javamail</groupId>
         </exclusion>
         <exclusion>
-          <artifactId>xbean-asm5-shaded</artifactId>
+          <artifactId>xbean-asm6-shaded</artifactId>
           <groupId>org.apache.xbean</groupId>
         </exclusion>
         <exclusion>

--- a/arquillian/arquillian-tomee-webapp-remote/pom.xml
+++ b/arquillian/arquillian-tomee-webapp-remote/pom.xml
@@ -170,7 +170,7 @@
           <groupId>org.apache.geronimo.javamail</groupId>
         </exclusion>
         <exclusion>
-          <artifactId>xbean-asm5-shaded</artifactId>
+          <artifactId>xbean-asm6-shaded</artifactId>
           <groupId>org.apache.xbean</groupId>
         </exclusion>
         <exclusion>

--- a/container/openejb-core/pom.xml
+++ b/container/openejb-core/pom.xml
@@ -399,7 +399,7 @@
             </manifest>
             <manifestEntries>
               <Class-Path>openejb-loader-${project.version}.jar openejb-client-${project.version}.jar
-                xbean-finder-shaded-${xbeanVersion}.jar xbean-asm5-shaded-${xbeanVersion}.jar
+                xbean-finder-shaded-${xbeanVersion}.jar xbean-asm6-shaded-${xbeanVersion}.jar
               </Class-Path>
               <J2EE-DeploymentFactory-Implementation-Class>
                 org.apache.openejb.config.VmDeploymentFactory
@@ -558,7 +558,7 @@
     <!-- End: JavaMail -->
     <dependency>
       <groupId>org.apache.xbean</groupId>
-      <artifactId>xbean-asm5-shaded</artifactId>
+      <artifactId>xbean-asm6-shaded</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.xbean</groupId>

--- a/container/openejb-jpa-integration/pom.xml
+++ b/container/openejb-jpa-integration/pom.xml
@@ -33,7 +33,7 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.xbean</groupId>
-      <artifactId>xbean-asm5-shaded</artifactId>
+      <artifactId>xbean-asm6-shaded</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/container/openejb-jpa-integration/src/main/java/org/apache/openejb/jpa/integration/MakeTxLookup.java
+++ b/container/openejb-jpa-integration/src/main/java/org/apache/openejb/jpa/integration/MakeTxLookup.java
@@ -16,11 +16,11 @@
  */
 package org.apache.openejb.jpa.integration;
 
-import org.apache.xbean.asm5.ClassWriter;
-import org.apache.xbean.asm5.Label;
-import org.apache.xbean.asm5.MethodVisitor;
-import org.apache.xbean.asm5.Opcodes;
-import org.apache.xbean.asm5.Type;
+import org.apache.xbean.asm6.ClassWriter;
+import org.apache.xbean.asm6.Label;
+import org.apache.xbean.asm6.MethodVisitor;
+import org.apache.xbean.asm6.Opcodes;
+import org.apache.xbean.asm6.Type;
 
 import java.io.File;
 import java.io.FileOutputStream;

--- a/examples/deltaspike-fullstack/pom.xml
+++ b/examples/deltaspike-fullstack/pom.xml
@@ -128,7 +128,7 @@
           <groupId>org.slf4j</groupId>
         </exclusion>
         <exclusion>
-          <artifactId>xbean-asm5-shaded</artifactId>
+          <artifactId>xbean-asm6-shaded</artifactId>
           <groupId>org.apache.xbean</groupId>
         </exclusion>
         <exclusion>
@@ -147,8 +147,8 @@
     </dependency>
     <dependency>
       <groupId>org.apache.xbean</groupId>
-      <artifactId>xbean-asm5-shaded</artifactId>
-      <version>3.18</version>
+      <artifactId>xbean-asm6-shaded</artifactId>
+      <version>4.6-SNAPSHOT</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -106,10 +106,10 @@
     <johnzon.version>1.0.0</johnzon.version>
 
     <!-- Maven module versions -->
-    <maven-bundle-plugin.version>2.3.7</maven-bundle-plugin.version>
+    <maven-bundle-plugin.version>3.3.0</maven-bundle-plugin.version>
 
     <!-- This is used by a manifest classpath entry -->
-    <xbeanVersion>4.5</xbeanVersion>
+    <xbeanVersion>4.6-SNAPSHOT</xbeanVersion>
 
     <!-- OSGi bundles properties -->
     <openejb.bundle.activator/>
@@ -259,7 +259,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-failsafe-plugin</artifactId>
-          <version>2.20</version>
+          <version>2.20.1</version>
         </plugin>
         <plugin> <!-- maven-dependency-plugin:properties doesn't work as well as this one for us -->
           <groupId>org.apache.geronimo.buildsupport</groupId>
@@ -334,7 +334,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.20</version>
+          <version>2.20.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -362,7 +362,10 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
           <source>1.7</source>
-          <target>1.7</target>
+          <target>1.9</target>
+          <compilerArgs>
+            <arg>--add-modules</arg><arg>java.xml.bind</arg>
+          </compilerArgs>
         </configuration>
       </plugin>
       <plugin>
@@ -1241,7 +1244,7 @@
       </dependency>
       <dependency>
         <groupId>org.apache.xbean</groupId>
-        <artifactId>xbean-asm5-shaded</artifactId>
+        <artifactId>xbean-asm6-shaded</artifactId>
         <version>${xbeanVersion}</version>
       </dependency>
       <dependency>

--- a/server/openejb-server/pom.xml
+++ b/server/openejb-server/pom.xml
@@ -85,7 +85,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.xbean</groupId>
-      <artifactId>xbean-asm5-shaded</artifactId>
+      <artifactId>xbean-asm6-shaded</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.xbean</groupId>

--- a/tomee/apache-tomee/pom.xml
+++ b/tomee/apache-tomee/pom.xml
@@ -254,7 +254,7 @@
           </dependency>
           <dependency>
             <groupId>org.apache.xbean</groupId>
-            <artifactId>xbean-asm5-shaded</artifactId>
+            <artifactId>xbean-asm6-shaded</artifactId>
             <version>${xbeanVersion}</version>
           </dependency>
           <dependency>


### PR DESCRIPTION
Changes to plugin versions in order to compile TomEE with Java 9.

maven-bundle-plugin.version>3.3.0
maven-failsafe-plugin>2.20.1
maven-surefire-plugin>2.20.1
xbeanVersion>4.6-SNAPSHOT
plugin xbean-asm5-shaded by xbean-asm6-shaded

**Issues:**
- Please note this should only **be merged after** the next release of the org.apache.xbean project.
- Requires openJPA plugin upgrade, The compilation of the arquillian-tomee-webprofile-tests subproject fails due to the `openjpa-maven-plugin:1.2:enhance` This plugin also uses uses ASM5 and needs to be upgraded to ASM6 (see  org.apache.xbean project upgrade to 4.6). 