### PR TITLE
Tomee 7.0.4 issue with CDI interceptor and WebServiceContext resource injection

### DIFF
--- a/arquillian/arquillian-common/pom.xml
+++ b/arquillian/arquillian-common/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>arquillian</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
 
   <artifactId>arquillian-common</artifactId>

--- a/arquillian/arquillian-openejb-embedded/pom.xml
+++ b/arquillian/arquillian-openejb-embedded/pom.xml
@@ -22,13 +22,13 @@
   <parent>
     <artifactId>arquillian</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>arquillian-openejb-embedded</artifactId>
   <name>OpenEJB :: Arquillian Adaptors Parent :: OpenEJB Container</name>
-  <version>7.0.4-SNAPSHOT</version>
+  <version>7.0.4</version>
 
   <dependencies>
     <dependency>

--- a/arquillian/arquillian-openejb-transaction-provider/pom.xml
+++ b/arquillian/arquillian-openejb-transaction-provider/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>arquillian</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/arquillian/arquillian-tck/pom.xml
+++ b/arquillian/arquillian-tck/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>arquillian</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
 
   <artifactId>arquillian-tck</artifactId>

--- a/arquillian/arquillian-tomee-common/pom.xml
+++ b/arquillian/arquillian-tomee-common/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>arquillian</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
   <artifactId>arquillian-tomee-common</artifactId>
   <packaging>jar</packaging>

--- a/arquillian/arquillian-tomee-embedded/pom.xml
+++ b/arquillian/arquillian-tomee-embedded/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>arquillian</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
   <artifactId>arquillian-tomee-embedded</artifactId>
   <packaging>jar</packaging>

--- a/arquillian/arquillian-tomee-moviefun-example/pom.xml
+++ b/arquillian/arquillian-tomee-moviefun-example/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.apache.tomee</groupId>
     <artifactId>arquillian</artifactId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
   <artifactId>arquillian-tomee-moviefun-example</artifactId>
   <packaging>war</packaging>

--- a/arquillian/arquillian-tomee-remote/pom.xml
+++ b/arquillian/arquillian-tomee-remote/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>arquillian</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
   <artifactId>arquillian-tomee-remote</artifactId>
   <packaging>jar</packaging>
@@ -92,7 +92,7 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>apache-tomee</artifactId>
       <type>zip</type>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <classifier>webprofile</classifier>
       <scope>provided</scope>
     </dependency>
@@ -121,7 +121,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>arquillian-tomee-common</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <type>jar</type>
       <scope>compile</scope>
     </dependency>
@@ -148,7 +148,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>arquillian-common</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
     </dependency>
 
     <dependency>

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-codi-tests/pom.xml
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-codi-tests/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>arquillian-tomee-tests</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
 
   <artifactId>arquillian-tomee-codi-tests</artifactId>

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-config-tests/pom.xml
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-config-tests/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>arquillian-tomee-tests</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
 
   <artifactId>arquillian-tomee-config-tests</artifactId>

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-jaxrs-tests/pom.xml
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-jaxrs-tests/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>arquillian-tomee-tests</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
 
   <artifactId>arquillian-tomee-jaxrs-tests</artifactId>

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-jaxws-tests/pom.xml
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-jaxws-tests/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>arquillian-tomee-tests</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
 
   <artifactId>arquillian-tomee-jaxws-tests</artifactId>

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-jms-tests/pom.xml
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-jms-tests/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>arquillian-tomee-tests</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
 
   <artifactId>arquillian-tomee-jms-tests</artifactId>

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/pom.xml
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>arquillian-tomee-tests</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
 
   <artifactId>arquillian-tomee-webprofile-tests</artifactId>

--- a/arquillian/arquillian-tomee-tests/pom.xml
+++ b/arquillian/arquillian-tomee-tests/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <artifactId>arquillian</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
   
   <artifactId>arquillian-tomee-tests</artifactId>

--- a/arquillian/arquillian-tomee-webapp-remote/pom.xml
+++ b/arquillian/arquillian-tomee-webapp-remote/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>arquillian</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
   <artifactId>arquillian-tomee-webapp-remote</artifactId>
   <packaging>jar</packaging>

--- a/arquillian/pom.xml
+++ b/arquillian/pom.xml
@@ -23,11 +23,11 @@
   <parent>
     <artifactId>tomee-project</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
 
   <artifactId>arquillian</artifactId>
-  <version>7.0.4-SNAPSHOT</version>
+  <version>7.0.4</version>
   <packaging>pom</packaging>
   <name>OpenEJB :: Arquillian Adaptors Parent</name>
 

--- a/arquillian/ziplock/pom.xml
+++ b/arquillian/ziplock/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>arquillian</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
   <artifactId>ziplock</artifactId>
   <packaging>jar</packaging>

--- a/assembly/openejb-lite/pom.xml
+++ b/assembly/openejb-lite/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <artifactId>assembly</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
 
   <artifactId>openejb-lite</artifactId>

--- a/assembly/openejb-standalone/pom.xml
+++ b/assembly/openejb-standalone/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <artifactId>assembly</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
 
   <artifactId>openejb-standalone</artifactId>

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>tomee-project</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>assembly</artifactId>

--- a/container/mbean-annotation-api/pom.xml
+++ b/container/mbean-annotation-api/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>container</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
   <artifactId>mbean-annotation-api</artifactId>
   <name>OpenEJB :: Container :: MBean Annotation API</name>

--- a/container/openejb-api/pom.xml
+++ b/container/openejb-api/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>container</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/container/openejb-core/pom.xml
+++ b/container/openejb-core/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <artifactId>container</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
 
   <artifactId>openejb-core</artifactId>

--- a/container/openejb-javaagent/pom.xml
+++ b/container/openejb-javaagent/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>container</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>openejb-javaagent</artifactId>

--- a/container/openejb-jee-accessors/pom.xml
+++ b/container/openejb-jee-accessors/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>container</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>openejb-jee-accessors</artifactId>

--- a/container/openejb-jee/pom.xml
+++ b/container/openejb-jee/pom.xml
@@ -62,14 +62,17 @@
     <dependency>
       <groupId>javax.xml.bind</groupId>
       <artifactId>jaxb-api</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.sun.xml.bind</groupId>
       <artifactId>jaxb-impl</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.sun.xml.bind</groupId>
       <artifactId>jaxb-core</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/container/openejb-jee/pom.xml
+++ b/container/openejb-jee/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>container</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>openejb-jee</artifactId>

--- a/container/openejb-jpa-integration/pom.xml
+++ b/container/openejb-jpa-integration/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>container</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/container/openejb-junit/pom.xml
+++ b/container/openejb-junit/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>container</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/container/openejb-loader/pom.xml
+++ b/container/openejb-loader/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>container</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>openejb-loader</artifactId>

--- a/container/pom.xml
+++ b/container/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>tomee-project</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/examples/access-timeout-meta/pom.xml
+++ b/examples/access-timeout-meta/pom.xml
@@ -71,7 +71,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-core</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/examples/access-timeout-meta/pom.xml
+++ b/examples/access-timeout-meta/pom.xml
@@ -25,7 +25,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>access-timeout-meta</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: @AccessTimeout (Meta)</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/examples/access-timeout/pom.xml
+++ b/examples/access-timeout/pom.xml
@@ -25,7 +25,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>access-timeout</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: @AccessTimeout</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/examples/access-timeout/pom.xml
+++ b/examples/access-timeout/pom.xml
@@ -71,7 +71,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-core</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/examples/alternate-descriptors/pom.xml
+++ b/examples/alternate-descriptors/pom.xml
@@ -92,7 +92,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-core</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/examples/alternate-descriptors/pom.xml
+++ b/examples/alternate-descriptors/pom.xml
@@ -26,7 +26,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>alternate-descriptors</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: Alternate Descriptors</name>
 
   <properties>

--- a/examples/applet/pom.xml
+++ b/examples/applet/pom.xml
@@ -44,7 +44,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-client</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -112,7 +112,7 @@
                 <artifactItem>
                   <groupId>org.apache.tomee</groupId>
                   <artifactId>openejb-client</artifactId>
-                  <version>7.0.4-SNAPSHOT</version>
+                  <version>7.0.4</version>
                   <outputDirectory>${project.build.directory}/${project.build.finalName}</outputDirectory>
                   <destFileName>openejb-client.jar</destFileName>
                 </artifactItem>

--- a/examples/applet/pom.xml
+++ b/examples/applet/pom.xml
@@ -22,7 +22,7 @@
   <groupId>org.superbiz.applet</groupId>
   <artifactId>applet</artifactId>
   <packaging>war</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Web Examples :: Signed Applet EJB Client</name>
   <url>http://tomee.apache.org</url>
   <properties>

--- a/examples/application-composer/pom.xml
+++ b/examples/application-composer/pom.xml
@@ -72,7 +72,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-core</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
 

--- a/examples/application-composer/pom.xml
+++ b/examples/application-composer/pom.xml
@@ -25,7 +25,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>application-composer</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: Application Composer</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/examples/applicationcomposer-jaxws-cdi/pom.xml
+++ b/examples/applicationcomposer-jaxws-cdi/pom.xml
@@ -69,13 +69,13 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-cxf</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>ziplock</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/examples/applicationcomposer-jaxws-cdi/pom.xml
+++ b/examples/applicationcomposer-jaxws-cdi/pom.xml
@@ -23,7 +23,7 @@
 
   <groupId>org.superbiz</groupId>
   <artifactId>ws-pojo-cdi</artifactId>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: Application Composer, JAX-WS and CDI are in a boat</name>
 
   <properties>

--- a/examples/applicationexception/pom.xml
+++ b/examples/applicationexception/pom.xml
@@ -82,7 +82,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-core</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/examples/applicationexception/pom.xml
+++ b/examples/applicationexception/pom.xml
@@ -25,7 +25,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>applicationexception</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: @ApplicationException inheritance</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/examples/arquillian-jpa/pom.xml
+++ b/examples/arquillian-jpa/pom.xml
@@ -14,7 +14,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>arquillian-jpa</artifactId>
   <name>OpenEJB :: Examples :: Arquillian Persistence Extension Sample</name>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
 
   <properties>
     <arquillian.version>1.1.10.Final</arquillian.version>

--- a/examples/arquillian-jpa/pom.xml
+++ b/examples/arquillian-jpa/pom.xml
@@ -19,7 +19,7 @@
   <properties>
     <arquillian.version>1.1.10.Final</arquillian.version>
     <arquillian-persistence.version>1.0.0.Alpha7</arquillian-persistence.version>
-    <tomee.version>7.0.4-SNAPSHOT</tomee.version>
+    <tomee.version>7.0.4</tomee.version>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
@@ -63,7 +63,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-core</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
     </dependency>
     <dependency>
       <groupId>org.apache.tomee</groupId>

--- a/examples/async-methods/pom.xml
+++ b/examples/async-methods/pom.xml
@@ -71,7 +71,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-core</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/examples/async-methods/pom.xml
+++ b/examples/async-methods/pom.xml
@@ -25,7 +25,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>async-methods</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: @Asynchronous Methods</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/examples/async-postconstruct/pom.xml
+++ b/examples/async-postconstruct/pom.xml
@@ -25,7 +25,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>async-postconstruct</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: @Asynchronous @PostConstrct</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/examples/async-postconstruct/pom.xml
+++ b/examples/async-postconstruct/pom.xml
@@ -71,7 +71,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-core</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/examples/bean-validation-design-by-contract/pom.xml
+++ b/examples/bean-validation-design-by-contract/pom.xml
@@ -27,7 +27,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <tomee.version>7.0.4-SNAPSHOT</tomee.version>
+    <tomee.version>7.0.4</tomee.version>
   </properties>
 
   <build>
@@ -70,7 +70,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-core</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/examples/bean-validation-design-by-contract/pom.xml
+++ b/examples/bean-validation-design-by-contract/pom.xml
@@ -22,7 +22,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>bean-validation-design-by-contract</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: Bean Validation Design By Contract</name>
 
   <properties>

--- a/examples/bval-evaluation-redeployment/WebApp1/pom.xml
+++ b/examples/bval-evaluation-redeployment/WebApp1/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.superbiz</groupId>
     <artifactId>bval-evaluation-redeployment</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.3</version>
   </parent>
 
   <artifactId>WebApp1</artifactId>

--- a/examples/bval-evaluation-redeployment/WebApp2/pom.xml
+++ b/examples/bval-evaluation-redeployment/WebApp2/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.superbiz</groupId>
     <artifactId>bval-evaluation-redeployment</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.3</version>
   </parent>
 
   <artifactId>WebApp2</artifactId>

--- a/examples/bval-evaluation-redeployment/pom.xml
+++ b/examples/bval-evaluation-redeployment/pom.xml
@@ -23,7 +23,7 @@
 
   <groupId>org.superbiz</groupId>
   <artifactId>bval-evaluation-redeployment</artifactId>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <packaging>pom</packaging>
 
   <properties>

--- a/examples/bval-evaluation-redeployment/pom.xml
+++ b/examples/bval-evaluation-redeployment/pom.xml
@@ -28,8 +28,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <tomee.test.version>7.0.4-SNAPSHOT</tomee.test.version>
-    <openejb.test.version>7.0.4-SNAPSHOT</openejb.test.version>
+    <tomee.test.version>7.0.4</tomee.test.version>
+    <openejb.test.version>7.0.4</openejb.test.version>
   </properties>
 
   <modules>
@@ -109,7 +109,7 @@
       <dependency>
         <groupId>org.apache.tomee</groupId>
         <artifactId>arquillian-tomee-remote</artifactId>
-        <version>7.0.4-SNAPSHOT</version>
+        <version>7.0.4</version>
         <scope>test</scope>
       </dependency>
       <dependency>

--- a/examples/bval-evaluation-redeployment/runner/pom.xml
+++ b/examples/bval-evaluation-redeployment/runner/pom.xml
@@ -51,7 +51,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>apache-tomee</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <type>zip</type>
       <classifier>webprofile</classifier>
       <scope>test</scope>

--- a/examples/bval-evaluation-redeployment/runner/pom.xml
+++ b/examples/bval-evaluation-redeployment/runner/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.superbiz</groupId>
     <artifactId>bval-evaluation-redeployment</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.3</version>
   </parent>
 
   <artifactId>runner</artifactId>

--- a/examples/cdi-alternative-and-stereotypes/pom.xml
+++ b/examples/cdi-alternative-and-stereotypes/pom.xml
@@ -71,7 +71,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-core</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/examples/cdi-alternative-and-stereotypes/pom.xml
+++ b/examples/cdi-alternative-and-stereotypes/pom.xml
@@ -25,7 +25,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>cdi-alternative-and-stereotypes</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: CDI Stereotypes</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/examples/cdi-application-scope/pom.xml
+++ b/examples/cdi-application-scope/pom.xml
@@ -14,7 +14,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>cdi-application-scope</artifactId>
   <name>OpenEJB :: Examples :: CDI Application Scope</name>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
 
   <build>
     <defaultGoal>install</defaultGoal>

--- a/examples/cdi-application-scope/pom.xml
+++ b/examples/cdi-application-scope/pom.xml
@@ -53,7 +53,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-core</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/examples/cdi-basic/pom.xml
+++ b/examples/cdi-basic/pom.xml
@@ -67,7 +67,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-core</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/examples/cdi-basic/pom.xml
+++ b/examples/cdi-basic/pom.xml
@@ -23,7 +23,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>cdi-basic</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: Basic CDI</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/examples/cdi-ejbcontext-jaas/pom.xml
+++ b/examples/cdi-ejbcontext-jaas/pom.xml
@@ -31,7 +31,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-core</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -58,7 +58,7 @@
       <plugin>
         <groupId>org.apache.tomee.maven</groupId>
         <artifactId>tomee-maven-plugin</artifactId>
-        <version>7.0.4-SNAPSHOT</version>
+        <version>7.0.4</version>
         <configuration>
           <systemVariables>
             <java.security.auth.login.config>${project.build.directory}/apache-tomee/conf/login.config</java.security.auth.login.config>

--- a/examples/cdi-ejbcontext-jaas/pom.xml
+++ b/examples/cdi-ejbcontext-jaas/pom.xml
@@ -23,7 +23,7 @@
 
   <groupId>org.superbiz</groupId>
   <artifactId>cdi-ejbcontext-jaas</artifactId>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <packaging>war</packaging>
   <name>OpenEJB :: Examples :: CDI, EJBContext and JAAS</name>
 

--- a/examples/cdi-events/pom.xml
+++ b/examples/cdi-events/pom.xml
@@ -25,7 +25,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>cdi-events</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: CDI Events</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/examples/cdi-events/pom.xml
+++ b/examples/cdi-events/pom.xml
@@ -71,7 +71,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-core</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
     <!-- to show events we log them in the test -->

--- a/examples/cdi-interceptors/pom.xml
+++ b/examples/cdi-interceptors/pom.xml
@@ -65,7 +65,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-core</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/examples/cdi-interceptors/pom.xml
+++ b/examples/cdi-interceptors/pom.xml
@@ -19,7 +19,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>cdi-interceptors</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: CDI Interceptors</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/examples/cdi-produces-disposes/pom.xml
+++ b/examples/cdi-produces-disposes/pom.xml
@@ -72,7 +72,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-core</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/examples/cdi-produces-disposes/pom.xml
+++ b/examples/cdi-produces-disposes/pom.xml
@@ -25,7 +25,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>cdi-produces-disposes</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: CDI-Disposes</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/examples/cdi-produces-field/pom.xml
+++ b/examples/cdi-produces-field/pom.xml
@@ -72,7 +72,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-core</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/examples/cdi-produces-field/pom.xml
+++ b/examples/cdi-produces-field/pom.xml
@@ -25,7 +25,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>cdi-produces-field</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: CDI-Field Producer</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/examples/cdi-realm/pom.xml
+++ b/examples/cdi-realm/pom.xml
@@ -23,7 +23,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>cdi-realm</artifactId>
   <packaging>war</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: CDI Realm</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/examples/cdi-realm/pom.xml
+++ b/examples/cdi-realm/pom.xml
@@ -27,7 +27,7 @@
   <name>OpenEJB :: Examples :: CDI Realm</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <tomee.version>7.0.4-SNAPSHOT</tomee.version>
+    <tomee.version>7.0.4</tomee.version>
   </properties>
   <build>
     <defaultGoal>install</defaultGoal>

--- a/examples/cdi-request-scope/pom.xml
+++ b/examples/cdi-request-scope/pom.xml
@@ -53,7 +53,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-core</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/examples/cdi-request-scope/pom.xml
+++ b/examples/cdi-request-scope/pom.xml
@@ -14,7 +14,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>cdi-request-scope</artifactId>
   <name>OpenEJB :: Examples :: CDI Request Scope</name>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
 
   <build>
     <defaultGoal>install</defaultGoal>

--- a/examples/cdi-session-scope/pom.xml
+++ b/examples/cdi-session-scope/pom.xml
@@ -45,7 +45,7 @@
       <plugin>
         <groupId>org.apache.tomee.maven</groupId>
         <artifactId>tomee-maven-plugin</artifactId>
-        <version>7.0.4-SNAPSHOT</version>
+        <version>7.0.4</version>
       </plugin>
     </plugins>
   </build>

--- a/examples/cdi-session-scope/pom.xml
+++ b/examples/cdi-session-scope/pom.xml
@@ -15,7 +15,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>cdi-session-scope</artifactId>
   <name>OpenEJB :: Examples :: CDI Session Scope</name>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <packaging>war</packaging>
 
   <properties>

--- a/examples/change-jaxws-url/pom.xml
+++ b/examples/change-jaxws-url/pom.xml
@@ -29,7 +29,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <tomee.version>7.0.4-SNAPSHOT</tomee.version>
+    <tomee.version>7.0.4</tomee.version>
   </properties>
 
   <repositories>

--- a/examples/change-jaxws-url/pom.xml
+++ b/examples/change-jaxws-url/pom.xml
@@ -24,7 +24,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>change-jaxws-url</artifactId>
   <packaging>war</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Web Examples :: Change JAXWS URL</name>
 
   <properties>

--- a/examples/client-resource-lookup-preview/pom.xml
+++ b/examples/client-resource-lookup-preview/pom.xml
@@ -60,13 +60,13 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-client</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-ejbd</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
     </dependency>
     <dependency>
       <groupId>org.apache.activemq</groupId>
@@ -85,7 +85,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>ziplock</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/examples/client-resource-lookup-preview/pom.xml
+++ b/examples/client-resource-lookup-preview/pom.xml
@@ -22,7 +22,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>client-resource-lookup-preview</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: Client Resource Lookup</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/examples/component-interfaces/pom.xml
+++ b/examples/component-interfaces/pom.xml
@@ -25,7 +25,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>component-interfaces</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: EJB 2.1 Component Interfaces</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/examples/component-interfaces/pom.xml
+++ b/examples/component-interfaces/pom.xml
@@ -79,7 +79,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-core</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/examples/cucumber-jvm/pom.xml
+++ b/examples/cucumber-jvm/pom.xml
@@ -25,7 +25,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>cucumber-jvm</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: Cucumber JVM</name>
 
   <properties>

--- a/examples/cucumber-jvm/pom.xml
+++ b/examples/cucumber-jvm/pom.xml
@@ -72,7 +72,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-core</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/examples/custom-injection/pom.xml
+++ b/examples/custom-injection/pom.xml
@@ -71,7 +71,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-core</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/examples/custom-injection/pom.xml
+++ b/examples/custom-injection/pom.xml
@@ -25,7 +25,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>custom-injection</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: Expanded support for Env Entries</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/examples/datasource-ciphered-password/pom.xml
+++ b/examples/datasource-ciphered-password/pom.xml
@@ -28,7 +28,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <tomee.version>7.0.4-SNAPSHOT</tomee.version>
+    <tomee.version>7.0.4</tomee.version>
   </properties>
 
   <build>

--- a/examples/datasource-ciphered-password/pom.xml
+++ b/examples/datasource-ciphered-password/pom.xml
@@ -23,7 +23,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>datasource-ciphered-password</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: Datasource Ciphered Password</name>
 
   <properties>

--- a/examples/datasource-definition/pom.xml
+++ b/examples/datasource-definition/pom.xml
@@ -21,7 +21,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>datasource-definition</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: Datasource Definition</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/examples/datasource-definition/pom.xml
+++ b/examples/datasource-definition/pom.xml
@@ -25,7 +25,7 @@
   <name>OpenEJB :: Examples :: Datasource Definition</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <tomee.version>7.0.4-SNAPSHOT</tomee.version>
+    <tomee.version>7.0.4</tomee.version>
   </properties>
   <build>
     <defaultGoal>install</defaultGoal>

--- a/examples/datasource-versioning/pom.xml
+++ b/examples/datasource-versioning/pom.xml
@@ -22,7 +22,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>datasource-versioning</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: Datasource Versioning</name>
 
   <properties>

--- a/examples/datasource-versioning/pom.xml
+++ b/examples/datasource-versioning/pom.xml
@@ -27,7 +27,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <tomee.version>7.0.4-SNAPSHOT</tomee.version>
+    <tomee.version>7.0.4</tomee.version>
   </properties>
 
   <build>
@@ -165,7 +165,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-core</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -177,7 +177,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>tomee-jdbc</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/examples/decorators/pom.xml
+++ b/examples/decorators/pom.xml
@@ -72,7 +72,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-core</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/examples/decorators/pom.xml
+++ b/examples/decorators/pom.xml
@@ -25,7 +25,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>decorators</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: Decorators</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/examples/deltaspike-configproperty/pom.xml
+++ b/examples/deltaspike-configproperty/pom.xml
@@ -24,7 +24,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>deltaspike-configproperty</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: DeltaSpike @ConfigProperty</name>
 
   <properties>

--- a/examples/deltaspike-configproperty/pom.xml
+++ b/examples/deltaspike-configproperty/pom.xml
@@ -81,13 +81,13 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>arquillian-openejb-embedded</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>ziplock</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/examples/deltaspike-exception-handling/pom.xml
+++ b/examples/deltaspike-exception-handling/pom.xml
@@ -24,7 +24,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>deltaspike-exception-handling</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: DeltaSpike Exception Handling</name>
 
   <properties>

--- a/examples/deltaspike-exception-handling/pom.xml
+++ b/examples/deltaspike-exception-handling/pom.xml
@@ -80,13 +80,13 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>arquillian-openejb-embedded</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>ziplock</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/examples/deltaspike-fullstack/pom.xml
+++ b/examples/deltaspike-fullstack/pom.xml
@@ -15,7 +15,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>deltaspike-fullstack</artifactId>
   <name>OpenEJB :: Examples :: JSF2/CDI/BV/JPA/DeltaSpike</name>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
 
   <packaging>war</packaging>
 

--- a/examples/deltaspike-fullstack/pom.xml
+++ b/examples/deltaspike-fullstack/pom.xml
@@ -25,7 +25,7 @@
     <version.myfaces2>2.2.7</version.myfaces2>
     <version.deltaspike>1.3.0</version.deltaspike>
     <version.extval>2.0.8</version.extval>
-    <tomee.version>7.0.4-SNAPSHOT</tomee.version>
+    <tomee.version>7.0.4</tomee.version>
   </properties>
 
   <build>

--- a/examples/deltaspike-i18n/pom.xml
+++ b/examples/deltaspike-i18n/pom.xml
@@ -24,7 +24,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>deltaspike-i18n</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: DeltaSpike I18n</name>
 
   <properties>

--- a/examples/deltaspike-i18n/pom.xml
+++ b/examples/deltaspike-i18n/pom.xml
@@ -82,13 +82,13 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>arquillian-openejb-embedded</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>ziplock</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/examples/dynamic-dao-implementation/pom.xml
+++ b/examples/dynamic-dao-implementation/pom.xml
@@ -22,7 +22,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>dynamic-dao-implementation</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: Dynamic DAO Implementation</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/examples/dynamic-dao-implementation/pom.xml
+++ b/examples/dynamic-dao-implementation/pom.xml
@@ -69,7 +69,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-core</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/examples/dynamic-datasource-routing/pom.xml
+++ b/examples/dynamic-datasource-routing/pom.xml
@@ -28,7 +28,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <tomee.version>7.0.4-SNAPSHOT</tomee.version>
+    <tomee.version>7.0.4</tomee.version>
   </properties>
 
   <build>

--- a/examples/dynamic-datasource-routing/pom.xml
+++ b/examples/dynamic-datasource-routing/pom.xml
@@ -23,7 +23,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>dynamic-datasource-routing</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: Dynamic Datasource Routing</name>
 
   <properties>

--- a/examples/dynamic-implementation/pom.xml
+++ b/examples/dynamic-implementation/pom.xml
@@ -21,7 +21,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>dynamic-implementation</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: Dynamic Implementation</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/examples/dynamic-implementation/pom.xml
+++ b/examples/dynamic-implementation/pom.xml
@@ -57,7 +57,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-api</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
@@ -73,7 +73,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-core</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/examples/dynamic-proxy-to-access-mbean/pom.xml
+++ b/examples/dynamic-proxy-to-access-mbean/pom.xml
@@ -65,7 +65,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-api</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -82,7 +82,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-core</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/examples/dynamic-proxy-to-access-mbean/pom.xml
+++ b/examples/dynamic-proxy-to-access-mbean/pom.xml
@@ -21,7 +21,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>dynamic-proxy-to-access-mbean</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: Dynamic MBean Proxy</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/examples/ear-testing/business-logic/pom.xml
+++ b/examples/ear-testing/business-logic/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.superbiz</groupId>
     <artifactId>myear</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.3</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>business-logic</artifactId>

--- a/examples/ear-testing/business-logic/pom.xml
+++ b/examples/ear-testing/business-logic/pom.xml
@@ -78,7 +78,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-core</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/examples/ear-testing/business-model/pom.xml
+++ b/examples/ear-testing/business-model/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.superbiz</groupId>
     <artifactId>myear</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.3</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>business-model</artifactId>

--- a/examples/ear-testing/pom.xml
+++ b/examples/ear-testing/pom.xml
@@ -25,7 +25,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.superbiz</groupId>
   <artifactId>myear</artifactId>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <packaging>pom</packaging>
   <name>OpenEJB :: Examples :: Ear Testing</name>
   <modules>

--- a/examples/ejb-examples/pom.xml
+++ b/examples/ejb-examples/pom.xml
@@ -25,7 +25,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>ejb-examples</artifactId>
   <packaging>war</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Web Examples :: EJB Examples War</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/examples/ejb-examples/pom.xml
+++ b/examples/ejb-examples/pom.xml
@@ -62,7 +62,7 @@
       <plugin>
         <groupId>org.apache.tomee.maven</groupId>
         <artifactId>tomee-maven-plugin</artifactId>
-        <version>7.0.4-SNAPSHOT</version>
+        <version>7.0.4</version>
         <configuration>
           <context>/ejb-examples</context>
           <tomeeClassifier>plus</tomeeClassifier>

--- a/examples/ejb-webservice/pom.xml
+++ b/examples/ejb-webservice/pom.xml
@@ -25,7 +25,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>ejb-webservice</artifactId>
   <packaging>war</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Web Examples :: EJB WebService</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/examples/groovy-cdi/pom.xml
+++ b/examples/groovy-cdi/pom.xml
@@ -24,7 +24,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>groovy-cdi</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: Groovy CDI</name>
 
   <properties>

--- a/examples/groovy-cdi/pom.xml
+++ b/examples/groovy-cdi/pom.xml
@@ -99,13 +99,13 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>arquillian-openejb-embedded</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>ziplock</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/examples/groovy-jpa/pom.xml
+++ b/examples/groovy-jpa/pom.xml
@@ -100,13 +100,13 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>arquillian-openejb-embedded</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>ziplock</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/examples/groovy-jpa/pom.xml
+++ b/examples/groovy-jpa/pom.xml
@@ -24,7 +24,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>groovy-jpa</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: Groovy JPA</name>
 
   <properties>

--- a/examples/groovy-spock/pom.xml
+++ b/examples/groovy-spock/pom.xml
@@ -24,7 +24,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>groovy-spock</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: Groovy Spock</name>
 
   <properties>

--- a/examples/groovy-spock/pom.xml
+++ b/examples/groovy-spock/pom.xml
@@ -109,7 +109,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>arquillian-openejb-embedded</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -121,7 +121,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>ziplock</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/examples/helloworld-weblogic/pom.xml
+++ b/examples/helloworld-weblogic/pom.xml
@@ -25,7 +25,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>helloworld-weblogic</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: Hello World - Weblogic</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/examples/helloworld-weblogic/pom.xml
+++ b/examples/helloworld-weblogic/pom.xml
@@ -72,7 +72,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-core</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/examples/injection-of-connectionfactory/pom.xml
+++ b/examples/injection-of-connectionfactory/pom.xml
@@ -72,7 +72,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-core</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
 

--- a/examples/injection-of-connectionfactory/pom.xml
+++ b/examples/injection-of-connectionfactory/pom.xml
@@ -25,7 +25,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>injection-of-connectionfactory</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: @Resource javax.jms.ConnectionFactory</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/examples/injection-of-datasource/pom.xml
+++ b/examples/injection-of-datasource/pom.xml
@@ -72,7 +72,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-core</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
 

--- a/examples/injection-of-datasource/pom.xml
+++ b/examples/injection-of-datasource/pom.xml
@@ -25,7 +25,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>injection-of-datasource</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: @Resource DataSource Injection</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/examples/injection-of-ejbs/pom.xml
+++ b/examples/injection-of-ejbs/pom.xml
@@ -71,7 +71,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-core</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/examples/injection-of-ejbs/pom.xml
+++ b/examples/injection-of-ejbs/pom.xml
@@ -25,7 +25,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>injection-of-ejbs</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: @EJB Injection</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/examples/injection-of-entitymanager/pom.xml
+++ b/examples/injection-of-entitymanager/pom.xml
@@ -71,7 +71,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-core</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/examples/injection-of-entitymanager/pom.xml
+++ b/examples/injection-of-entitymanager/pom.xml
@@ -25,7 +25,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>injection-of-entitymanager</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: @PersistenceContext EntityManager Injection</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/examples/injection-of-env-entry/pom.xml
+++ b/examples/injection-of-env-entry/pom.xml
@@ -71,7 +71,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-core</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/examples/injection-of-env-entry/pom.xml
+++ b/examples/injection-of-env-entry/pom.xml
@@ -25,7 +25,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>injection-of-env-entry</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: @Resource env-entry Injection</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/examples/interceptors/pom.xml
+++ b/examples/interceptors/pom.xml
@@ -25,7 +25,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>interceptors</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: Interceptors</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/examples/interceptors/pom.xml
+++ b/examples/interceptors/pom.xml
@@ -71,7 +71,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-core</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/examples/javamail/pom.xml
+++ b/examples/javamail/pom.xml
@@ -82,7 +82,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-cxf-rs</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/examples/javamail/pom.xml
+++ b/examples/javamail/pom.xml
@@ -22,7 +22,7 @@
 
   <groupId>org.superbiz</groupId>
   <artifactId>javamail-api</artifactId>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: JavaMail API</name>
 
   <properties>

--- a/examples/jpa-eclipselink/pom.xml
+++ b/examples/jpa-eclipselink/pom.xml
@@ -74,7 +74,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-core</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
     <!-- toplink dependencies -->

--- a/examples/jpa-eclipselink/pom.xml
+++ b/examples/jpa-eclipselink/pom.xml
@@ -25,7 +25,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>jpa-eclipselink</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: JPA with EclipseLink</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/examples/jpa-enumerated/pom.xml
+++ b/examples/jpa-enumerated/pom.xml
@@ -25,7 +25,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>jpa-enumerated</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: JPA @Enumerated</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/examples/jpa-enumerated/pom.xml
+++ b/examples/jpa-enumerated/pom.xml
@@ -71,7 +71,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-core</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/examples/jpa-hibernate/pom.xml
+++ b/examples/jpa-hibernate/pom.xml
@@ -25,7 +25,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>jpa-hibernate</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: JPA with Hibernate</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/examples/jpa-hibernate/pom.xml
+++ b/examples/jpa-hibernate/pom.xml
@@ -82,7 +82,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-core-hibernate</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <type>pom</type>
       <scope>test</scope>
     </dependency>

--- a/examples/jsf-cdi-and-ejb/pom.xml
+++ b/examples/jsf-cdi-and-ejb/pom.xml
@@ -24,7 +24,7 @@
   <artifactId>jsf-cdi-and-ejb</artifactId>
   <packaging>war</packaging>
   <name>OpenEJB :: Web Examples :: JSF - CDI and EJB</name>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <url>http://tomee.apache.org</url>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/examples/jsf-managedBean-and-ejb/pom.xml
+++ b/examples/jsf-managedBean-and-ejb/pom.xml
@@ -26,7 +26,7 @@
   <artifactId>jsf-managedBean-and-ejb</artifactId>
   <packaging>war</packaging>
   <name>OpenEJB :: Web Examples :: JSF - ManangedBean and EJB</name>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <url>http://tomee.apache.org</url>
 
   <properties>

--- a/examples/jsf-managedBean-and-ejb/pom.xml
+++ b/examples/jsf-managedBean-and-ejb/pom.xml
@@ -54,7 +54,7 @@
       <plugin>
         <groupId>org.apache.tomee.maven</groupId>
         <artifactId>tomee-maven-plugin</artifactId>
-        <version>7.0.4-SNAPSHOT</version>
+        <version>7.0.4</version>
       </plugin>
     </plugins>
   </build>

--- a/examples/lookup-of-ejbs-with-descriptor/pom.xml
+++ b/examples/lookup-of-ejbs-with-descriptor/pom.xml
@@ -25,7 +25,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>lookup-of-ejbs-with-descriptor</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: EJB Lookup with descriptor</name>
   <properties>
     <!--

--- a/examples/lookup-of-ejbs-with-descriptor/pom.xml
+++ b/examples/lookup-of-ejbs-with-descriptor/pom.xml
@@ -75,7 +75,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-core</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/examples/lookup-of-ejbs/pom.xml
+++ b/examples/lookup-of-ejbs/pom.xml
@@ -75,7 +75,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-core</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/examples/lookup-of-ejbs/pom.xml
+++ b/examples/lookup-of-ejbs/pom.xml
@@ -25,7 +25,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>lookup-of-ejbs</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: @EJB Lookup</name>
   <properties>
     <!--

--- a/examples/mbean-auto-registration/pom.xml
+++ b/examples/mbean-auto-registration/pom.xml
@@ -28,7 +28,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <tomee.version>7.0.4-SNAPSHOT</tomee.version>
+    <tomee.version>7.0.4</tomee.version>
   </properties>
 
   <build>

--- a/examples/mbean-auto-registration/pom.xml
+++ b/examples/mbean-auto-registration/pom.xml
@@ -23,7 +23,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>mbean-auto-registration</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: MBean Auto Registration</name>
 
   <properties>

--- a/examples/moviefun-rest/pom.xml
+++ b/examples/moviefun-rest/pom.xml
@@ -19,7 +19,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>moviefun-rest</artifactId>
   <packaging>war</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Web Examples :: Moviefun Rest</name>
   
   <properties>
@@ -97,7 +97,7 @@
                 <artifactItem>
                   <groupId>taglibs</groupId>
                   <artifactId>standard</artifactId>
-                  <version>1.1.2</version>
+                  <version>1.2.3</version>
                 </artifactItem>
               </artifactItems>
               <outputDirectory>
@@ -196,7 +196,7 @@
     <dependency>
       <groupId>taglibs</groupId>
       <artifactId>standard</artifactId>
-      <version>1.1.2</version>
+      <version>1.2.3</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/examples/moviefun-rest/pom.xml
+++ b/examples/moviefun-rest/pom.xml
@@ -24,7 +24,7 @@
   
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <tomee.version>7.0.4-SNAPSHOT</tomee.version>
+    <tomee.version>7.0.4</tomee.version>
     <version.shrinkwrap.resolver>2.0.0</version.shrinkwrap.resolver>
   </properties>
   

--- a/examples/moviefun/pom.xml
+++ b/examples/moviefun/pom.xml
@@ -18,7 +18,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>moviefun</artifactId>
   <packaging>war</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Web Examples :: Moviefun</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -54,7 +54,7 @@
                 <artifactItem>
                   <groupId>taglibs</groupId>
                   <artifactId>standard</artifactId>
-                  <version>1.1.2</version>
+                  <version>1.2.3</version>
                 </artifactItem>
               </artifactItems>
               <outputDirectory>
@@ -161,7 +161,7 @@
     <dependency>
       <groupId>taglibs</groupId>
       <artifactId>standard</artifactId>
-      <version>1.1.2</version>
+      <version>1.2.3</version>
     </dependency>
     <dependency>
       <groupId>net.sourceforge.htmlunit</groupId>

--- a/examples/moviefun/pom.xml
+++ b/examples/moviefun/pom.xml
@@ -22,7 +22,7 @@
   <name>OpenEJB :: Web Examples :: Moviefun</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <tomee.version>7.0.4-SNAPSHOT</tomee.version>
+    <tomee.version>7.0.4</tomee.version>
     <version.shrinkwrap.resolver>2.0.0</version.shrinkwrap.resolver>
   </properties>
   <repositories>
@@ -105,7 +105,7 @@
       <plugin>
         <groupId>org.apache.tomee.maven</groupId>
         <artifactId>tomee-maven-plugin</artifactId>
-        <version>7.0.4-SNAPSHOT</version>
+        <version>7.0.4</version>
         <configuration>
           <tomeeClassifier>plus</tomeeClassifier>
           <args>-Xmx512m -XX:PermSize=256m</args>
@@ -155,7 +155,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-core</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -173,7 +173,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>tomee-embedded</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <!--<classifier>uber</classifier> -->
       <scope>test</scope>
     </dependency>
@@ -197,7 +197,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>ziplock</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/examples/movies-complete-meta/pom.xml
+++ b/examples/movies-complete-meta/pom.xml
@@ -72,7 +72,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-core</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
 

--- a/examples/movies-complete-meta/pom.xml
+++ b/examples/movies-complete-meta/pom.xml
@@ -25,7 +25,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>movies-complete-meta</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: Movies Complete (Meta)</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/examples/movies-complete/pom.xml
+++ b/examples/movies-complete/pom.xml
@@ -72,7 +72,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-core</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
 

--- a/examples/movies-complete/pom.xml
+++ b/examples/movies-complete/pom.xml
@@ -25,7 +25,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>movies-complete</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: Movies Complete</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/examples/mtom/pom.xml
+++ b/examples/mtom/pom.xml
@@ -23,7 +23,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.superbiz</groupId>
   <artifactId>mtom</artifactId>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: MTOM</name>
 
   <properties>

--- a/examples/mtom/pom.xml
+++ b/examples/mtom/pom.xml
@@ -28,7 +28,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <tomee.version>7.0.4-SNAPSHOT</tomee.version>
+    <tomee.version>7.0.4</tomee.version>
   </properties>
 
   <repositories>

--- a/examples/multi-jpa-provider-testing/pom.xml
+++ b/examples/multi-jpa-provider-testing/pom.xml
@@ -25,7 +25,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>multi-jpa-provider-testing</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: Multiple JPA providers</name>
 
   <properties>
@@ -124,7 +124,7 @@
     <dependency>
       <groupId>org.jboss.shrinkwrap</groupId>
       <artifactId>shrinkwrap-spi</artifactId>
-      <version>1.1.3</version>
+      <version>1.2.3</version>
       <scope>test</scope>
     </dependency>
 

--- a/examples/multi-jpa-provider-testing/pom.xml
+++ b/examples/multi-jpa-provider-testing/pom.xml
@@ -30,7 +30,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <tomee.version>7.0.4-SNAPSHOT</tomee.version>
+    <tomee.version>7.0.4</tomee.version>
   </properties>
 
   <build>

--- a/examples/multiple-arquillian-adapters/pom.xml
+++ b/examples/multiple-arquillian-adapters/pom.xml
@@ -25,7 +25,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>multiple-arquillian-adapters</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: Multiple Arquillian Adapters</name>
 
   <properties>

--- a/examples/multiple-arquillian-adapters/pom.xml
+++ b/examples/multiple-arquillian-adapters/pom.xml
@@ -30,7 +30,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <tomee.version>7.0.4-SNAPSHOT</tomee.version>
+    <tomee.version>7.0.4</tomee.version>
     <arquillian.version>1.1.10.Final</arquillian.version>
   </properties>
 

--- a/examples/multiple-tomee-arquillian/pom.xml
+++ b/examples/multiple-tomee-arquillian/pom.xml
@@ -23,7 +23,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>multiple-tomee-arquillian</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: Multiple TomEE with Arquillian</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/examples/multiple-tomee-arquillian/pom.xml
+++ b/examples/multiple-tomee-arquillian/pom.xml
@@ -27,7 +27,7 @@
   <name>OpenEJB :: Examples :: Multiple TomEE with Arquillian</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <tomee.version>7.0.4-SNAPSHOT</tomee.version>
+    <tomee.version>7.0.4</tomee.version>
   </properties>
   <build>
     <defaultGoal>install</defaultGoal>
@@ -86,7 +86,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-core</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -104,7 +104,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>ziplock</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/examples/myfaces-codi-demo/pom.xml
+++ b/examples/myfaces-codi-demo/pom.xml
@@ -46,7 +46,7 @@
       <plugin>
         <groupId>org.apache.tomee.maven</groupId>
         <artifactId>tomee-maven-plugin</artifactId>
-        <version>7.0.4-SNAPSHOT</version>
+        <version>7.0.4</version>
       </plugin>
     </plugins>
   </build>

--- a/examples/myfaces-codi-demo/pom.xml
+++ b/examples/myfaces-codi-demo/pom.xml
@@ -15,7 +15,7 @@
   <artifactId>myfaces-codi-demo</artifactId>
 
   <name>OpenEJB :: Examples :: JSF2/CDI/BV/JPA/CODI</name>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
 
   <packaging>war</packaging>
 

--- a/examples/persistence-fragment/pom.xml
+++ b/examples/persistence-fragment/pom.xml
@@ -25,7 +25,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>persistence-fragment</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: Persistence Fragment</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/examples/persistence-fragment/pom.xml
+++ b/examples/persistence-fragment/pom.xml
@@ -71,7 +71,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-core</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/examples/pojo-webservice/pom.xml
+++ b/examples/pojo-webservice/pom.xml
@@ -26,7 +26,7 @@
   <name>OpenEJB :: Web Examples :: Pojo WS</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <tomee.version>7.0.4-SNAPSHOT</tomee.version>
+    <tomee.version>7.0.4</tomee.version>
   </properties>
   <repositories>
     <repository>
@@ -68,7 +68,7 @@
       <plugin> <!-- http://localhost:8080/pojo-webservice?wsdl -->
         <groupId>org.apache.tomee.maven</groupId>
         <artifactId>tomee-maven-plugin</artifactId>
-        <version>7.0.4-SNAPSHOT</version>
+        <version>7.0.4</version>
         <configuration>
           <tomeeVersion>${tomee.version}</tomeeVersion>
           <tomeeClassifier>plus</tomeeClassifier>

--- a/examples/pojo-webservice/pom.xml
+++ b/examples/pojo-webservice/pom.xml
@@ -22,7 +22,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>pojo-webservice</artifactId>
   <packaging>war</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Web Examples :: Pojo WS</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/examples/polling-parent/polling-client/pom.xml
+++ b/examples/polling-parent/polling-client/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>polling-parent</artifactId>
     <groupId>jug</groupId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.3</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/examples/polling-parent/polling-core/pom.xml
+++ b/examples/polling-parent/polling-core/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>polling-parent</artifactId>
     <groupId>jug</groupId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.3</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/examples/polling-parent/polling-domain/pom.xml
+++ b/examples/polling-parent/polling-domain/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>polling-parent</artifactId>
     <groupId>jug</groupId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.3</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/examples/polling-parent/polling-web/pom.xml
+++ b/examples/polling-parent/polling-web/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>polling-parent</artifactId>
     <groupId>jug</groupId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.3</version>
   </parent>
 
   <artifactId>polling-web</artifactId>

--- a/examples/polling-parent/pom.xml
+++ b/examples/polling-parent/pom.xml
@@ -23,7 +23,7 @@
 
   <groupId>jug</groupId>
   <artifactId>polling-parent</artifactId>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <packaging>pom</packaging>
   <name>OpenEJB :: Examples :: Polling</name>
   

--- a/examples/polling-parent/pom.xml
+++ b/examples/polling-parent/pom.xml
@@ -30,7 +30,7 @@
   <properties>
     <xbean.version>4.4</xbean.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <tomee.version>7.0.4-SNAPSHOT</tomee.version>
+    <tomee.version>7.0.4</tomee.version>
   </properties>
 
   <build>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <artifactId>tomee-project</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
 
   <artifactId>examples</artifactId>

--- a/examples/projectstage-demo/pom.xml
+++ b/examples/projectstage-demo/pom.xml
@@ -23,7 +23,7 @@
 
   <groupId>org.superbiz</groupId>
   <artifactId>projectstage-demo</artifactId>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: DeltaSpike ProjectStage</name>
 
   <properties>

--- a/examples/projectstage-demo/pom.xml
+++ b/examples/projectstage-demo/pom.xml
@@ -27,7 +27,7 @@
   <name>OpenEJB :: Examples :: DeltaSpike ProjectStage</name>
 
   <properties>
-    <tomee.version>7.0.4-SNAPSHOT</tomee.version>
+    <tomee.version>7.0.4</tomee.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 

--- a/examples/quartz-app/pom.xml
+++ b/examples/quartz-app/pom.xml
@@ -28,7 +28,7 @@
   
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <tomee.version>7.0.4-SNAPSHOT</tomee.version>
+    <tomee.version>7.0.4</tomee.version>
   </properties>
   
   <modules>

--- a/examples/quartz-app/pom.xml
+++ b/examples/quartz-app/pom.xml
@@ -22,7 +22,7 @@
   
   <groupId>org.superbiz.quartz</groupId>
   <artifactId>quartz-app</artifactId>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <packaging>pom</packaging>
   <name>OpenEJB :: Examples :: Quartz</name>
   

--- a/examples/quartz-app/quartz-beans/pom.xml
+++ b/examples/quartz-app/quartz-beans/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.superbiz.quartz</groupId>
     <artifactId>quartz-app</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.3</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>quartz-beans</artifactId>

--- a/examples/quartz-app/quartz-ra/pom.xml
+++ b/examples/quartz-app/quartz-ra/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.superbiz.quartz</groupId>
     <artifactId>quartz-app</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.3</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>quartz-ra</artifactId>

--- a/examples/realm-in-tomee/pom.xml
+++ b/examples/realm-in-tomee/pom.xml
@@ -47,7 +47,7 @@
       <plugin>
         <groupId>org.apache.tomee.maven</groupId>
         <artifactId>tomee-maven-plugin</artifactId>
-        <version>7.0.4-SNAPSHOT</version>
+        <version>7.0.4</version>
       </plugin>
     </plugins>
   </build>

--- a/examples/realm-in-tomee/pom.xml
+++ b/examples/realm-in-tomee/pom.xml
@@ -22,7 +22,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>realm-in-tomee</artifactId>
   <packaging>war</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: DataSource Realm</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/examples/reload-persistence-unit-properties/pom.xml
+++ b/examples/reload-persistence-unit-properties/pom.xml
@@ -25,7 +25,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>reload-persistence-unit-properties</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: Reloadable Persistence Unit Properties</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/examples/reload-persistence-unit-properties/pom.xml
+++ b/examples/reload-persistence-unit-properties/pom.xml
@@ -72,7 +72,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-core</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/examples/resources-declared-in-webapp/pom.xml
+++ b/examples/resources-declared-in-webapp/pom.xml
@@ -24,7 +24,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>resources-declared-in-webapp</artifactId>
   <packaging>war</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Web Examples :: Resource Declared In A Webapp</name>
 
   <properties>

--- a/examples/resources-declared-in-webapp/pom.xml
+++ b/examples/resources-declared-in-webapp/pom.xml
@@ -29,7 +29,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <tomee.version>7.0.4-SNAPSHOT</tomee.version>
+    <tomee.version>7.0.4</tomee.version>
   </properties>
 
   <repositories>

--- a/examples/resources-jmx-example/pom.xml
+++ b/examples/resources-jmx-example/pom.xml
@@ -30,7 +30,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <tomee.version>7.0.4-SNAPSHOT</tomee.version>
+    <tomee.version>7.0.4</tomee.version>
   </properties>
   
   <modules>

--- a/examples/resources-jmx-example/pom.xml
+++ b/examples/resources-jmx-example/pom.xml
@@ -25,7 +25,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>resources-jmx</artifactId>
   <packaging>pom</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: Resources/JMX Example</name>
 
   <properties>

--- a/examples/resources-jmx-example/resources-jmx-ear/pom.xml
+++ b/examples/resources-jmx-example/resources-jmx-ear/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.superbiz</groupId>
     <artifactId>resources-jmx</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.3</version>
   </parent>
   <artifactId>resources-jmx-ear</artifactId>
   <packaging>ear</packaging>

--- a/examples/resources-jmx-example/resources-jmx-ejb/pom.xml
+++ b/examples/resources-jmx-example/resources-jmx-ejb/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.superbiz</groupId>
     <artifactId>resources-jmx</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.3</version>
   </parent>
   
   <artifactId>resources-jmx-ejb</artifactId>

--- a/examples/rest-applicationcomposer-mockito/pom.xml
+++ b/examples/rest-applicationcomposer-mockito/pom.xml
@@ -23,7 +23,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>rest-applicationcomposer-mockito</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: REST, Mockito and Application Composer</name>
 
   <properties>

--- a/examples/rest-applicationcomposer-mockito/pom.xml
+++ b/examples/rest-applicationcomposer-mockito/pom.xml
@@ -76,19 +76,19 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-core</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-cxf-rs</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-mockito</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/examples/rest-applicationcomposer/pom.xml
+++ b/examples/rest-applicationcomposer/pom.xml
@@ -23,7 +23,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>rest-applicationcomposer</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: REST and Application Composer</name>
 
   <properties>

--- a/examples/rest-applicationcomposer/pom.xml
+++ b/examples/rest-applicationcomposer/pom.xml
@@ -76,13 +76,13 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-core</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-cxf-rs</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/examples/rest-cdi/pom.xml
+++ b/examples/rest-cdi/pom.xml
@@ -75,7 +75,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-cxf-rs</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/examples/rest-cdi/pom.xml
+++ b/examples/rest-cdi/pom.xml
@@ -22,7 +22,7 @@
 
   <groupId>org.superbiz</groupId>
   <artifactId>rest-cdi</artifactId>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: REST XML JSON</name>
 
   <properties>

--- a/examples/rest-example-with-application/pom.xml
+++ b/examples/rest-example-with-application/pom.xml
@@ -29,7 +29,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <tomee.version>7.0.4-SNAPSHOT</tomee.version>
+    <tomee.version>7.0.4</tomee.version>
   </properties>
 
   <repositories>

--- a/examples/rest-example-with-application/pom.xml
+++ b/examples/rest-example-with-application/pom.xml
@@ -24,7 +24,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>rest-example-with-application</artifactId>
   <packaging>war</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Web Examples :: REST Example With Application</name>
 
   <properties>

--- a/examples/rest-example/pom.xml
+++ b/examples/rest-example/pom.xml
@@ -29,7 +29,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <tomee.version>7.0.4-SNAPSHOT</tomee.version>
+    <tomee.version>7.0.4</tomee.version>
     <version.openjpa>2.4.0</version.openjpa>
   </properties>
 

--- a/examples/rest-example/pom.xml
+++ b/examples/rest-example/pom.xml
@@ -24,7 +24,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>rest-example</artifactId>
   <packaging>war</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Web Examples :: REST Example</name>
 
   <properties>

--- a/examples/rest-jaas/pom.xml
+++ b/examples/rest-jaas/pom.xml
@@ -23,7 +23,7 @@
 
   <groupId>org.superbiz</groupId>
   <artifactId>rest-jaas</artifactId>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <packaging>war</packaging>
   <name>OpenEJB :: Examples :: JAXRS and JAAS</name>
 

--- a/examples/rest-jaas/pom.xml
+++ b/examples/rest-jaas/pom.xml
@@ -51,7 +51,7 @@
       <plugin>
         <groupId>org.apache.tomee.maven</groupId>
         <artifactId>tomee-maven-plugin</artifactId>
-        <version>7.0.4-SNAPSHOT</version>
+        <version>7.0.4</version>
         <configuration>
           <systemVariables>
             <java.security.auth.login.config>${project.build.directory}/apache-tomee/conf/login.config</java.security.auth.login.config>

--- a/examples/rest-on-ejb/pom.xml
+++ b/examples/rest-on-ejb/pom.xml
@@ -27,7 +27,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>rest-on-ejb</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: REST and EJB</name>
 
   <properties>

--- a/examples/rest-on-ejb/pom.xml
+++ b/examples/rest-on-ejb/pom.xml
@@ -32,7 +32,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <tomee.version>7.0.4-SNAPSHOT</tomee.version>
+    <tomee.version>7.0.4</tomee.version>
   </properties>
 
   <build>

--- a/examples/rest-xml-json/pom.xml
+++ b/examples/rest-xml-json/pom.xml
@@ -75,7 +75,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-cxf-rs</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/examples/rest-xml-json/pom.xml
+++ b/examples/rest-xml-json/pom.xml
@@ -22,7 +22,7 @@
 
   <groupId>org.superbiz</groupId>
   <artifactId>rest-xml-json</artifactId>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: REST XML JSON</name>
 
   <properties>

--- a/examples/scala-basic/pom.xml
+++ b/examples/scala-basic/pom.xml
@@ -146,7 +146,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-core</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/examples/scala-basic/pom.xml
+++ b/examples/scala-basic/pom.xml
@@ -24,7 +24,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>scala-basic</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: Basic Scala</name>
 
   <properties>

--- a/examples/schedule-events/pom.xml
+++ b/examples/schedule-events/pom.xml
@@ -71,7 +71,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-core</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/examples/schedule-events/pom.xml
+++ b/examples/schedule-events/pom.xml
@@ -25,7 +25,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>schedule-events</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: @Schedule Events</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/examples/schedule-expression/pom.xml
+++ b/examples/schedule-expression/pom.xml
@@ -25,7 +25,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>schedule-expression</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: ScheduleExpression</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/examples/schedule-expression/pom.xml
+++ b/examples/schedule-expression/pom.xml
@@ -71,7 +71,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-core</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/examples/schedule-methods-meta/pom.xml
+++ b/examples/schedule-methods-meta/pom.xml
@@ -25,7 +25,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>schedule-methods-meta</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: @Schedule Methods (Meta)</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/examples/schedule-methods-meta/pom.xml
+++ b/examples/schedule-methods-meta/pom.xml
@@ -71,7 +71,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-core</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/examples/schedule-methods/pom.xml
+++ b/examples/schedule-methods/pom.xml
@@ -71,7 +71,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-core</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/examples/schedule-methods/pom.xml
+++ b/examples/schedule-methods/pom.xml
@@ -25,7 +25,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>schedule-methods</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: @Schedule Methods</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/examples/server-events/pom.xml
+++ b/examples/server-events/pom.xml
@@ -69,7 +69,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-core</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>provided</scope>
     </dependency>
 
@@ -83,7 +83,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>arquillian-openejb-embedded</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/examples/server-events/pom.xml
+++ b/examples/server-events/pom.xml
@@ -26,7 +26,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>server-events</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: Server Events</name>
 
   <properties>

--- a/examples/simple-cdi-interceptor/pom.xml
+++ b/examples/simple-cdi-interceptor/pom.xml
@@ -65,7 +65,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-core</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/examples/simple-cdi-interceptor/pom.xml
+++ b/examples/simple-cdi-interceptor/pom.xml
@@ -19,7 +19,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>simple-cdi-interceptor</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: Simple CDI Interceptor</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/examples/simple-cmp2/pom.xml
+++ b/examples/simple-cmp2/pom.xml
@@ -27,7 +27,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>simple-cmp2</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: Simple CMP2 Entity</name>
 
   <properties>

--- a/examples/simple-cmp2/pom.xml
+++ b/examples/simple-cmp2/pom.xml
@@ -32,7 +32,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <tomee.version>7.0.4-SNAPSHOT</tomee.version>
+    <tomee.version>7.0.4</tomee.version>
   </properties>
 
   <build>

--- a/examples/simple-mdb-and-cdi/pom.xml
+++ b/examples/simple-mdb-and-cdi/pom.xml
@@ -71,7 +71,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-core</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/examples/simple-mdb-and-cdi/pom.xml
+++ b/examples/simple-mdb-and-cdi/pom.xml
@@ -25,7 +25,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>simple-mdb-and-cdi</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: Simple MDB With a CDI Injection</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/examples/simple-mdb-with-descriptor/pom.xml
+++ b/examples/simple-mdb-with-descriptor/pom.xml
@@ -72,7 +72,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-core</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
 

--- a/examples/simple-mdb-with-descriptor/pom.xml
+++ b/examples/simple-mdb-with-descriptor/pom.xml
@@ -25,7 +25,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>simple-mdb-with-descriptor</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: Simple MDB Using Deployment Descriptor Example</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/examples/simple-mdb/pom.xml
+++ b/examples/simple-mdb/pom.xml
@@ -71,7 +71,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-core</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/examples/simple-mdb/pom.xml
+++ b/examples/simple-mdb/pom.xml
@@ -25,7 +25,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>simple-mdb</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: Simple MDB Example</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/examples/simple-remote-tomcatusers/pom.xml
+++ b/examples/simple-remote-tomcatusers/pom.xml
@@ -26,7 +26,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>simple-remote-tomcatusers</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: Simple Remote tomcat-users.xml</name>
 
   <properties>

--- a/examples/simple-remote-tomcatusers/pom.xml
+++ b/examples/simple-remote-tomcatusers/pom.xml
@@ -79,7 +79,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>arquillian-tomee-remote</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/examples/simple-rest/pom.xml
+++ b/examples/simple-rest/pom.xml
@@ -75,7 +75,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-cxf-rs</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/examples/simple-rest/pom.xml
+++ b/examples/simple-rest/pom.xml
@@ -22,7 +22,7 @@
 
   <groupId>org.superbiz</groupId>
   <artifactId>simple-rest</artifactId>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: Simple REST</name>
 
   <properties>

--- a/examples/simple-singleton/pom.xml
+++ b/examples/simple-singleton/pom.xml
@@ -25,7 +25,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>simple-singleton</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: Simple Singleton</name>
 
   <properties>

--- a/examples/simple-singleton/pom.xml
+++ b/examples/simple-singleton/pom.xml
@@ -74,7 +74,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-core</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/examples/simple-stateful-callbacks/pom.xml
+++ b/examples/simple-stateful-callbacks/pom.xml
@@ -25,7 +25,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>simple-stateful-callbacks</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: Simple Stateful Pojo Callbacks</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/examples/simple-stateful-callbacks/pom.xml
+++ b/examples/simple-stateful-callbacks/pom.xml
@@ -71,7 +71,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-core</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/examples/simple-stateful/pom.xml
+++ b/examples/simple-stateful/pom.xml
@@ -25,7 +25,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>simple-stateful</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: Simple Stateful Pojo</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/examples/simple-stateful/pom.xml
+++ b/examples/simple-stateful/pom.xml
@@ -71,7 +71,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-core</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/examples/simple-stateless-callbacks/pom.xml
+++ b/examples/simple-stateless-callbacks/pom.xml
@@ -25,7 +25,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>simple-stateless-callbacks</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: Simple Stateless Pojo Callbacks</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/examples/simple-stateless-callbacks/pom.xml
+++ b/examples/simple-stateless-callbacks/pom.xml
@@ -72,7 +72,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-core</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/examples/simple-stateless-with-descriptor/pom.xml
+++ b/examples/simple-stateless-with-descriptor/pom.xml
@@ -72,13 +72,13 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-core</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-jee-accessors</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/examples/simple-stateless-with-descriptor/pom.xml
+++ b/examples/simple-stateless-with-descriptor/pom.xml
@@ -25,7 +25,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>simple-stateless-with-descriptor</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: Simple Stateless With Deployment Descriptor</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/examples/simple-stateless/pom.xml
+++ b/examples/simple-stateless/pom.xml
@@ -25,7 +25,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>simple-stateless</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: Simple Stateless Pojo</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/examples/simple-stateless/pom.xml
+++ b/examples/simple-stateless/pom.xml
@@ -72,7 +72,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-core</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/examples/simple-webservice-without-interface/pom.xml
+++ b/examples/simple-webservice-without-interface/pom.xml
@@ -70,7 +70,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-cxf</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
     <!-- This is required on IBM JDKs (and potentially others) because saaj-impl depends

--- a/examples/simple-webservice-without-interface/pom.xml
+++ b/examples/simple-webservice-without-interface/pom.xml
@@ -25,7 +25,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>simple-webservice-without-interface</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: Simple Webservice Without Interface</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/examples/simple-webservice/pom.xml
+++ b/examples/simple-webservice/pom.xml
@@ -70,7 +70,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-cxf</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
     <!-- This is required on IBM JDKs (and potentially others) because saaj-impl depends

--- a/examples/simple-webservice/pom.xml
+++ b/examples/simple-webservice/pom.xml
@@ -25,7 +25,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>simple-webservice</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: Simple Webservice</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/examples/spring-data-proxy-meta/pom.xml
+++ b/examples/spring-data-proxy-meta/pom.xml
@@ -70,7 +70,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-core</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
     </dependency>
   </dependencies>
 

--- a/examples/spring-data-proxy-meta/pom.xml
+++ b/examples/spring-data-proxy-meta/pom.xml
@@ -22,7 +22,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>spring-data-proxy-meta</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: Spring Data Meta</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/examples/spring-data-proxy/pom.xml
+++ b/examples/spring-data-proxy/pom.xml
@@ -70,7 +70,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-core</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
     </dependency>
   </dependencies>
 

--- a/examples/spring-data-proxy/pom.xml
+++ b/examples/spring-data-proxy/pom.xml
@@ -22,7 +22,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>spring-data-proxy</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: Spring Data</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/examples/struts/pom.xml
+++ b/examples/struts/pom.xml
@@ -21,7 +21,7 @@
   <groupId>org.superbiz.struts</groupId>
   <artifactId>struts</artifactId>
   <packaging>war</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Web Examples :: Struts</name>
   <url>http://tomee.apache.org</url>
 
@@ -116,7 +116,7 @@
     <dependency>
       <groupId>taglibs</groupId>
       <artifactId>standard</artifactId>
-      <version>1.1.2</version>
+      <version>1.2.3</version>
     </dependency>
   </dependencies>
   <!--

--- a/examples/telephone-stateful/pom.xml
+++ b/examples/telephone-stateful/pom.xml
@@ -84,7 +84,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-ejbd</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
     <!-- END SNIPPET: openejbdep -->

--- a/examples/telephone-stateful/pom.xml
+++ b/examples/telephone-stateful/pom.xml
@@ -25,7 +25,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>telephone-stateful</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: Telephone Stateful Pojo</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/examples/testcase-injection/pom.xml
+++ b/examples/testcase-injection/pom.xml
@@ -72,7 +72,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-core</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
 

--- a/examples/testcase-injection/pom.xml
+++ b/examples/testcase-injection/pom.xml
@@ -25,7 +25,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>testcase-injection</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: TestCase Injection</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/examples/testing-security-2/pom.xml
+++ b/examples/testing-security-2/pom.xml
@@ -25,7 +25,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>testing-security-2</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: Testing Security</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/examples/testing-security-2/pom.xml
+++ b/examples/testing-security-2/pom.xml
@@ -77,7 +77,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-core</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
 

--- a/examples/testing-security-3/pom.xml
+++ b/examples/testing-security-3/pom.xml
@@ -77,7 +77,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-core</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>provided</scope>
     </dependency>
 

--- a/examples/testing-security-3/pom.xml
+++ b/examples/testing-security-3/pom.xml
@@ -25,7 +25,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>testing-security-3</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: Testing Security Service Provider</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/examples/testing-security-4/pom.xml
+++ b/examples/testing-security-4/pom.xml
@@ -25,7 +25,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>testing-security-4</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: Testing Security Script Service Provider</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/examples/testing-security-4/pom.xml
+++ b/examples/testing-security-4/pom.xml
@@ -77,7 +77,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-core</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>provided</scope>
     </dependency>
 

--- a/examples/testing-security-meta/pom.xml
+++ b/examples/testing-security-meta/pom.xml
@@ -76,7 +76,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-core</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/examples/testing-security-meta/pom.xml
+++ b/examples/testing-security-meta/pom.xml
@@ -25,7 +25,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>testing-security-meta</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: Testing Security (Meta)</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/examples/testing-security/pom.xml
+++ b/examples/testing-security/pom.xml
@@ -25,7 +25,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>testing-security</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: Testing Security</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/examples/testing-security/pom.xml
+++ b/examples/testing-security/pom.xml
@@ -76,7 +76,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-core</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/examples/testing-transactions-bmt/pom.xml
+++ b/examples/testing-transactions-bmt/pom.xml
@@ -72,7 +72,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-core</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
 

--- a/examples/testing-transactions-bmt/pom.xml
+++ b/examples/testing-transactions-bmt/pom.xml
@@ -25,7 +25,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>testing-transactions-bmt</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: Testing Transactions BMT</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/examples/testing-transactions/pom.xml
+++ b/examples/testing-transactions/pom.xml
@@ -72,7 +72,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-core</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
 

--- a/examples/testing-transactions/pom.xml
+++ b/examples/testing-transactions/pom.xml
@@ -25,7 +25,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>testing-transactions</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: Testing Transactions</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/examples/tomee-jersey-eclipselink/pom.xml
+++ b/examples/tomee-jersey-eclipselink/pom.xml
@@ -23,7 +23,7 @@
 
   <groupId>org.superbiz</groupId>
   <artifactId>tomee-jersey-eclipselink</artifactId>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <packaging>war</packaging>
   <name>OpenEJB :: Examples :: TomEE, Jersey, Eclipselink</name>
 

--- a/examples/tomee-jersey-eclipselink/pom.xml
+++ b/examples/tomee-jersey-eclipselink/pom.xml
@@ -97,7 +97,7 @@
       <plugin>
         <groupId>org.apache.tomee.maven</groupId>
         <artifactId>tomee-maven-plugin</artifactId>
-        <version>7.0.4-SNAPSHOT</version>
+        <version>7.0.4</version>
         <configuration>
           <systemVariables>
             <com.sun.jersey.server.impl.cdi.lookupExtensionInBeanManager>true</com.sun.jersey.server.impl.cdi.lookupExtensionInBeanManager>

--- a/examples/transaction-rollback/pom.xml
+++ b/examples/transaction-rollback/pom.xml
@@ -69,7 +69,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-core</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
 

--- a/examples/transaction-rollback/pom.xml
+++ b/examples/transaction-rollback/pom.xml
@@ -25,7 +25,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>transaction-rollback</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: Transaction Rollback</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/examples/troubleshooting/pom.xml
+++ b/examples/troubleshooting/pom.xml
@@ -68,7 +68,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-core</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/examples/troubleshooting/pom.xml
+++ b/examples/troubleshooting/pom.xml
@@ -25,7 +25,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>troubleshooting</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: Troubleshooting</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/examples/webservice-attachments/pom.xml
+++ b/examples/webservice-attachments/pom.xml
@@ -70,7 +70,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-cxf</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
     <!-- This is required on IBM JDKs (and potentially others) because saaj-impl depends

--- a/examples/webservice-attachments/pom.xml
+++ b/examples/webservice-attachments/pom.xml
@@ -25,7 +25,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>webservice-attachments</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: Webservice Attachments</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/examples/webservice-handlerchain/pom.xml
+++ b/examples/webservice-handlerchain/pom.xml
@@ -70,7 +70,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-cxf</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
     <!-- This is required on IBM JDKs (and potentially others) because saaj-impl depends

--- a/examples/webservice-handlerchain/pom.xml
+++ b/examples/webservice-handlerchain/pom.xml
@@ -25,7 +25,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>webservice-handlerchain</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: Web Service Handlers</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/examples/webservice-holder/pom.xml
+++ b/examples/webservice-holder/pom.xml
@@ -70,7 +70,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-cxf</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
     <!-- This is required on IBM JDKs (and potentially others) because saaj-impl depends

--- a/examples/webservice-holder/pom.xml
+++ b/examples/webservice-holder/pom.xml
@@ -25,7 +25,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>webservice-holder</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: @WebService Holder</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/examples/webservice-inheritance/pom.xml
+++ b/examples/webservice-inheritance/pom.xml
@@ -70,7 +70,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-cxf</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
     <!-- This is required on IBM JDKs (and potentially others) because saaj-impl depends

--- a/examples/webservice-inheritance/pom.xml
+++ b/examples/webservice-inheritance/pom.xml
@@ -25,7 +25,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>webservice-inheritance</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Examples :: Webservice Inheritance</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/examples/webservice-security/pom.xml
+++ b/examples/webservice-security/pom.xml
@@ -70,7 +70,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-cxf</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
     <!-- This is required on IBM JDKs (and potentially others) because saaj-impl depends

--- a/examples/webservice-security/pom.xml
+++ b/examples/webservice-security/pom.xml
@@ -25,7 +25,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>webservice-security</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Web Examples :: EJB WebService with Security</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/examples/webservice-ws-security/pom.xml
+++ b/examples/webservice-ws-security/pom.xml
@@ -25,7 +25,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>webservice-ws-security</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Web Examples :: EJB WebService with WS-Security</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/examples/webservice-ws-security/pom.xml
+++ b/examples/webservice-ws-security/pom.xml
@@ -57,7 +57,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-cxf</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/examples/webservice-ws-with-resources-config/pom.xml
+++ b/examples/webservice-ws-with-resources-config/pom.xml
@@ -22,7 +22,7 @@
   <groupId>org.superbiz</groupId>
   <artifactId>webservice-ws-with-resources-config</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.3</version>
   <name>OpenEJB :: Web Examples :: EJB WebService WS Security with resources.xml</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/examples/webservice-ws-with-resources-config/pom.xml
+++ b/examples/webservice-ws-with-resources-config/pom.xml
@@ -38,7 +38,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>openejb-cxf</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/gradle/gradle-tomee-embedded/pom.xml
+++ b/gradle/gradle-tomee-embedded/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>gradle</artifactId>
     <groupId>org.apache.tomee.gradle</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/gradle/pom.xml
+++ b/gradle/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>tomee-project</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/itests/failover-ejb/pom.xml
+++ b/itests/failover-ejb/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>itests</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
 
   <groupId>org.apache.openejb.itests</groupId>

--- a/itests/failover/pom.xml
+++ b/itests/failover/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>itests</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
 
   <groupId>org.apache.openejb.itests</groupId>

--- a/itests/legacy-client/pom.xml
+++ b/itests/legacy-client/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>itests</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/itests/legacy-server/pom.xml
+++ b/itests/legacy-server/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>itests</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
 
   <groupId>org.apache.openejb.itests</groupId>

--- a/itests/openejb-itests-app/pom.xml
+++ b/itests/openejb-itests-app/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <artifactId>itests</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
 
   <artifactId>openejb-itests-app</artifactId>

--- a/itests/openejb-itests-beans/pom.xml
+++ b/itests/openejb-itests-beans/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>itests</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
 
   <artifactId>openejb-itests-beans</artifactId>

--- a/itests/openejb-itests-client/pom.xml
+++ b/itests/openejb-itests-client/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <artifactId>itests</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
 
   <artifactId>openejb-itests-client</artifactId>

--- a/itests/openejb-itests-interceptor-beans/pom.xml
+++ b/itests/openejb-itests-interceptor-beans/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.apache.tomee</groupId>
     <artifactId>itests</artifactId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
 
   <artifactId>openejb-itests-interceptor-beans</artifactId>

--- a/itests/openejb-itests-servlets/pom.xml
+++ b/itests/openejb-itests-servlets/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>itests</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
 
   <artifactId>openejb-itests-servlets</artifactId>

--- a/itests/openejb-itests-web/pom.xml
+++ b/itests/openejb-itests-web/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <artifactId>itests</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
 
   <artifactId>openejb-itests-web</artifactId>

--- a/itests/pom.xml
+++ b/itests/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>tomee-project</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/maven/applicationcomposer-maven-plugin/pom.xml
+++ b/maven/applicationcomposer-maven-plugin/pom.xml
@@ -22,13 +22,13 @@
   <parent>
     <artifactId>maven</artifactId>
     <groupId>org.apache.tomee.maven</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>applicationcomposer-maven-plugin</artifactId>
   <packaging>maven-plugin</packaging>
-  <version>7.0.4-SNAPSHOT</version>
+  <version>7.0.4</version>
   <name>OpenEJB :: Maven Plugins :: ApplicationComposer Maven Plugin</name>
 
   <dependencies>

--- a/maven/jarstxt-maven-plugin/pom.xml
+++ b/maven/jarstxt-maven-plugin/pom.xml
@@ -21,12 +21,12 @@ Licensed to the Apache Software Foundation (ASF) under one or more
   <parent>
     <artifactId>maven</artifactId>
     <groupId>org.apache.tomee.maven</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>jarstxt-maven-plugin</artifactId>
-  <version>7.0.4-SNAPSHOT</version>
+  <version>7.0.4</version>
   <packaging>maven-plugin</packaging>
   <name>OpenEJB :: Maven Plugins :: jars.txt Maven Plugin</name>
 

--- a/maven/maven-util/pom.xml
+++ b/maven/maven-util/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>maven</artifactId>
     <groupId>org.apache.tomee.maven</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/maven/openejb-embedded-maven-plugin/pom.xml
+++ b/maven/openejb-embedded-maven-plugin/pom.xml
@@ -22,13 +22,13 @@
   <parent>
     <artifactId>maven</artifactId>
     <groupId>org.apache.tomee.maven</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>openejb-embedded-maven-plugin</artifactId>
   <packaging>maven-plugin</packaging>
-  <version>7.0.4-SNAPSHOT</version>
+  <version>7.0.4</version>
   <name>OpenEJB :: Maven Plugins :: OpenEJB Embedded Maven Plugin</name>
 
   <dependencies>

--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -23,11 +23,11 @@
   <parent>
     <artifactId>tomee-project</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
 
   <groupId>org.apache.tomee.maven</groupId>
-  <version>7.0.4-SNAPSHOT</version>
+  <version>7.0.4</version>
   <artifactId>maven</artifactId>
   <packaging>pom</packaging>
   <name>OpenEJB :: Maven Plugins</name>

--- a/maven/tomee-embedded-maven-plugin/pom.xml
+++ b/maven/tomee-embedded-maven-plugin/pom.xml
@@ -24,11 +24,11 @@
   <parent>
     <artifactId>maven</artifactId>
     <groupId>org.apache.tomee.maven</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
 
   <artifactId>tomee-embedded-maven-plugin</artifactId>
-  <version>7.0.4-SNAPSHOT</version>
+  <version>7.0.4</version>
   <packaging>maven-plugin</packaging>
   <name>OpenEJB :: Maven Plugins :: TomEE Embedded Maven Plugin</name>
 

--- a/maven/tomee-maven-plugin/pom.xml
+++ b/maven/tomee-maven-plugin/pom.xml
@@ -24,11 +24,11 @@
   <parent>
     <artifactId>maven</artifactId>
     <groupId>org.apache.tomee.maven</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
 
   <artifactId>tomee-maven-plugin</artifactId>
-  <version>7.0.4-SNAPSHOT</version>
+  <version>7.0.4</version>
   <packaging>maven-plugin</packaging>
   <name>OpenEJB :: Maven Plugins :: TomEE Maven Plugin</name>
 

--- a/maven/tomee-webapp-archetype/pom.xml
+++ b/maven/tomee-webapp-archetype/pom.xml
@@ -21,7 +21,7 @@ Licensed to the Apache Software Foundation (ASF) under one or more
   <parent>
     <artifactId>maven</artifactId>
     <groupId>org.apache.tomee.maven</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
   <groupId>org.apache.tomee</groupId>
   <artifactId>tomee-project</artifactId>
   <packaging>pom</packaging>
-  <version>7.0.4-SNAPSHOT</version>
+  <version>7.0.4</version>
 
   <name>Apache OpenEJB</name>
   <description>Apache OpenEJB is an open source, modular, configurable and extensible EJB Container System and EJB Server.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -133,7 +133,7 @@
 
     <tomcat.version>8.5.20</tomcat.version>
 
-    <cxf.version>3.1.12</cxf.version>
+    <cxf.version>3.1.13</cxf.version>
     <ehcache.version>2.10.3</ehcache.version>
     <!-- used by cxf for security (replay attack) -->
     <jetty.version>7.5.3.v20111011</jetty.version>
@@ -1676,17 +1676,17 @@
       <dependency>
         <groupId>javax.xml.bind</groupId>
         <artifactId>jaxb-api</artifactId>
-        <version>2.3.0-b170201.1204</version>
+        <version>2.3.0</version>
       </dependency>
       <dependency>
         <groupId>com.sun.xml.bind</groupId>
         <artifactId>jaxb-impl</artifactId>
-        <version>2.3.0-b170127.1453</version>
+        <version>2.3.0</version>
       </dependency>
       <dependency>
         <groupId>com.sun.xml.bind</groupId>
         <artifactId>jaxb-core</artifactId>
-        <version>2.3.0-b170127.1453</version>
+        <version>2.3.0</version>
       </dependency>
       <dependency> <!-- licence apache, only 110ko -->
         <groupId>org.fusesource.jansi</groupId>

--- a/server/openejb-activemq/pom.xml
+++ b/server/openejb-activemq/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>server</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>openejb-activemq</artifactId>

--- a/server/openejb-axis/pom.xml
+++ b/server/openejb-axis/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>server</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>openejb-axis</artifactId>

--- a/server/openejb-bonecp/pom.xml
+++ b/server/openejb-bonecp/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>server</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/server/openejb-client/pom.xml
+++ b/server/openejb-client/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <artifactId>server</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
 
   <artifactId>openejb-client</artifactId>

--- a/server/openejb-common-cli/pom.xml
+++ b/server/openejb-common-cli/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>server</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/server/openejb-cxf-rs/pom.xml
+++ b/server/openejb-cxf-rs/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>server</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/server/openejb-cxf-transport/pom.xml
+++ b/server/openejb-cxf-transport/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>server</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/server/openejb-cxf/pom.xml
+++ b/server/openejb-cxf/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>server</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/server/openejb-daemon/pom.xml
+++ b/server/openejb-daemon/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>server</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>openejb-daemon</artifactId>

--- a/server/openejb-derbynet/pom.xml
+++ b/server/openejb-derbynet/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>server</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>openejb-derbynet</artifactId>

--- a/server/openejb-ejbd/pom.xml
+++ b/server/openejb-ejbd/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <artifactId>server</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
 
   <artifactId>openejb-ejbd</artifactId>

--- a/server/openejb-hessian/pom.xml
+++ b/server/openejb-hessian/pom.xml
@@ -25,7 +25,7 @@ limitations under the License.
   <parent>
     <artifactId>server</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
 
   <artifactId>openejb-hessian</artifactId>
@@ -35,7 +35,7 @@ limitations under the License.
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>openejb-http</artifactId>
-      <version>7.0.4-SNAPSHOT</version>
+      <version>7.0.4</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/server/openejb-hsql/pom.xml
+++ b/server/openejb-hsql/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>server</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>openejb-hsql</artifactId>

--- a/server/openejb-http/pom.xml
+++ b/server/openejb-http/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <artifactId>server</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
 
   <artifactId>openejb-http</artifactId>

--- a/server/openejb-multicast/pom.xml
+++ b/server/openejb-multicast/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>server</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>openejb-multicast</artifactId>

--- a/server/openejb-rest/pom.xml
+++ b/server/openejb-rest/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>server</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/server/openejb-server/pom.xml
+++ b/server/openejb-server/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>server</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>openejb-server</artifactId>

--- a/server/openejb-ssh/pom.xml
+++ b/server/openejb-ssh/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>server</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/server/openejb-webservices/pom.xml
+++ b/server/openejb-webservices/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>server</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>openejb-webservices</artifactId>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>tomee-project</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
 
   <artifactId>server</artifactId>

--- a/tck/bval-embedded/pom.xml
+++ b/tck/bval-embedded/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>tck</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/tck/bval-tomee/pom.xml
+++ b/tck/bval-tomee/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>tck</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/tck/cdi-embedded/pom.xml
+++ b/tck/cdi-embedded/pom.xml
@@ -20,13 +20,13 @@
   <parent>
     <artifactId>tck</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>cdi-embedded</artifactId>
   <packaging>jar</packaging>
   <name>OpenEJB :: TCK :: CDI Embedded</name>
-  <version>7.0.4-SNAPSHOT</version>
+  <version>7.0.4</version>
 
   <dependencies>
     <dependency>

--- a/tck/cdi-tomee/pom.xml
+++ b/tck/cdi-tomee/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>tck</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>tomee-project</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>tck</artifactId>

--- a/tck/tck-common/pom.xml
+++ b/tck/tck-common/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>tck</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>tck-common</artifactId>

--- a/tomee/apache-tomee/pom.xml
+++ b/tomee/apache-tomee/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>tomee</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/tomee/pom.xml
+++ b/tomee/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <artifactId>tomee-project</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
   
   <artifactId>tomee</artifactId>

--- a/tomee/tomee-catalina/pom.xml
+++ b/tomee/tomee-catalina/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>tomee</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/tomee/tomee-common/pom.xml
+++ b/tomee/tomee-common/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>tomee</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>tomee-common</artifactId>

--- a/tomee/tomee-deb/pom.xml
+++ b/tomee/tomee-deb/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <artifactId>tomee</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/tomee/tomee-embedded/pom.xml
+++ b/tomee/tomee-embedded/pom.xml
@@ -25,14 +25,14 @@
   <parent>
     <artifactId>tomee</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
   <artifactId>tomee-embedded</artifactId>
   <packaging>jar</packaging>
   <name>OpenEJB :: TomEE :: TomEE Embedded</name>
-  <version>7.0.4-SNAPSHOT</version>
+  <version>7.0.4</version>
 
   <build>
     <plugins>

--- a/tomee/tomee-jaxrs/pom.xml
+++ b/tomee/tomee-jaxrs/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>tomee</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/tomee/tomee-jdbc/pom.xml
+++ b/tomee/tomee-jdbc/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>tomee</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/tomee/tomee-juli/pom.xml
+++ b/tomee/tomee-juli/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>tomee</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/tomee/tomee-loader/pom.xml
+++ b/tomee/tomee-loader/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>tomee</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/tomee/tomee-mojarra/pom.xml
+++ b/tomee/tomee-mojarra/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>tomee</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/tomee/tomee-myfaces/pom.xml
+++ b/tomee/tomee-myfaces/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>tomee</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
 
   <artifactId>tomee-myfaces</artifactId>

--- a/tomee/tomee-overlay-runner/pom.xml
+++ b/tomee/tomee-overlay-runner/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>tomee</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/tomee/tomee-plume-webapp/pom.xml
+++ b/tomee/tomee-plume-webapp/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>tomee</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/tomee/tomee-plus-webapp/pom.xml
+++ b/tomee/tomee-plus-webapp/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>tomee</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/tomee/tomee-util/pom.xml
+++ b/tomee/tomee-util/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>tomee</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/tomee/tomee-webaccess/pom.xml
+++ b/tomee/tomee-webaccess/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <artifactId>tomee</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
   <artifactId>tomee-webaccess</artifactId>
   <packaging>war</packaging>

--- a/tomee/tomee-webapp/pom.xml
+++ b/tomee/tomee-webapp/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>tomee</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>tomee-webapp</artifactId>

--- a/tomee/tomee-webservices/pom.xml
+++ b/tomee/tomee-webservices/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>tomee</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>tomee-webservices</artifactId>

--- a/utils/livereload-tomee/pom.xml
+++ b/utils/livereload-tomee/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>utils</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/utils/log4j2-tomee/pom.xml
+++ b/utils/log4j2-tomee/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>utils</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/utils/openejb-core-eclipselink/pom.xml
+++ b/utils/openejb-core-eclipselink/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>utils</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/utils/openejb-core-hibernate/pom.xml
+++ b/utils/openejb-core-hibernate/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>utils</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
 
   <artifactId>openejb-core-hibernate</artifactId>

--- a/utils/openejb-mockito/pom.xml
+++ b/utils/openejb-mockito/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>utils</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/utils/openejb-provisionning/pom.xml
+++ b/utils/openejb-provisionning/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>utils</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>tomee-project</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>utils</artifactId>

--- a/utils/webdeployer/pom.xml
+++ b/utils/webdeployer/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>utils</artifactId>
     <groupId>org.apache.tomee</groupId>
-    <version>7.0.4-SNAPSHOT</version>
+    <version>7.0.4</version>
   </parent>
 
   <artifactId>webdeployer</artifactId>


### PR DESCRIPTION
I have defined an annotation like below:
@Inherited
@InterceptorBinding
@Target({ElementType.METHOD, ElementType.TYPE})
@Retention(RetentionPolicy.RUNTIME)
public @interface Logged {
   @Nonbinding
   String logLevel() default "INFO";
}

Then, I have written a class like this:
@Logged
@Interceptor
public class LoggingInterceptor {
     private Class<?> intercepted;

     @AroundInvoke
     public Object logMethod(final InvocationContext ctx) throws Exception {
      .....
     }
}

In my POJO, webservice endpoint, I have:
@WebService(name = "MyManager", targetNamespace ="http://com.test/wsdl", 
                      serviceName = "MyManagerService") 
@Logged 
public class MyManager implements IMyManager {
    @Resource
    private WebServiceContext wsc;       //=>=> ALWAYS null on TomEE 7.0.4!!!
    ....
    }
}

That's the test case I built which doesn't work on TomEE 7.0.4 but works, as I have already mentioned,  on Glassfish 4.1.2/5.0, Weblogic Server 12.2.1.3 and Wildfly 10.0.1/11.0.0.
