### PR TITLE
updates cxf to version 3.1.16

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,7 +133,7 @@
 
     <tomcat.version>8.5.30</tomcat.version>
 
-    <cxf.version>3.1.15</cxf.version>
+    <cxf.version>3.1.16</cxf.version>
     <version.shrinkwrap.shrinkwrap>1.2.6</version.shrinkwrap.shrinkwrap>
     <version.shrinkwrap.descriptor>2.0.0</version.shrinkwrap.descriptor>
     <version.arquillian>1.1.13.Final</version.arquillian>


### PR DESCRIPTION


Updates CXF version based on the CVE: http://cxf.apache.org/security-advisories.data/CVE-2018-8039.txt.asc?version=1&modificationDate=1530184663000&api=v2