### PR TITLE
Uses Boolean.valueof instaed of new instance

### DIFF
--- a/container/openejb-core/src/main/java/org/apache/openejb/core/singleton/SingletonEjbObjectHandler.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/core/singleton/SingletonEjbObjectHandler.java
@@ -52,7 +52,7 @@ public class SingletonEjbObjectHandler extends EjbObjectProxyHandler {
     protected Object isIdentical(final Method method, final Object[] args, final Object proxy) throws Throwable {
         try {
             final EjbObjectProxyHandler handler = (EjbObjectProxyHandler) ProxyManager.getInvocationHandler(args[0]);
-            return new Boolean(deploymentID.equals(handler.deploymentID)); //NOPMD
+            return Boolean.valueOf(deploymentID.equals(handler.deploymentID)); //NOPMD
         } catch (final Throwable t) {
             return Boolean.FALSE;
         }


### PR DESCRIPTION
While I was studying the code, I found at SingletonEjbObjectHandler.java that they are creating a new Boolean instance instead of using the `Boolean.valueOf.` method.
The boolean wrapper has a singleton instance to both true and false. However, it will use when the code uses the Boolean.valueOf method.

Beyond the waste of memory, because they're creating a new `boolean` instance every time, it will be slower than the `valueOf` method.

```java
@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
@Measurement(iterations = 20, time = 1, timeUnit = TimeUnit.SECONDS)
@Fork(3)
@BenchmarkMode(Mode.AverageTime)
@OutputTimeUnit(TimeUnit.NANOSECONDS)
@State(Scope.Thread)
public class FasterReflectionClientBenchmark {

    private ThreadLocalRandom random = ThreadLocalRandom.current();

    @Benchmark
    public Boolean newInstance() {
        return new Boolean(random.nextBoolean());
    }

    @Benchmark
    public Boolean valueOf() {
        return Boolean.valueOf(random.nextBoolean());
    }
}
```

|Benchmark|Mode|Cnt|Score| Obs|
| ------------- |:------|-----|----:| ------:|
|valueOf|      avgt|   60|  5,048| ---|
|newInstance  |avgt|   60|  6,467|  (20% slower)|




ps: The equals method returns a primitive value if we keep without the wrapper, it will automatically do a wrapper using the  `Boolean.valueOf.`