### PR TITLE
Avoid String in a loop

### DIFF
--- a/container/openejb-core/src/main/java/org/apache/openejb/assembler/classic/Assembler.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/assembler/classic/Assembler.java
@@ -786,12 +786,13 @@ public class Assembler extends AssemblerTool implements org.apache.openejb.spi.A
             final List<String> used = getDuplicates(appInfo);
 
             if (used.size() > 0) {
-                String message = logger.error("createApplication.appFailedDuplicateIds", appInfo.path);
+                StringBuilder message = new StringBuilder(logger.error("createApplication.appFailedDuplicateIds"
+                        , appInfo.path));
                 for (final String id : used) {
                     logger.error("createApplication.deploymentIdInUse", id);
-                    message += "\n    " + id;
+                    message.append("\n    ").append(id);
                 }
-                throw new DuplicateDeploymentIdException(message);
+                throw new DuplicateDeploymentIdException(message.toString());
             }
 
             final ClassLoader oldCl = Thread.currentThread().getContextClassLoader();

--- a/container/openejb-core/src/main/java/org/apache/openejb/config/AnnotationDeployer.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/config/AnnotationDeployer.java
@@ -2939,12 +2939,14 @@ public class AnnotationDeployer implements DynamicDeployer {
                         }
 
                         if (interfaces.size() != 1) {
-                            String msg = "When annotating a bean class as @MessageDriven without declaring messageListenerInterface, the bean must implement exactly one interface, no more and no less. beanClass=" + clazz.getName() + " interfaces=";
+                            StringBuilder msg = new StringBuilder("When annotating a bean class as @MessageDriven without" +
+                                    " declaring messageListenerInterface, the bean must implement exactly one interface, no more and" +
+                                    " no less. beanClass=" + clazz.getName() + " interfaces=");
                             for (final Class<?> intf : interfaces) {
-                                msg += intf.getName() + ", ";
+                                msg.append(intf.getName()).append(", ");
                             }
                             // TODO: Make this a validation failure, not an exception
-                            throw new IllegalStateException(msg);
+                            throw new IllegalStateException(msg.toString());
                         }
                         mdb.setMessagingType(interfaces.get(0).getName());
                     }

--- a/container/openejb-core/src/main/java/org/apache/openejb/config/SunConversion.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/config/SunConversion.java
@@ -1170,7 +1170,7 @@ public class SunConversion implements DynamicDeployer {
         final List bits = Collections.list(new StringTokenizer(queryFilter, " \t\n\r\f()&|<>=!~+-/*", true));
 
         boolean inWitespace = false;
-        String currentSymbol = "";
+        StringBuilder currentSymbol = new StringBuilder();
         for (int i = 0; i < bits.size(); i++) {
             final TokenType tokenType;
             final String bit = (String) bits.get(i);
@@ -1190,7 +1190,7 @@ public class SunConversion implements DynamicDeployer {
                 case '<':
                 case '!':
                     // symbols are blindly coalesced so you can end up with nonsence like +-=+
-                    currentSymbol += bit.charAt(0);
+                    currentSymbol.append(bit.charAt(0));
                     tokenType = TokenType.SYMBOL;
                     break;
                 default:
@@ -1201,8 +1201,8 @@ public class SunConversion implements DynamicDeployer {
                 inWitespace = false;
             }
             if (tokenType != TokenType.SYMBOL && currentSymbol.length() > 0) {
-                tokens.add(currentSymbol);
-                currentSymbol = "";
+                tokens.add(currentSymbol.toString());
+                currentSymbol = new StringBuilder();
             }
             if (tokenType == TokenType.NORMAL) {
                 tokens.add(bit);
@@ -1210,8 +1210,8 @@ public class SunConversion implements DynamicDeployer {
         }
         // add saved symobl if we have one
         if (currentSymbol.length() > 0) {
-            tokens.add(currentSymbol);
-            currentSymbol = "";
+            tokens.add(currentSymbol.toString());
+            currentSymbol = new StringBuilder();
         }
         // strip off leading space
         if (tokens.getFirst().equals(" ")) {

--- a/container/openejb-core/src/main/java/org/apache/openejb/monitoring/ObjectNameBuilder.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/monitoring/ObjectNameBuilder.java
@@ -66,7 +66,7 @@ public class ObjectNameBuilder {
 
             return new ObjectName(sb.toString());
         } catch (final MalformedObjectNameException e) {
-            throw new IllegalStateException("Failed to build valid name for: " + sb.toString(), e);
+            throw new IllegalStateException("Failed to build valid name for: " + sb, e);
         }
     }
 

--- a/container/openejb-core/src/main/java/org/apache/openejb/resource/AutoConnectionTracker.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/resource/AutoConnectionTracker.java
@@ -140,7 +140,7 @@ public class AutoConnectionTracker implements ConnectionTracker {
                                     sb.append("\n  ").append("Connection handle opened at ").append(stackTraceToString(connectionInfo.getTrace().getStackTrace()));
                                 }
 
-                                logger.warning("Transaction complete, but connection still has handles associated: " + managedConnectionInfo + "\nAbandoned connection information: " + sb.toString());
+                                logger.warning("Transaction complete, but connection still has handles associated: " + managedConnectionInfo + "\nAbandoned connection information: " + sb);
                             }
                         }
                     }

--- a/container/openejb-core/src/main/java/org/apache/openejb/resource/jdbc/logging/LoggingPreparedSqlStatement.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/resource/jdbc/logging/LoggingPreparedSqlStatement.java
@@ -75,13 +75,13 @@ public class LoggingPreparedSqlStatement implements InvocationHandler {
 
             parameters.add(param);
         } else if (execute) {
-            String str = sql;
-            if (str.contains("?")) {
+            StringBuilder str = new StringBuilder(sql);
+            if (str.toString().contains("?")) {
                 Collections.sort(parameters);
                 int lastBatch = 0;
                 for (int i = 0; i < parameters.size(); i++) {
                     final Parameter param = parameters.get(i);
-                    if (str.contains("?")) {
+                    if (str.toString().contains("?")) {
                         try {
                             String val;
                             if (ByteArrayInputStream.class.isInstance(param.value)) {
@@ -95,40 +95,40 @@ public class LoggingPreparedSqlStatement implements InvocationHandler {
                             } else {
                                 val = param.value.toString();
                             }
-                            str = str.replaceFirst("\\?", val);
+                            str = new StringBuilder(str.toString().replaceFirst("\\?", val));
                         } catch (final Exception e) {
                             if (param.value == null) {
-                                str = str.replaceFirst("\\?", "null");
+                                str = new StringBuilder(str.toString().replaceFirst("\\?", "null"));
                             } else {
-                                str = str.replaceFirst("\\?", param.value.getClass().getName());
+                                str = new StringBuilder(str.toString().replaceFirst("\\?", param.value.getClass().getName()));
                             }
                         }
                         lastBatch = param.batchIndex;
                     } else {
                         if (lastBatch != param.batchIndex) {
-                            str += ", (";
+                            str.append(", (");
                             lastBatch = param.batchIndex;
                         }
 
                         try {
-                            str += param.value.toString();
+                            str.append(param.value.toString());
                         } catch (final Exception e) {
                             if (param.value == null) {
-                                str += "null";
+                                str.append("null");
                             } else {
-                                str += param.value.getClass().getName();
+                                str.append(param.value.getClass().getName());
                             }
                         }
 
                         if (i == parameters.size() - 1 || parameters.get(i + 1).batchIndex != lastBatch) {
-                            str += ")";
+                            str.append(")");
                         } else {
-                            str += ",";
+                            str.append(",");
                         }
                     }
                 }
             }
-            LOGGER.info(result.format(str) + (packages != null ? " - stack:" + TimeWatcherExecutor.inlineStack(packages) : ""));
+            LOGGER.info(result.format(str.toString()) + (packages != null ? " - stack:" + TimeWatcherExecutor.inlineStack(packages) : ""));
         } else if ("clearParameters".equals(mtdName)) {
             parameters.clear();
             parameterIndex = 0;

--- a/container/openejb-loader/src/main/java/org/apache/openejb/loader/provisining/MavenResolver.java
+++ b/container/openejb-loader/src/main/java/org/apache/openejb/loader/provisining/MavenResolver.java
@@ -281,7 +281,7 @@ public class MavenResolver implements ArchiveResolver, ProvisioningResolverAware
             parser.parse(metadata, handler);
             if (handler.timestamp != null && handler.buildNumber != null) {
                 return defaultVersion.substring(0, defaultVersion.length() - SNAPSHOT_SUFFIX.length())
-                        + "-" + handler.timestamp.toString() + "-" + handler.buildNumber.toString();
+                        + "-" + handler.timestamp + "-" + handler.buildNumber;
             }
         } catch (final Exception e) {
             // no-op: not parseable so ignoring

--- a/tomee/tomee-webapp/src/main/java/org/apache/tomee/webapp/installer/InstallerServlet.java
+++ b/tomee/tomee-webapp/src/main/java/org/apache/tomee/webapp/installer/InstallerServlet.java
@@ -49,7 +49,7 @@ public class InstallerServlet extends HttpServlet {
         if (!list.isEmpty()) {
             sb.deleteCharAt(sb.length() - 1);
         }
-        return "[" + sb.toString() + "]";
+        return "[" + sb + "]";
     }
 
     @Override


### PR DESCRIPTION
The reason to prefer StringBuilder is that both + and concat create a new object every time you call them (provided the right-hand side argument is not empty). This can quickly add up to a lot of objects, almost all of which are completely unnecessary.

```java
public class Main
{
    public static void main(String[] args)
    {
        long now = System.currentTimeMillis();
        slow();
        System.out.println("slow elapsed " + (System.currentTimeMillis() - now) + " ms");

        now = System.currentTimeMillis();
        fast();
        System.out.println("fast elapsed " + (System.currentTimeMillis() - now) + " ms");
    }

    private static void fast()
    {
        StringBuilder s = new StringBuilder();
        for(int i=0;i<100000;i++)
            s.append("*");      
    }

    private static void slow()
    {
        String s = "";
        for(int i=0;i<100000;i++)
            s+="*";
    }
}
```

* slow elapsed 11741 ms
* fast elapsed 7 ms

Also, this PR avoids unnecessary call in StringBuilder