### PR TITLE
Hacking around with loading CMP modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ quick.bat
 /temp
 /report.txt
 nb-configuration.xml
+.factorypath

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/cmp/CmpMappingTest.java
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/cmp/CmpMappingTest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.openejb.arquillian.tests.cmp;
+
+import org.apache.ziplock.IO;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.ClassLoaderAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.net.URL;
+
+/**
+ * @version $Rev$ $Date$
+ */
+@RunWith(Arquillian.class)
+public class CmpMappingTest {
+
+    @ArquillianResource
+    private URL url;
+
+    @Deployment(testable = false)
+    public static WebArchive createDeployment() {
+        WebArchive archive = ShrinkWrap.create(WebArchive.class, CmpMappingTest.class.getSimpleName() + ".war")
+                .addClasses(CmpServlet.class, MyCmpBean.class, MyLocalHome.class, MyLocalObject.class, MyRemoteHome.class, MyRemoteObject.class)
+                .addAsWebInfResource(new ClassLoaderAsset("org/apache/openejb/arquillian/tests/cmp/openejb-cmp-orm.xml"), "openejb-cmp-orm.xml")
+                .addAsWebInfResource(new ClassLoaderAsset("org/apache/openejb/arquillian/tests/cmp/ejb-jar.xml"), "ejb-jar.xml");
+
+        System.out.println(archive.toString(true));
+        return archive;
+    }
+
+    @Test
+    @RunAsClient
+    public void checkCmpJpaEntityORMMappings() throws Exception {
+        final String output = IO.readString(new URL(url.toExternalForm()));
+        System.out.println(output);
+    }
+}

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/cmp/CmpServlet.java
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/cmp/CmpServlet.java
@@ -1,0 +1,30 @@
+package org.apache.openejb.arquillian.tests.cmp;
+
+import org.apache.openejb.assembler.classic.AppInfo;
+import org.apache.openejb.assembler.classic.Assembler;
+import org.apache.openejb.loader.SystemInstance;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Collection;
+
+@WebServlet(name="Cmp", urlPatterns = "/*")
+public class CmpServlet extends HttpServlet {
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+
+        final Assembler assembler = SystemInstance.get().getComponent(Assembler.class);
+        final Collection<AppInfo> deployedApplications = assembler.getDeployedApplications();
+
+        for (final AppInfo deployedApplication : deployedApplications) {
+            if ("CmpMappingTest".equals(deployedApplication.appId)) {
+                final String cmpMappingsXml = deployedApplication.cmpMappingsXml;
+                resp.getWriter().write(cmpMappingsXml == null ? "null" : cmpMappingsXml);
+            }
+        }
+    }
+}

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/cmp/MyCmpBean.java
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/cmp/MyCmpBean.java
@@ -1,0 +1,53 @@
+package org.apache.openejb.arquillian.tests.cmp;
+
+import javax.ejb.CreateException;
+import javax.ejb.EntityBean;
+import javax.ejb.EntityContext;
+import javax.ejb.LocalHome;
+import javax.ejb.RemoteHome;
+import javax.ejb.RemoveException;
+
+@LocalHome(MyLocalHome.class)
+@RemoteHome(MyRemoteHome.class)
+public abstract class MyCmpBean implements EntityBean {
+
+    // CMP
+    public abstract Integer getId();
+
+    public abstract void setId(Integer id);
+
+    public abstract String getName();
+
+    public abstract void setName(String number);
+
+    public void doit() {
+    }
+
+    public Integer ejbCreateObject(final String id) throws CreateException {
+        return null;
+    }
+
+    public void ejbPostCreateObject(final String id) {
+    }
+
+    public void setEntityContext(final EntityContext ctx) {
+    }
+
+    public void unsetEntityContext() {
+    }
+
+    public void ejbActivate() {
+    }
+
+    public void ejbPassivate() {
+    }
+
+    public void ejbLoad() {
+    }
+
+    public void ejbStore() {
+    }
+
+    public void ejbRemove() throws RemoveException {
+    }
+}

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/cmp/MyLocalHome.java
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/cmp/MyLocalHome.java
@@ -1,0 +1,14 @@
+package org.apache.openejb.arquillian.tests.cmp;
+
+public interface MyLocalHome extends javax.ejb.EJBLocalHome {
+
+    public MyLocalObject createObject(String name)
+            throws javax.ejb.CreateException;
+
+    public MyLocalObject findByPrimaryKey(Integer primarykey)
+            throws javax.ejb.FinderException;
+
+    public java.util.Collection findEmptyCollection()
+            throws javax.ejb.FinderException;
+
+}

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/cmp/MyLocalObject.java
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/cmp/MyLocalObject.java
@@ -1,0 +1,7 @@
+package org.apache.openejb.arquillian.tests.cmp;
+
+public interface MyLocalObject extends javax.ejb.EJBLocalObject {
+
+    public void doit();
+
+}

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/cmp/MyRemoteHome.java
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/cmp/MyRemoteHome.java
@@ -1,0 +1,14 @@
+package org.apache.openejb.arquillian.tests.cmp;
+
+public interface MyRemoteHome extends javax.ejb.EJBHome {
+
+    public MyRemoteObject createObject(String name)
+            throws javax.ejb.CreateException, java.rmi.RemoteException;
+
+    public MyRemoteObject findByPrimaryKey(Integer primarykey)
+            throws javax.ejb.FinderException, java.rmi.RemoteException;
+
+    public java.util.Collection findEmptyCollection()
+            throws javax.ejb.FinderException, java.rmi.RemoteException;
+
+}

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/cmp/MyRemoteObject.java
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/cmp/MyRemoteObject.java
@@ -1,0 +1,9 @@
+package org.apache.openejb.arquillian.tests.cmp;
+
+import java.rmi.RemoteException;
+
+public interface MyRemoteObject extends javax.ejb.EJBObject {
+
+    public void doit() throws RemoteException;
+
+}

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/resources/org/apache/openejb/arquillian/tests/cmp/ejb-jar.xml
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/resources/org/apache/openejb/arquillian/tests/cmp/ejb-jar.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<ejb-jar xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         version="3.1"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/ejb-jar_3_1.xsd">
+  <enterprise-beans>
+    <entity>
+      <ejb-name>MyCmpBean</ejb-name>
+      <ejb-class>org.apache.openejb.arquillian.tests.cmp.MyCmpBean</ejb-class>
+      <persistence-type>Container</persistence-type>
+      <prim-key-class>java.lang.Integer</prim-key-class>
+      <reentrant>false</reentrant>
+      <cmp-field>
+        <field-name>name</field-name>
+      </cmp-field>
+      <primkey-field>id</primkey-field>
+      <query>
+        <query-method>
+          <method-name>findByPrimaryKey</method-name>
+          <method-params>
+            <method-param>java.lang.Integer</method-param>
+          </method-params>
+        </query-method>
+        <ejb-ql>SELECT OBJECT(DL) FROM License DL</ejb-ql>
+      </query>
+    </entity>
+  </enterprise-beans>
+  <assembly-descriptor>
+    <container-transaction>
+      <method>
+        <ejb-name>MyCmpBean</ejb-name>
+        <method-name>*</method-name>
+      </method>
+      <trans-attribute>Supports</trans-attribute>
+    </container-transaction>
+  </assembly-descriptor>
+</ejb-jar>

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/resources/org/apache/openejb/arquillian/tests/cmp/openejb-cmp-orm.xml
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/resources/org/apache/openejb/arquillian/tests/cmp/openejb-cmp-orm.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<entity-mappings xmlns="http://java.sun.com/xml/ns/persistence/orm" version="1.0">
+  <entity class="org.apache.openejb.arquillian.tests.cmp.MyCmpBean" name="MyCmpBean">
+    <description>MyCmpBean</description>
+    <named-query name="MyCmpBean.findByPrimaryKey(java.lang.Integer)">
+      <query>SELECT OBJECT(DL) FROM License DL</query>
+    </named-query>
+    <attributes>
+      <id name="id"/>
+      <basic name="name">
+        <column name="wNAME" length="300"/>
+      </basic>
+    </attributes>
+  </entity>
+</entity-mappings>

--- a/container/openejb-core/src/main/java/org/apache/openejb/config/ReadDescriptors.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/config/ReadDescriptors.java
@@ -548,7 +548,8 @@ public class ReadDescriptors implements DynamicDeployer {
         return current;
     }
 
-    private void readCmpOrm(final EjbModule ejbModule) throws OpenEJBException {
+    // package scoped for testing
+    void readCmpOrm(final EjbModule ejbModule) throws OpenEJBException {
         final Object data = ejbModule.getAltDDs().get("openejb-cmp-orm.xml");
         if (data != null && !(data instanceof EntityMappings)) {
             if (data instanceof URL) {

--- a/container/openejb-core/src/test/java/org/apache/openejb/config/ReadDescriptorsTest.java
+++ b/container/openejb-core/src/test/java/org/apache/openejb/config/ReadDescriptorsTest.java
@@ -19,6 +19,8 @@ package org.apache.openejb.config;
 
 import org.apache.openejb.config.sys.Resource;
 import org.apache.openejb.config.sys.Resources;
+import org.apache.openejb.jee.EjbJar;
+import org.apache.openejb.jee.jpa.EntityMappings;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -92,4 +94,12 @@ public class ReadDescriptorsTest {
         Assert.assertNull(res.getProperties().getProperty("InitializeAfterDeployment"));
     }
 
+    @Test
+    public void testReadCmpOrmDescriptor() throws Exception {
+        final EjbModule ejbModule = new EjbModule(new EjbJar());
+        ejbModule.getAltDDs().put("openejb-cmp-orm.xml", getClass().getResource("test-openejb-cmp-orm.xml"));
+        new ReadDescriptors().readCmpOrm(ejbModule);
+        Assert.assertNotNull(ejbModule.getAltDDs().get("openejb-cmp-orm.xml"));
+        Assert.assertTrue(EntityMappings.class.isInstance(ejbModule.getAltDDs().get("openejb-cmp-orm.xml")));
+    }
 }

--- a/container/openejb-core/src/test/resources/org/apache/openejb/config/test-openejb-cmp-orm.xml
+++ b/container/openejb-core/src/test/resources/org/apache/openejb/config/test-openejb-cmp-orm.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<entity-mappings xmlns="http://java.sun.com/xml/ns/persistence/orm" version="1.0">
+  <entity class="MyCmpBean" name="MyCmpBean">
+    <description>MyCmpBean</description>
+    <named-query name="MyCmpBean.findByPrimaryKey(java.lang.Integer)">
+      <query>SELECT OBJECT(DL) FROM License DL</query>
+    </named-query>
+    <attributes>
+      <id name="id"/>
+      <basic name="name">
+        <column name="wNAME" length="300"/>
+      </basic>
+    </attributes>
+  </entity>
+</entity-mappings>


### PR DESCRIPTION
This is not intended for merge but collaboration and discussion. This PR adds a simple test to `LegacyInterfaceTest` to ensure that user-provided mappings are taken into consideration and not overwritten. These are provided programmatically, as opposed to via XML. This passes, so, so far-so good.

There is an Arquillian test with the same CMP classes, and the same CMP/JPA mappings, but provided via `WEB-INF/openejb-cmp-orm.xml`. This fails with a JAXB error stating that:

```
CmpMappingTest/WEB-INF/openejb-cmp-orm.xml: unexpected element (uri:"http://java.sun.com/xml/ns/javaee", local:"entity"). Expected elements are <{http://java.sun.com/xml/ns/persistence/orm}embeddable>,<{http://java.sun.com/xml/ns/persistence/orm}entity>,<{http://java.sun.com/xml/ns/persistence/orm}table-generator>,<{http://java.sun.com/xml/ns/persistence/orm}named-native-query>,<{http://java.sun.com/xml/ns/persistence/orm}sequence-generator>,<{http://java.sun.com/xml/ns/persistence/orm}sql-result-set-mapping>,<{http://java.sun.com/xml/ns/persistence/orm}named-query>,<{http://java.sun.com/xml/ns/persistence/orm}description>,<{http://java.sun.com/xml/ns/persistence/orm}persistence-unit-metadata>,<{http://java.sun.com/xml/ns/persistence/orm}catalog>,<{http://java.sun.com/xml/ns/persistence/orm}schema>,<{http://java.sun.com/xml/ns/persistence/orm}access>,<{http://java.sun.com/xml/ns/persistence/orm}mapped-superclass>,<{http://java.sun.com/xml/ns/persistence/orm}package>
```

The javaee namespace here is weird. Finally, I added a unit test specifically for `ReadDescriptors` to check the `readCmpOrm()` method directly with the same XML. This also fails with the same issue.

I think we likely need to change the `readCmpOrm()` method so it doesn't fiddle with the namespace.