### PR TITLE
upgrade xmlsec dependency to fix incompatibility issue with wss4j 2.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1320,7 +1320,7 @@
       <dependency>
         <artifactId>xmlsec</artifactId>
         <groupId>org.apache.santuario</groupId>
-        <version>2.0.6</version>
+        <version>2.1.2</version>
       </dependency>
       <dependency>
         <groupId>wsdl4j</groupId>


### PR DESCRIPTION
The error was

`java.lang.NoSuchMethodError: 
org.apache.xml.security.utils.XMLUtils.encodeToString([B)Ljava/lang/String; 
       at 
org.apache.wss4j.dom.message.token.UsernameToken.addNonce(UsernameToken.java:303) 
       at 
org.apache.wss4j.dom.message.token.UsernameToken.<init>(UsernameToken.java:264) 
       at 
org.apache.wss4j.dom.message.WSSecUsernameToken.prepare(WSSecUsernameToken.java:168) 
       at 
org.apache.wss4j.dom.message.WSSecUsernameToken.build(WSSecUsernameToken.java:225) 
       at 
org.apache.wss4j.dom.action.UsernameTokenAction.execute(UsernameTokenAction.java:69) 
       at 
org.apache.wss4j.dom.handler.WSHandler.doSenderAction(WSHandler.java:238) 
       at 
org.apache.cxf.ws.security.wss4j.WSS4JOutInterceptor.access$100(WSS4JOutInterceptor.java:57) 
       at 
org.apache.cxf.ws.security.wss4j.WSS4JOutInterceptor$WSS4JOutInterceptorInternal.handleMessageInternal(WSS4JOutInterceptor.java:275) 
       at 
org.apache.cxf.ws.security.wss4j.WSS4JOutInterceptor$WSS4JOutInterceptorInternal.handleMessage(WSS4JOutInterceptor.java:147) 
       at 
org.apache.cxf.ws.security.wss4j.WSS4JOutInterceptor$WSS4JOutInterceptorInternal.handleMessage(WSS4JOutInterceptor.java:132) 
       at 
org.apache.cxf.phase.PhaseInterceptorChain.doIntercept(PhaseInterceptorChain.java:308) 
       at org.apache.cxf.endpoint.ClientImpl.doInvoke(ClientImpl.java:537) 
       at org.apache.cxf.endpoint.ClientImpl.invoke(ClientImpl.java:446) 
       at org.apache.cxf.endpoint.ClientImpl.invoke(ClientImpl.java:361) 
       at org.apache.cxf.endpoint.ClientImpl.invoke(ClientImpl.java:319) 
       at 
org.apache.cxf.frontend.ClientProxy.invokeSync(ClientProxy.java:96) 
       at 
org.apache.cxf.jaxws.JaxWsClientProxy.invoke(JaxWsClientProxy.java:140) `