### PR TITLE
Fixing documentation on some of the examples

### DIFF
--- a/examples/mp-metrics-timed/README.md
+++ b/examples/mp-metrics-timed/README.md
@@ -5,7 +5,7 @@ This is an example on how to use MicroProfile metrics in TomEE.
 
     mvn clean install tomee:run 
 
-Within the application there is an endpoint that will give you weather status for the day.
+Within the application there is an endpoint that will give you the weather status for the day.
 
 ##### For the day status call:
 
@@ -124,7 +124,7 @@ For json format add the header _Accept=application/json_ to the request.
     }
    
 #### Metric metadata
-A metric will have a metadata so you can know more information about it, like displayName, description, tags e etc.
+A metric will have metadata so you can know more about it, like displayName, description, tags e etc.
 
 Check the metric metadata doing a _OPTIONS_ request:
 

--- a/examples/quartz-app/README.md
+++ b/examples/quartz-app/README.md
@@ -1,6 +1,6 @@
 Title: Quartz Resource Adapter usage
 
-Note this example is somewhat dated.  It predates the schedule API which was added to EJB 3.1.  Modern applications should use the schedule API which has many, if not all,
+Note: this example is somewhat dated.  It predates the schedule API which was added to EJB 3.1.  Modern applications should use the schedule API which has many, if not all,
 the same features as Quartz.  In fact, Quartz is the engine that drives the `@Schedule` and `ScheduleExpression` support in OpenEJB and TomEE.
 
 Despite being dated from a scheduling perspective it is still an excellent reference for how to plug-in and test a custom Java EE Resource Adapter.
@@ -8,9 +8,9 @@ Despite being dated from a scheduling perspective it is still an excellent refer
 # Project structure
 
 As `.rar` files do not do well on a standard classpath structure the goal is to effectively "unwrap" the `.rar` so that its dependencies are on the classpath and its `ra.xml` file
-can be found in scanned by OpenEJB.
+can be found and scanned by OpenEJB.
 
-We do this by creating a mini maven module to represent the rar in maven terms.  The `pom.xml` of the "rar module" declares all of the jars that would be inside `.rar` as maven
+We do this by creating a mini maven module to represent the `.rar` in maven terms.  The `pom.xml` of the "rar module" declares all of the jars that would be inside the `.rar` as maven
 dependencies.  The `ra.xml` file is added to the project in `src/main/resources/META-INF/ra.xml` where it will be visible to other modules.
 
     quartz-app

--- a/examples/realm-in-tomee/README.md
+++ b/examples/realm-in-tomee/README.md
@@ -23,9 +23,9 @@ Then this datasource is referenced in server.xml:
         userRoleTable="user_roles"
         roleNameCol="role_name"/>
 
-To initialize the datasource (for the test) we used the TomEE hook which consists in providing
-a file import-<datasource name>.sql. It should be in the classpath of the datasource so here it is
-the TomEE classpath so we added it to lib (by default in the classloader). It simply contains the
+To initialize the datasource (for the test) we used the TomEE hook which provides 
+a file import-<datasource name>.sql. The file should be in the classpath of the datasource 
+so we added it to lib (by default in the classloader). It simply contains the
 table creations and the insertion of the "admin" "tomee" with the password "tomee".
 
 ## Test it

--- a/examples/reload-persistence-unit-properties/README.md
+++ b/examples/reload-persistence-unit-properties/README.md
@@ -2,7 +2,7 @@ Title: Reload Persistence Unit Properties
 
 This example aims to simulate a benchmark campaign on JPA.
 
-First you'll run your application then you'll realize you could need L2 cache to respect your SLA.
+First you'll run your application then you'll realize you need an L2 cache to conform to your Service Level Agreement (SLA).
 
 So you change your persistence.xml configuration, then restart your application,
 you wait a bit because you are using OpenEJB ;)...but you wait...
@@ -12,9 +12,9 @@ your configuration file to keep the modification.
 
 To do it we can simply use JMX.
 
-OpenEJB automatically register one MBeans by entitymanager (persistence unit).
+OpenEJB automatically registers one MBean by entitymanager (persistence unit).
 
-It allows you mainly to change your persistence unit properties even if more is possible.
+It allows you to change your persistence unit properties even if more is possible.
 
 ## The test itself
 


### PR DESCRIPTION
I've noticed that some of the README.mb files have text that could be improved. These commits improve the text on those examples.