### PR TITLE
Creates an unmarshal that does not filter to JavaEE namespace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ quick.bat
 /temp
 /report.txt
 nb-configuration.xml
+.factorypath

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/cmp/CmpMappingTest.java
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/cmp/CmpMappingTest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.openejb.arquillian.tests.cmp;
+
+import org.apache.ziplock.IO;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.ClassLoaderAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.net.URL;
+
+/**
+ * @version $Rev$ $Date$
+ */
+@RunWith(Arquillian.class)
+public class CmpMappingTest {
+
+    @ArquillianResource
+    private URL url;
+
+    @Deployment(testable = false)
+    public static WebArchive createDeployment() {
+        WebArchive archive = ShrinkWrap.create(WebArchive.class, CmpMappingTest.class.getSimpleName() + ".war")
+                .addClasses(CmpServlet.class, MyCmpBean.class, MyLocalHome.class, MyLocalObject.class, MyRemoteHome.class, MyRemoteObject.class)
+                .addAsWebInfResource(new ClassLoaderAsset("org/apache/openejb/arquillian/tests/cmp/openejb-cmp-orm.xml"), "openejb-cmp-orm.xml")
+                .addAsWebInfResource(new ClassLoaderAsset("org/apache/openejb/arquillian/tests/cmp/ejb-jar.xml"), "ejb-jar.xml");
+
+        System.out.println(archive.toString(true));
+        return archive;
+    }
+
+    @Test
+    @RunAsClient
+    public void checkCmpJpaEntityORMMappings() throws Exception {
+        final String output = IO.readString(new URL(url.toExternalForm()));
+        System.out.println(output);
+    }
+}

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/cmp/CmpServlet.java
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/cmp/CmpServlet.java
@@ -1,0 +1,30 @@
+package org.apache.openejb.arquillian.tests.cmp;
+
+import org.apache.openejb.assembler.classic.AppInfo;
+import org.apache.openejb.assembler.classic.Assembler;
+import org.apache.openejb.loader.SystemInstance;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Collection;
+
+@WebServlet(name="Cmp", urlPatterns = "/*")
+public class CmpServlet extends HttpServlet {
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+
+        final Assembler assembler = SystemInstance.get().getComponent(Assembler.class);
+        final Collection<AppInfo> deployedApplications = assembler.getDeployedApplications();
+
+        for (final AppInfo deployedApplication : deployedApplications) {
+            if ("CmpMappingTest".equals(deployedApplication.appId)) {
+                final String cmpMappingsXml = deployedApplication.cmpMappingsXml;
+                resp.getWriter().write(cmpMappingsXml == null ? "null" : cmpMappingsXml);
+            }
+        }
+    }
+}

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/cmp/MyCmpBean.java
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/cmp/MyCmpBean.java
@@ -1,0 +1,53 @@
+package org.apache.openejb.arquillian.tests.cmp;
+
+import javax.ejb.CreateException;
+import javax.ejb.EntityBean;
+import javax.ejb.EntityContext;
+import javax.ejb.LocalHome;
+import javax.ejb.RemoteHome;
+import javax.ejb.RemoveException;
+
+@LocalHome(MyLocalHome.class)
+@RemoteHome(MyRemoteHome.class)
+public abstract class MyCmpBean implements EntityBean {
+
+    // CMP
+    public abstract Integer getId();
+
+    public abstract void setId(Integer id);
+
+    public abstract String getName();
+
+    public abstract void setName(String number);
+
+    public void doit() {
+    }
+
+    public Integer ejbCreateObject(final String id) throws CreateException {
+        return null;
+    }
+
+    public void ejbPostCreateObject(final String id) {
+    }
+
+    public void setEntityContext(final EntityContext ctx) {
+    }
+
+    public void unsetEntityContext() {
+    }
+
+    public void ejbActivate() {
+    }
+
+    public void ejbPassivate() {
+    }
+
+    public void ejbLoad() {
+    }
+
+    public void ejbStore() {
+    }
+
+    public void ejbRemove() throws RemoveException {
+    }
+}

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/cmp/MyLocalHome.java
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/cmp/MyLocalHome.java
@@ -1,0 +1,14 @@
+package org.apache.openejb.arquillian.tests.cmp;
+
+public interface MyLocalHome extends javax.ejb.EJBLocalHome {
+
+    public MyLocalObject createObject(String name)
+            throws javax.ejb.CreateException;
+
+    public MyLocalObject findByPrimaryKey(Integer primarykey)
+            throws javax.ejb.FinderException;
+
+    public java.util.Collection findEmptyCollection()
+            throws javax.ejb.FinderException;
+
+}

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/cmp/MyLocalObject.java
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/cmp/MyLocalObject.java
@@ -1,0 +1,7 @@
+package org.apache.openejb.arquillian.tests.cmp;
+
+public interface MyLocalObject extends javax.ejb.EJBLocalObject {
+
+    public void doit();
+
+}

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/cmp/MyRemoteHome.java
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/cmp/MyRemoteHome.java
@@ -1,0 +1,14 @@
+package org.apache.openejb.arquillian.tests.cmp;
+
+public interface MyRemoteHome extends javax.ejb.EJBHome {
+
+    public MyRemoteObject createObject(String name)
+            throws javax.ejb.CreateException, java.rmi.RemoteException;
+
+    public MyRemoteObject findByPrimaryKey(Integer primarykey)
+            throws javax.ejb.FinderException, java.rmi.RemoteException;
+
+    public java.util.Collection findEmptyCollection()
+            throws javax.ejb.FinderException, java.rmi.RemoteException;
+
+}

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/cmp/MyRemoteObject.java
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/cmp/MyRemoteObject.java
@@ -1,0 +1,9 @@
+package org.apache.openejb.arquillian.tests.cmp;
+
+import java.rmi.RemoteException;
+
+public interface MyRemoteObject extends javax.ejb.EJBObject {
+
+    public void doit() throws RemoteException;
+
+}

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/resources/org/apache/openejb/arquillian/tests/cmp/ejb-jar.xml
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/resources/org/apache/openejb/arquillian/tests/cmp/ejb-jar.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<ejb-jar xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         version="3.1"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/ejb-jar_3_1.xsd">
+  <enterprise-beans>
+    <entity>
+      <ejb-name>MyCmpBean</ejb-name>
+      <ejb-class>org.apache.openejb.arquillian.tests.cmp.MyCmpBean</ejb-class>
+      <persistence-type>Container</persistence-type>
+      <prim-key-class>java.lang.Integer</prim-key-class>
+      <reentrant>false</reentrant>
+      <cmp-field>
+        <field-name>name</field-name>
+      </cmp-field>
+      <primkey-field>id</primkey-field>
+      <query>
+        <query-method>
+          <method-name>findByPrimaryKey</method-name>
+          <method-params>
+            <method-param>java.lang.Integer</method-param>
+          </method-params>
+        </query-method>
+        <ejb-ql>SELECT OBJECT(DL) FROM License DL</ejb-ql>
+      </query>
+    </entity>
+  </enterprise-beans>
+  <assembly-descriptor>
+    <container-transaction>
+      <method>
+        <ejb-name>MyCmpBean</ejb-name>
+        <method-name>*</method-name>
+      </method>
+      <trans-attribute>Supports</trans-attribute>
+    </container-transaction>
+  </assembly-descriptor>
+</ejb-jar>

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/resources/org/apache/openejb/arquillian/tests/cmp/openejb-cmp-orm.xml
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/resources/org/apache/openejb/arquillian/tests/cmp/openejb-cmp-orm.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<entity-mappings xmlns="http://java.sun.com/xml/ns/persistence/orm" version="1.0">
+  <entity class="org.apache.openejb.arquillian.tests.cmp.MyCmpBean" name="MyCmpBean">
+    <description>MyCmpBean</description>
+    <named-query name="MyCmpBean.findByPrimaryKey(java.lang.Integer)">
+      <query>SELECT OBJECT(DL) FROM License DL</query>
+    </named-query>
+    <attributes>
+      <id name="id"/>
+      <basic name="name">
+        <column name="wNAME" length="300"/>
+      </basic>
+    </attributes>
+  </entity>
+</entity-mappings>

--- a/container/openejb-core/src/main/java/org/apache/openejb/config/ReadDescriptors.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/config/ReadDescriptors.java
@@ -548,7 +548,8 @@ public class ReadDescriptors implements DynamicDeployer {
         return current;
     }
 
-    private void readCmpOrm(final EjbModule ejbModule) throws OpenEJBException {
+    // package scoped for testing
+    void readCmpOrm(final EjbModule ejbModule) throws OpenEJBException {
         final Object data = ejbModule.getAltDDs().get("openejb-cmp-orm.xml");
         if (data != null && !(data instanceof EntityMappings)) {
             if (data instanceof URL) {

--- a/container/openejb-core/src/main/java/org/apache/openejb/config/ReadDescriptors.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/config/ReadDescriptors.java
@@ -555,7 +555,7 @@ public class ReadDescriptors implements DynamicDeployer {
             if (data instanceof URL) {
                 final URL url = (URL) data;
                 try {
-                    final EntityMappings entitymappings = (EntityMappings) JaxbJavaee.unmarshalJavaee(EntityMappings.class, IO.read(url));
+                    final EntityMappings entitymappings = (EntityMappings) JaxbJavaee.unmarshal(EntityMappings.class, IO.read(url));
                     ejbModule.getAltDDs().put("openejb-cmp-orm.xml", entitymappings);
                 } catch (final SAXException e) {
                     throw new OpenEJBException("Cannot parse the openejb-cmp-orm.xml file: " + url.toExternalForm(), e);

--- a/container/openejb-core/src/test/java/org/apache/openejb/config/ReadDescriptorsTest.java
+++ b/container/openejb-core/src/test/java/org/apache/openejb/config/ReadDescriptorsTest.java
@@ -19,6 +19,8 @@ package org.apache.openejb.config;
 
 import org.apache.openejb.config.sys.Resource;
 import org.apache.openejb.config.sys.Resources;
+import org.apache.openejb.jee.EjbJar;
+import org.apache.openejb.jee.jpa.EntityMappings;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -92,4 +94,12 @@ public class ReadDescriptorsTest {
         Assert.assertNull(res.getProperties().getProperty("InitializeAfterDeployment"));
     }
 
+    @Test
+    public void testReadCmpOrmDescriptor() throws Exception {
+        final EjbModule ejbModule = new EjbModule(new EjbJar());
+        ejbModule.getAltDDs().put("openejb-cmp-orm.xml", getClass().getResource("test-openejb-cmp-orm.xml"));
+        new ReadDescriptors().readCmpOrm(ejbModule);
+        Assert.assertNotNull(ejbModule.getAltDDs().get("openejb-cmp-orm.xml"));
+        Assert.assertTrue(EntityMappings.class.isInstance(ejbModule.getAltDDs().get("openejb-cmp-orm.xml")));
+    }
 }

--- a/container/openejb-core/src/test/java/org/apache/openejb/core/webservices/JPACMDIntegrationTest.java
+++ b/container/openejb-core/src/test/java/org/apache/openejb/core/webservices/JPACMDIntegrationTest.java
@@ -1,0 +1,325 @@
+package org.apache.openejb.core.webservices;
+
+import org.apache.openejb.assembler.classic.ReloadableEntityManagerFactory;
+import org.apache.openejb.config.AppModule;
+import org.apache.openejb.config.EjbModule;
+import org.apache.openejb.jee.CmpField;
+import org.apache.openejb.jee.ContainerTransaction;
+import org.apache.openejb.jee.EjbJar;
+import org.apache.openejb.jee.EntityBean;
+import org.apache.openejb.jee.PersistenceType;
+import org.apache.openejb.jee.Query;
+import org.apache.openejb.jee.QueryMethod;
+import org.apache.openejb.jee.SingletonBean;
+import org.apache.openejb.jee.TransAttribute;
+import org.apache.openejb.jee.jpa.Attributes;
+import org.apache.openejb.jee.jpa.Basic;
+import org.apache.openejb.jee.jpa.Column;
+import org.apache.openejb.jee.jpa.EntityMappings;
+import org.apache.openejb.jee.jpa.NamedQuery;
+import org.apache.openejb.jee.jpa.unit.Persistence;
+import org.apache.openejb.jee.jpa.unit.PersistenceUnit;
+import org.apache.openejb.junit.ApplicationComposer;
+import org.apache.openejb.testing.Configuration;
+import org.apache.openejb.testing.Module;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.annotation.Resource;
+import javax.ejb.CreateException;
+import javax.ejb.EJBException;
+import javax.ejb.EntityContext;
+import javax.ejb.LocalHome;
+import javax.ejb.RemoteHome;
+import javax.ejb.RemoveException;
+import javax.ejb.SessionContext;
+import javax.naming.Context;
+import javax.persistence.Entity;
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import java.io.File;
+import java.rmi.RemoteException;
+import java.util.List;
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(ApplicationComposer.class)
+public class JPACMDIntegrationTest {
+
+    @javax.persistence.PersistenceUnit
+    private EntityManagerFactory emf;
+
+
+    @Module
+    public Persistence persistence() throws Exception {
+        final PersistenceUnit unit = new PersistenceUnit("foo-unit");
+        unit.addClass(User.class);
+        unit.setProperty("openjpa.jdbc.SynchronizeMappings", "buildSchema(ForeignKeys=true)");
+        unit.getProperties().setProperty("openjpa.RuntimeUnenhancedClasses", "supported");
+        unit.getProperties().setProperty("openjpa.DatCache", "false");
+        unit.setExcludeUnlistedClasses(true);
+
+        final Persistence persistence = new org.apache.openejb.jee.jpa.unit.Persistence(unit);
+        persistence.setVersion("2.0");
+        return persistence;
+    }
+
+
+    @Module
+    public EjbModule ejbModule() throws Exception {
+        final EjbJar ejbJar = new EjbJar();
+        ejbJar.addEnterpriseBean(new SingletonBean(MySingletonBean.class));
+        ejbJar.addEnterpriseBean(new EntityBean(MyBmpBean.class, PersistenceType.BEAN));
+
+        final EntityBean cmp = ejbJar.addEnterpriseBean(new EntityBean(MyCmpBean.class, PersistenceType.CONTAINER));
+        cmp.setPrimKeyClass(Integer.class.getName());
+        cmp.setPrimkeyField("id");
+        cmp.getCmpField().add(new CmpField("id"));
+        cmp.getCmpField().add(new CmpField("name"));
+        final Query query = new Query();
+        query.setQueryMethod(new QueryMethod("findByPrimaryKey", Integer.class.getName()));
+        query.setEjbQl("SELECT OBJECT(DL) FROM License DL");
+        cmp.getQuery().add(query);
+        final List<ContainerTransaction> transactions = ejbJar.getAssemblyDescriptor().getContainerTransaction();
+
+        transactions.add(new ContainerTransaction(TransAttribute.SUPPORTS, null, "MyBmpBean", "*"));
+        transactions.add(new ContainerTransaction(TransAttribute.SUPPORTS, null, "MyCmpBean", "*"));
+        transactions.add(new ContainerTransaction(TransAttribute.SUPPORTS, null, "MySingletonBean", "*"));
+
+        final File f = new File("test").getAbsoluteFile();
+        if (!f.exists() && !f.mkdirs()) {
+            throw new Exception("Failed to create test directory: " + f);
+        }
+
+        final EntityMappings entityMappings = new EntityMappings();
+
+        final org.apache.openejb.jee.jpa.Entity entity = new org.apache.openejb.jee.jpa.Entity();
+        entity.setClazz("openejb.org.apache.openejb.core.MyCmpBean");
+        entity.setName("MyCmpBean");
+        entity.setDescription("MyCmpBean");
+        entity.setAttributes(new Attributes());
+
+        final NamedQuery namedQuery = new NamedQuery();
+        namedQuery.setQuery("SELECT OBJECT(DL) FROM License DL");
+        entity.getNamedQuery().add(namedQuery);
+
+        final org.apache.openejb.jee.jpa.Id id = new org.apache.openejb.jee.jpa.Id();
+        id.setName("id");
+        entity.getAttributes().getId().add(id);
+
+        final Basic basic = new Basic();
+        basic.setName("name");
+        final Column column = new Column();
+        column.setName("wNAME");
+        column.setLength(300);
+        basic.setColumn(column);
+        entity.getAttributes().getBasic().add(basic);
+
+        entityMappings.getEntity().add(entity);
+
+        return new EjbModule(ejbJar);
+    }
+
+
+    @Test
+    public void shouldCreateEntityMapper() {
+        EntityManager entityManager = emf.createEntityManager();
+
+        User user = new User();
+        user.id = "id";
+        user.name = "ada";
+        entityManager.merge(user);
+
+        User user1 = entityManager.find(User.class, "id");
+        Assert.assertNotNull(user1);
+        System.out.println(user1);
+
+    }
+
+    @javax.persistence.Entity
+    public static class User {
+
+        @javax.persistence.Id
+        private String id;
+
+        @javax.persistence.Column
+        private String name;
+    }
+
+
+    @LocalHome(MyLocalHome.class)
+    @RemoteHome(MyRemoteHome.class)
+    public static abstract class MyCmpBean implements javax.ejb.EntityBean {
+
+        // CMP
+        public abstract Integer getId();
+
+        public abstract void setId(Integer id);
+
+        public abstract String getName();
+
+        public abstract void setName(String number);
+
+        public void doit() {
+        }
+
+        public Integer ejbCreateObject(final String id) throws CreateException {
+            return null;
+        }
+
+        public void ejbPostCreateObject(final String id) {
+        }
+
+        public void setEntityContext(final EntityContext ctx) {
+        }
+
+        public void unsetEntityContext() {
+        }
+
+        public void ejbActivate() {
+        }
+
+        public void ejbPassivate() {
+        }
+
+        public void ejbLoad() {
+        }
+
+        public void ejbStore() {
+        }
+
+        public void ejbRemove() throws RemoveException {
+        }
+    }
+
+    @LocalHome(MyLocalHome.class)
+    @RemoteHome(MyRemoteHome.class)
+    public class MyBmpBean implements javax.ejb.EntityBean {
+
+        public void doit() {
+        }
+
+        public java.util.Collection ejbFindEmptyCollection() throws javax.ejb.FinderException, java.rmi.RemoteException {
+            return new java.util.Vector();
+        }
+
+        public Integer ejbFindByPrimaryKey(final Integer primaryKey) throws javax.ejb.FinderException {
+            return new Integer(-1);
+        }
+
+        public Integer ejbCreateObject(final String name) throws javax.ejb.CreateException {
+            return new Integer(-1);
+        }
+
+        public void ejbPostCreateObject(final String name) throws javax.ejb.CreateException {
+        }
+
+
+        public void ejbLoad() throws EJBException, RemoteException {
+        }
+
+        public void setEntityContext(final EntityContext entityContext) throws EJBException, RemoteException {
+        }
+
+        public void unsetEntityContext() throws EJBException, RemoteException {
+        }
+
+        public void ejbStore() throws EJBException, RemoteException {
+        }
+
+        public void ejbRemove() throws RemoveException, EJBException, RemoteException {
+        }
+
+        public void ejbActivate() throws EJBException, RemoteException {
+        }
+
+        public void ejbPassivate() throws EJBException, RemoteException {
+        }
+    }
+
+    public interface MyRemoteHome extends javax.ejb.EJBHome {
+
+        MyRemoteObject createObject(String name)
+                throws javax.ejb.CreateException, java.rmi.RemoteException;
+
+        MyRemoteObject findByPrimaryKey(Integer primarykey)
+                throws javax.ejb.FinderException, java.rmi.RemoteException;
+
+        java.util.Collection findEmptyCollection()
+                throws javax.ejb.FinderException, java.rmi.RemoteException;
+
+    }
+
+    public interface MyRemoteObject extends javax.ejb.EJBObject {
+
+        public void doit() throws RemoteException;
+
+    }
+
+    public interface MyLocalHome extends javax.ejb.EJBLocalHome {
+
+        public MyLocalObject createObject(String name)
+                throws javax.ejb.CreateException;
+
+        public MyLocalObject findByPrimaryKey(Integer primarykey)
+                throws javax.ejb.FinderException;
+
+        public java.util.Collection findEmptyCollection()
+                throws javax.ejb.FinderException;
+
+    }
+
+    public interface MyLocalObject extends javax.ejb.EJBLocalObject {
+
+        public void doit();
+
+    }
+
+    @LocalHome(MySessionLocalHome.class)
+    @RemoteHome(MySessionRemoteHome.class)
+    public static class MySingletonBean implements javax.ejb.SessionBean {
+
+        public void doit() {
+        }
+
+        public void ejbCreateObject() throws javax.ejb.CreateException {
+        }
+
+        public void ejbActivate() throws EJBException, RemoteException {
+        }
+
+        public void ejbPassivate() throws EJBException, RemoteException {
+        }
+
+        public void ejbRemove() throws EJBException, RemoteException {
+        }
+
+        public void setSessionContext(final SessionContext sessionContext) throws EJBException, RemoteException {
+        }
+    }
+
+    public interface MySessionRemoteHome extends javax.ejb.EJBHome {
+         MySessionRemoteObject createObject()
+                throws javax.ejb.CreateException, java.rmi.RemoteException;
+    }
+
+    public interface MySessionRemoteObject extends javax.ejb.EJBObject {
+        void doit();
+    }
+
+    public interface MySessionLocalHome extends javax.ejb.EJBLocalHome {
+         MySessionLocalObject createObject()
+                throws javax.ejb.CreateException;
+    }
+
+    public interface MySessionLocalObject extends javax.ejb.EJBLocalObject {
+        public void doit();
+    }
+
+
+
+}

--- a/container/openejb-core/src/test/resources/org/apache/openejb/config/test-openejb-cmp-orm.xml
+++ b/container/openejb-core/src/test/resources/org/apache/openejb/config/test-openejb-cmp-orm.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<entity-mappings xmlns="http://java.sun.com/xml/ns/persistence/orm" version="1.0">
+  <entity class="MyCmpBean" name="MyCmpBean">
+    <description>MyCmpBean</description>
+    <named-query name="MyCmpBean.findByPrimaryKey(java.lang.Integer)">
+      <query>SELECT OBJECT(DL) FROM License DL</query>
+    </named-query>
+    <attributes>
+      <id name="id"/>
+      <basic name="name">
+        <column name="wNAME" length="300"/>
+      </basic>
+    </attributes>
+  </entity>
+</entity-mappings>

--- a/container/openejb-jee/src/main/java/org/apache/openejb/jee/JaxbJavaee.java
+++ b/container/openejb-jee/src/main/java/org/apache/openejb/jee/JaxbJavaee.java
@@ -315,11 +315,7 @@ public class JaxbJavaee {
             if (uri != null && (uri.startsWith("http://jboss.org") || uri.startsWith("urn:java:"))) { // ignore it to be able to read beans.xml with weld config for instances
                 ignore = true;
             } else {
-                if ("entity-mappings".equals(localName) && "entity-mappings".equals(localName)) {
-                    super.startElement("http://java.sun.com/xml/ns/javaee", localName, qname, atts);
-                } else {
-                    super.startElement("http://java.sun.com/xml/ns/persistence/orm", localName, qname, atts);
-                }
+                super.startElement("http://java.sun.com/xml/ns/javaee", localName, qname, atts);
             }
         }
 

--- a/container/openejb-jee/src/main/java/org/apache/openejb/jee/JaxbJavaee.java
+++ b/container/openejb-jee/src/main/java/org/apache/openejb/jee/JaxbJavaee.java
@@ -5,14 +5,14 @@
  * The ASF licenses this file to You under the Apache License, Version 2.0
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.apache.openejb.jee;
 
@@ -91,18 +91,7 @@ public class JaxbJavaee {
         return jaxbContext;
     }
 
-    /**
-     * Convert the namespaceURI in the input to the javaee URI, do not validate the xml, and read in a T.
-     *
-     * @param type Class of object to be read in
-     * @param in   input stream to read
-     * @param <T>  class of object to be returned
-     * @return a T read from the input stream
-     * @throws ParserConfigurationException is the SAX parser can not be configured
-     * @throws SAXException                 if there is an xml problem
-     * @throws JAXBException                if the xml cannot be marshalled into a T.
-     */
-    public static <T> Object unmarshalJavaee(final Class<T> type, final InputStream in) throws ParserConfigurationException, SAXException, JAXBException {
+    private static <T> Object unmarshalJavaee(final Class<T> type, final InputStream in, boolean filter) throws ParserConfigurationException, SAXException, JAXBException {
 
         final SAXParserFactory factory = SAXParserFactory.newInstance();
         factory.setNamespaceAware(true);
@@ -122,11 +111,16 @@ public class JaxbJavaee {
             }
         });
 
-        final JavaeeNamespaceFilter xmlFilter = new JavaeeNamespaceFilter(parser.getXMLReader());
-        xmlFilter.setContentHandler(unmarshaller.getUnmarshallerHandler());
+        SAXSource source = null;
+        if (filter) {
+            final JavaeeNamespaceFilter xmlFilter = new JavaeeNamespaceFilter(parser.getXMLReader());
+            xmlFilter.setContentHandler(unmarshaller.getUnmarshallerHandler());
+            // unmarshall
+            source = new SAXSource(xmlFilter, new InputSource(in));
+        } else {
+            source = new SAXSource(new InputSource(in));
+        }
 
-        // unmarshall
-        final SAXSource source = new SAXSource(xmlFilter, new InputSource(in));
 
         currentPublicId.set(new TreeSet<String>());
         try {
@@ -135,6 +129,37 @@ public class JaxbJavaee {
         } finally {
             currentPublicId.set(null);
         }
+    }
+
+    /**
+     *
+     * It unmarshals, but not using the {@link JavaeeNamespaceFilter}
+     *
+     * @param type Class of object to be read in
+     * @param in   input stream to read
+     * @param <T>  class of object to be returned
+     * @return a T read from the input stream
+     * @throws ParserConfigurationException is the SAX parser can not be configured
+     * @throws SAXException                 if there is an xml problem
+     * @throws JAXBException                if the xml cannot be marshalled into a T.
+     */
+    public static <T> Object unmarshal(final Class<T> type, final InputStream in) throws ParserConfigurationException, SAXException, JAXBException {
+        return unmarshalJavaee(type, in, false);
+    }
+
+    /**
+     * Convert the namespaceURI in the input to the javaee URI, do not validate the xml, and read in a T.
+     *
+     * @param type Class of object to be read in
+     * @param in   input stream to read
+     * @param <T>  class of object to be returned
+     * @return a T read from the input stream
+     * @throws ParserConfigurationException is the SAX parser can not be configured
+     * @throws SAXException                 if there is an xml problem
+     * @throws JAXBException                if the xml cannot be marshalled into a T.
+     */
+    public static <T> Object unmarshalJavaee(final Class<T> type, final InputStream in) throws ParserConfigurationException, SAXException, JAXBException {
+        return unmarshalJavaee(type, in, true);
     }
 
     /**
@@ -290,7 +315,11 @@ public class JaxbJavaee {
             if (uri != null && (uri.startsWith("http://jboss.org") || uri.startsWith("urn:java:"))) { // ignore it to be able to read beans.xml with weld config for instances
                 ignore = true;
             } else {
-                super.startElement("http://java.sun.com/xml/ns/javaee", localName, qname, atts);
+                if ("entity-mappings".equals(localName) && "entity-mappings".equals(localName)) {
+                    super.startElement("http://java.sun.com/xml/ns/javaee", localName, qname, atts);
+                } else {
+                    super.startElement("http://java.sun.com/xml/ns/persistence/orm", localName, qname, atts);
+                }
             }
         }
 
@@ -327,7 +356,7 @@ public class JaxbJavaee {
 
         protected String eeUri(final String uri) {
             // if ee 7 then switch back on ee 6 to not break compatibility - to rework surely when we'll be fully ee 7
-            return "http://xmlns.jcp.org/xml/ns/javaee".equals(uri) ? "http://java.sun.com/xml/ns/javaee": uri;
+            return "http://xmlns.jcp.org/xml/ns/javaee".equals(uri) ? "http://java.sun.com/xml/ns/javaee" : uri;
         }
 
         @Override
@@ -555,10 +584,10 @@ public class JaxbJavaee {
         schemaFactory.setResourceResolver(resourceResolver);
 
         final Schema schema = schemaFactory.newSchema(
-            new Source[]{
-                new StreamSource(xmlSchemaURL.openStream()),
-                new StreamSource(javaeeSchemaURL.openStream())
-            });
+                new Source[]{
+                        new StreamSource(xmlSchemaURL.openStream()),
+                        new StreamSource(javaeeSchemaURL.openStream())
+                });
 
         // validate
         schema.newValidator().validate(sourceForValidate);


### PR DESCRIPTION
We found an error when using CMP; when the container starts, it returns an unmarshal error:


```java

	at com.sun.xml.bind.v2.runtime.unmarshaller.UnmarshallingContext.handleEvent(UnmarshallingContext.java:662)
	at com.sun.xml.bind.v2.runtime.unmarshaller.Loader.reportError(Loader.java:258)
	at com.sun.xml.bind.v2.runtime.unmarshaller.Loader.reportError(Loader.java:253)
	at com.sun.xml.bind.v2.runtime.unmarshaller.Loader.reportUnexpectedChildElement(Loader.java:120)
	at com.sun.xml.bind.v2.runtime.unmarshaller.Loader.childElement(Loader.java:105)
	at com.sun.xml.bind.v2.runtime.unmarshaller.StructureLoader.childElement(StructureLoader.java:262)
	at com.sun.xml.bind.v2.runtime.unmarshaller.UnmarshallingContext._startElement(UnmarshallingContext.java:498)
	at com.sun.xml.bind.v2.runtime.unmarshaller.UnmarshallingContext.startElement(UnmarshallingContext.java:480)
	at com.sun.xml.bind.v2.runtime.unmarshaller.SAXConnector.startElement(SAXConnector.java:150)
	at org.xml.sax.helpers.XMLFilterImpl.startElement(XMLFilterImpl.java:551)
	at org.apache.openejb.jee.JaxbJavaee$JavaeeNamespaceFilter.startElement(JaxbJavaee.java:291)
	at com.sun.org.apache.xerces.internal.parsers.AbstractSAXParser.startElement(AbstractSAXParser.java:509)
	at com.sun.org.apache.xerces.internal.impl.XMLDocumentFragmentScannerImpl.scanStartElement(XMLDocumentFragmentScannerImpl.java:1359)
	at com.sun.org.apache.xerces.internal.impl.XMLDocumentFragmentScannerImpl$FragmentContentDriver.next(XMLDocumentFragmentScannerImpl.java:2784)
	at com.sun.org.apache.xerces.internal.impl.XMLDocumentScannerImpl.next(XMLDocumentScannerImpl.java:602)
	at com.sun.org.apache.xerces.internal.impl.XMLDocumentFragmentScannerImpl.scanDocument(XMLDocumentFragmentScannerImpl.java:505)
	at com.sun.org.apache.xerces.internal.parsers.XML11Configuration.parse(XML11Configuration.java:842)
	at com.sun.org.apache.xerces.internal.parsers.XML11Configuration.parse(XML11Configuration.java:771)
	at com.sun.org.apache.xerces.internal.parsers.XMLParser.parse(XMLParser.java:141)
	at com.sun.org.apache.xerces.internal.parsers.AbstractSAXParser.parse(AbstractSAXParser.java:1213)
	at com.sun.org.apache.xerces.internal.jaxp.SAXParserImpl$JAXPSAXParser.parse(SAXParserImpl.java:643)
	at org.xml.sax.helpers.XMLFilterImpl.parse(XMLFilterImpl.java:357)
	at com.sun.xml.bind.v2.runtime.unmarshaller.UnmarshallerImpl.unmarshal0(UnmarshallerImpl.java:258)
	at com.sun.xml.bind.v2.runtime.unmarshaller.UnmarshallerImpl.unmarshal(UnmarshallerImpl.java:236)
	at com.sun.xml.bind.v2.runtime.unmarshaller.UnmarshallerImpl.unmarshal(UnmarshallerImpl.java:288)
```

I found the error at the  `JavaeeNamespaceFilter` that initially I try to use either Strategy or Strategy to do a bypass on this filter when is CMP. However, with a not good result. So, I created a more straightforward solution that creates a new method that does not use this filter.