### PR TITLE
Improve performance using Collections in TomEE container

### DIFF
--- a/container/openejb-core/src/main/java/org/apache/openejb/BeanContext.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/BeanContext.java
@@ -211,8 +211,7 @@ public class BeanContext extends DeploymentContext {
         if (timeout != null) {
             final AnnotatedType annotatedType = cdiEjbBean.getAnnotatedType();
             final AnnotationManager annotationManager = getWebBeansContext().getAnnotationManager();
-            final Collection<Annotation> annotations = new HashSet<>();
-            annotations.addAll(annotationManager.getInterceptorAnnotations(annotatedType.getAnnotations()));
+            final Collection<Annotation> annotations = new HashSet<>(annotationManager.getInterceptorAnnotations(annotatedType.getAnnotations()));
             final Set<AnnotatedMethod<?>> methods = annotatedType.getMethods();
             for (final AnnotatedMethod<?> m : methods) {
                 if (timeout.equals(m.getJavaMember())) {

--- a/container/openejb-core/src/main/java/org/apache/openejb/BeanContext.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/BeanContext.java
@@ -691,13 +691,9 @@ public class BeanContext extends DeploymentContext {
 
         final ArrayList<Class> classes = new ArrayList<>();
 
-        for (final Class local : businessRemotes) {
-            classes.add(local);
-        }
+        classes.addAll(businessRemotes);
 
-        for (final Class local : businessLocals) {
-            classes.add(local);
-        }
+        classes.addAll(businessLocals);
 
         classes.add(this.beanClass);
 

--- a/container/openejb-core/src/main/java/org/apache/openejb/ClassLoaderUtil.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/ClassLoaderUtil.java
@@ -334,8 +334,7 @@ public class ClassLoaderUtil {
             urls = rawUrls;
         } else {
             final CompositeClassLoaderConfigurer configurer = new CompositeClassLoaderConfigurer(configurer1, configurer2, configurer3);
-            final Collection<URL> list = new ArrayList<>();
-            list.addAll(Arrays.asList(rawUrls));
+            final Collection<URL> list = new ArrayList<>(Arrays.asList(rawUrls));
             ClassLoaderConfigurer.Helper.configure(list, configurer);
             urls = list.toArray(new URL[list.size()]);
         }

--- a/container/openejb-core/src/main/java/org/apache/openejb/OpenEjbContainer.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/OpenEjbContainer.java
@@ -278,8 +278,7 @@ public final class OpenEjbContainer extends EJBContainer {
 
                 final Set<String> callers;
                 if (map.containsKey(OPENEJB_ADDITIONNAL_CALLERS_KEY)) {
-                    callers = new LinkedHashSet<>();
-                    callers.addAll(Arrays.asList(((String) map.get(OPENEJB_ADDITIONNAL_CALLERS_KEY)).split(",")));
+                    callers = new LinkedHashSet<>(Arrays.asList(((String) map.get(OPENEJB_ADDITIONNAL_CALLERS_KEY)).split(",")));
                 } else {
                     callers = NewLoaderLogic.callers();
                 }

--- a/container/openejb-core/src/main/java/org/apache/openejb/assembler/classic/Assembler.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/assembler/classic/Assembler.java
@@ -1416,18 +1416,10 @@ public class Assembler extends AssemblerTool implements org.apache.openejb.spi.A
         final List<CommonInfoObject> vfs = new ArrayList<>(
             appInfo.clients.size() + appInfo.connectors.size() +
                 appInfo.ejbJars.size() + appInfo.webApps.size());
-        for (final ClientInfo clientInfo : appInfo.clients) {
-            vfs.add(clientInfo);
-        }
-        for (final ConnectorInfo connectorInfo : appInfo.connectors) {
-            vfs.add(connectorInfo);
-        }
-        for (final EjbJarInfo ejbJarInfo : appInfo.ejbJars) {
-            vfs.add(ejbJarInfo);
-        }
-        for (final WebAppInfo webAppInfo : appInfo.webApps) {
-            vfs.add(webAppInfo);
-        }
+        vfs.addAll(appInfo.clients);
+        vfs.addAll(appInfo.connectors);
+        vfs.addAll(appInfo.ejbJars);
+        vfs.addAll(appInfo.webApps);
         return vfs;
     }
 
@@ -2422,12 +2414,8 @@ public class Assembler extends AssemblerTool implements org.apache.openejb.spi.A
             final List<String> clientIds = new ArrayList<>();
             for (final ClientInfo clientInfo : appInfo.clients) {
                 clientIds.add(clientInfo.moduleId);
-                for (final String className : clientInfo.localClients) {
-                    clientIds.add(className);
-                }
-                for (final String className : clientInfo.remoteClients) {
-                    clientIds.add(className);
-                }
+                clientIds.addAll(clientInfo.localClients);
+                clientIds.addAll(clientInfo.remoteClients);
             }
 
             for (final WebContext webContext : appContext.getWebContexts()) {

--- a/container/openejb-core/src/main/java/org/apache/openejb/assembler/classic/Assembler.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/assembler/classic/Assembler.java
@@ -611,10 +611,9 @@ public class Assembler extends AssemblerTool implements org.apache.openejb.spi.A
             containerInfos.add(serviceInfo);
         }
 
-        final Set<String> apps = appContainers.keySet();
-        for (final String app : apps) {
-            final List<ContainerInfo> containerInfos = appContainers.get(app);
-            final ClassLoader classLoader = appClassLoaders.get(app);
+        for (final Entry<String, List<ContainerInfo>> stringListEntry : appContainers.entrySet()) {
+            final List<ContainerInfo> containerInfos = stringListEntry.getValue();
+            final ClassLoader classLoader = appClassLoaders.get(stringListEntry.getKey());
 
             final ClassLoader oldCl = Thread.currentThread().getContextClassLoader();
 

--- a/container/openejb-core/src/main/java/org/apache/openejb/assembler/classic/EnterpriseBeanBuilder.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/assembler/classic/EnterpriseBeanBuilder.java
@@ -40,6 +40,7 @@ import javax.persistence.SynchronizationType;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -387,7 +388,7 @@ class EnterpriseBeanBuilder {
                         candidateInfo.className = info.className;
                         candidateInfo.id = info.id;
                         candidateInfo.methodName = info.methodName;
-                        candidateInfo.methodParams = Arrays.asList(Timer.class.getName());
+                        candidateInfo.methodParams = Collections.singletonList(Timer.class.getName());
                         timeout = MethodInfoUtil.toMethod(ejbClass, candidateInfo);
                     }
                 }

--- a/container/openejb-core/src/main/java/org/apache/openejb/assembler/classic/InterceptorBindingBuilder.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/assembler/classic/InterceptorBindingBuilder.java
@@ -30,8 +30,8 @@ import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.EnumSet;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -206,7 +206,7 @@ public class InterceptorBindingBuilder {
         //    - Any addition for current level and/or exclusion for a lower level
         //   (lowest)
         //
-        final Set<Level> excludes = new HashSet<>();
+        final Set<Level> excludes = EnumSet.noneOf(Level.class);
         for (final InterceptorBindingInfo info : bindings) {
             final Level level = level(info);
 

--- a/container/openejb-core/src/main/java/org/apache/openejb/assembler/classic/MethodInfoUtil.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/assembler/classic/MethodInfoUtil.java
@@ -432,10 +432,9 @@ public class MethodInfoUtil {
     }
 
     private static List<Method> getWildCardView(final BeanContext info) {
-        final List<Method> methods = new ArrayList<>();
 
         final List<Method> beanMethods = asList(info.getBeanClass().getMethods());
-        methods.addAll(beanMethods);
+        final List<Method> methods = new ArrayList<>(beanMethods);
 
         if (info.getRemoteInterface() != null) {
             methods.addAll(exclude(beanMethods, info.getRemoteInterface().getMethods()));

--- a/container/openejb-core/src/main/java/org/apache/openejb/assembler/classic/ValidatorBuilder.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/assembler/classic/ValidatorBuilder.java
@@ -96,9 +96,7 @@ public final class ValidatorBuilder {
             for (final PropertyType p : config.getProperty()) {
                 info.propertyTypes.put(p.getName(), p.getValue());
             }
-            for (final String element : config.getConstraintMapping()) {
-                info.constraintMappings.add(element);
-            }
+            info.constraintMappings.addAll(config.getConstraintMapping());
         }
         return info;
     }

--- a/container/openejb-core/src/main/java/org/apache/openejb/assembler/classic/ValidatorBuilder.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/assembler/classic/ValidatorBuilder.java
@@ -50,6 +50,7 @@ import javax.validation.valueextraction.ValueExtractor;
 import java.io.InputStream;
 import java.io.Serializable;
 import java.util.Collection;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -161,7 +162,7 @@ public final class ValidatorBuilder {
             thread.setContextClassLoader(classLoader);
         }
 
-        final Set<ExecutableType> types = new HashSet<>();
+        final Set<ExecutableType> types = EnumSet.noneOf(ExecutableType.class);
         for (final String type : info.validatedTypes) {
             types.add(ExecutableType.valueOf(type));
         }

--- a/container/openejb-core/src/main/java/org/apache/openejb/cdi/WebappBeanManager.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/cdi/WebappBeanManager.java
@@ -90,8 +90,7 @@ public class WebappBeanManager extends BeanManagerImpl {
 
     @Override
     public <T> Set<ObserverMethod<? super T>> resolveObserverMethods(final T event, final EventMetadataImpl metadata) {
-        final Set<ObserverMethod<? super T>> set = new HashSet<>();
-        set.addAll(super.resolveObserverMethods(event, metadata));
+        final Set<ObserverMethod<? super T>> set = new HashSet<>(super.resolveObserverMethods(event, metadata));
 
         if (isEvent(event)) {
             final BeanManagerImpl parentBm = getParentBm();

--- a/container/openejb-core/src/main/java/org/apache/openejb/config/AnnotationDeployer.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/config/AnnotationDeployer.java
@@ -3127,7 +3127,7 @@ public class AnnotationDeployer implements DynamicDeployer {
             all.local.addAll(xml.local);
             all.remote.addAll(xml.remote);
 
-            final List<Class<?>> classes = strict ? new ArrayList(Arrays.asList(beanClass)) : Classes.ancestors(beanClass);
+            final List<Class<?>> classes = strict ? new ArrayList(Collections.singletonList(beanClass)) : Classes.ancestors(beanClass);
 
             for (final Class<?> clazz : classes) {
 

--- a/container/openejb-core/src/main/java/org/apache/openejb/config/AutoConfig.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/config/AutoConfig.java
@@ -2287,19 +2287,19 @@ public class AutoConfig implements DynamicDeployer, JndiConstants {
             for (final String s : resourceAdapterIds) {
                 logger.debug(appId + " module contains resource adapter id: " + s);
             }
-            for (final String s : resourceIdsByType.keySet()) {
-                for (final String value : resourceIdsByType.get(s)) {
-                    logger.debug(appId + " module contains resource type: " + s + " --> " + value);
+            for (final Map.Entry<String, List<String>> stringListEntry : resourceIdsByType.entrySet()) {
+                for (final String value : stringListEntry.getValue()) {
+                    logger.debug(appId + " module contains resource type: " + stringListEntry.getKey() + " --> " + value);
                 }
             }
-            for (final String s : resourceEnvIdsByType.keySet()) {
-                for (final String value : resourceEnvIdsByType.get(s)) {
-                    logger.debug(appId + " module contains resource env type: " + s + " --> " + value);
+            for (final Map.Entry<String, List<String>> stringListEntry : resourceEnvIdsByType.entrySet()) {
+                for (final String value : stringListEntry.getValue()) {
+                    logger.debug(appId + " module contains resource env type: " + stringListEntry.getKey() + " --> " + value);
                 }
             }
-            for (final String s : containerIdsByType.keySet()) {
-                for (final String value : containerIdsByType.get(s)) {
-                    logger.debug(appId + " module contains container type: " + s + " --> " + value);
+            for (final Map.Entry<String, List<String>> stringListEntry : containerIdsByType.entrySet()) {
+                for (final String value : stringListEntry.getValue()) {
+                    logger.debug(appId + " module contains container type: " + stringListEntry.getKey() + " --> " + value);
                 }
             }
         }

--- a/container/openejb-core/src/main/java/org/apache/openejb/config/ConfigurableClasspathArchive.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/config/ConfigurableClasspathArchive.java
@@ -34,6 +34,7 @@ import java.net.URLClassLoader;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -56,7 +57,7 @@ public class ConfigurableClasspathArchive extends CompositeArchive implements Sc
     }
 
     public ConfigurableClasspathArchive(final ClassLoader loader, final URL url) {
-        this(new FakeModule(loader), Arrays.asList(url));
+        this(new FakeModule(loader), Collections.singletonList(url));
     }
 
     public ConfigurableClasspathArchive(final Module module, final boolean forceDescriptor, final Iterable<URL> urls) {

--- a/container/openejb-core/src/main/java/org/apache/openejb/config/ConfigurationFactory.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/config/ConfigurationFactory.java
@@ -1711,15 +1711,11 @@ public class ConfigurationFactory implements OpenEjbConfigurationFactory {
 
         final OpenEjbConfiguration runningConfig = getRunningConfig();
         if (runningConfig != null) {
-            for (final ContainerInfo containerInfo : runningConfig.containerSystem.containers) {
-                containers.add(containerInfo);
-            }
+            containers.addAll(runningConfig.containerSystem.containers);
         }
 
         if (sys != null) {
-            for (final ContainerInfo containerInfo : sys.containerSystem.containers) {
-                containers.add(containerInfo);
-            }
+            containers.addAll(sys.containerSystem.containers);
         }
         return containers;
     }

--- a/container/openejb-core/src/main/java/org/apache/openejb/config/DeploymentLoader.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/config/DeploymentLoader.java
@@ -837,7 +837,8 @@ public class DeploymentLoader implements DeploymentFilterable {
         {
             final Object pXml = appModule.getAltDDs().get("persistence.xml");
 
-            List<URL> persistenceXmls = pXml == null ? null : (List.class.isInstance(pXml) ? (List<URL>) pXml : new ArrayList<>(asList(URL.class.cast(pXml))));
+            List<URL> persistenceXmls = pXml == null ? null : (List.class.isInstance(pXml) ? (List<URL>) pXml :
+                    new ArrayList<>(Collections.singletonList(URL.class.cast(pXml))));
             if (persistenceXmls == null) {
                 persistenceXmls = new ArrayList<>();
                 appModule.getAltDDs().put("persistence.xml", persistenceXmls);

--- a/container/openejb-core/src/main/java/org/apache/openejb/config/DeploymentLoader.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/config/DeploymentLoader.java
@@ -75,6 +75,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -92,8 +93,6 @@ import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.jar.Manifest;
 import java.util.zip.ZipEntry;
-
-import static java.util.Arrays.asList;
 
 /**
  * @version $Revision$ $Date$
@@ -1907,7 +1906,7 @@ public class DeploymentLoader implements DeploymentFilterable {
     }
 
     public Class<? extends DeploymentModule> discoverModuleType(final URL baseUrl, final ClassLoader classLoader, final boolean searchForDescriptorlessApplications) throws IOException, UnknownModuleTypeException {
-        final Set<RequireDescriptors> search = new HashSet<>();
+        final Set<RequireDescriptors> search = EnumSet.noneOf(RequireDescriptors.class);
 
         if (!searchForDescriptorlessApplications) {
             search.addAll(Arrays.asList(RequireDescriptors.values()));

--- a/container/openejb-core/src/main/java/org/apache/openejb/config/DeploymentLoader.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/config/DeploymentLoader.java
@@ -268,10 +268,9 @@ public class DeploymentLoader implements DeploymentFilterable {
     }
 
     public static void addWebModuleDescriptors(final URL baseUrl, final WebModule webModule, final AppModule appModule) throws OpenEJBException {
-        final Map<String, Object> otherDD = new HashMap<>();
         final List<URL> urls = webModule.getScannableUrls();
         final ResourceFinder finder = new ResourceFinder("", urls.toArray(new URL[urls.size()]));
-        otherDD.putAll(getDescriptors(finder, false));
+        final Map<String, Object> otherDD = new HashMap<>(getDescriptors(finder, false));
 
         // "persistence.xml" is done separately since we manage a list of url and not s single url
         try {
@@ -965,9 +964,8 @@ public class DeploymentLoader implements DeploymentFilterable {
 
         // determine war class path
 
-        final List<URL> webUrls = new ArrayList<>();
         ensureContainerUrls();
-        webUrls.addAll(containerUrls);
+        final List<URL> webUrls = new ArrayList<>(containerUrls);
 
         final SystemInstance systemInstance = SystemInstance.get();
 
@@ -1543,8 +1541,7 @@ public class DeploymentLoader implements DeploymentFilterable {
         }
 
         // create the class loader
-        final List<URL> classPath = new ArrayList<>();
-        classPath.addAll(rarLibs.values());
+        final List<URL> classPath = new ArrayList<>(rarLibs.values());
 
         final ClassLoaderConfigurer configurer = QuickJarsTxtParser.parse(new File(rarFile, "META-INF/" + QuickJarsTxtParser.FILE_NAME));
         if (configurer != null) {

--- a/container/openejb-core/src/main/java/org/apache/openejb/config/DeploymentLoader.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/config/DeploymentLoader.java
@@ -561,9 +561,9 @@ public class DeploymentLoader implements DeploymentFilterable {
             }
 
             // EJB modules
-            for (final String moduleName : ejbModules.keySet()) {
+            for (final Map.Entry<String, URL> stringURLEntry : ejbModules.entrySet()) {
                 try {
-                    URL ejbUrl = ejbModules.get(moduleName);
+                    URL ejbUrl = stringURLEntry.getValue();
                     // we should try to use a reference to the temp classloader
                     if (ClassLoaderUtil.isUrlCached(appModule.getJarLocation(), ejbUrl)) {
                         try {
@@ -579,14 +579,14 @@ public class DeploymentLoader implements DeploymentFilterable {
                     final EjbModule ejbModule = createEjbModule(ejbUrl, absolutePath, appClassLoader);
                     appModule.getEjbModules().add(ejbModule);
                 } catch (final OpenEJBException e) {
-                    logger.error("Unable to load EJBs from EAR: " + appId + ", module: " + moduleName + ". Exception: " + e.getMessage(), e);
+                    logger.error("Unable to load EJBs from EAR: " + appId + ", module: " + stringURLEntry.getKey() + ". Exception: " + e.getMessage(), e);
                 }
             }
 
             // Application Client Modules
-            for (final String moduleName : clientModules.keySet()) {
+            for (final Map.Entry<String, URL> stringURLEntry : clientModules.entrySet()) {
                 try {
-                    URL clientUrl = clientModules.get(moduleName);
+                    URL clientUrl = stringURLEntry.getValue();
                     // we should try to use a reference to the temp classloader
                     if (ClassLoaderUtil.isUrlCached(appModule.getJarLocation(), clientUrl)) {
                         try {
@@ -603,14 +603,14 @@ public class DeploymentLoader implements DeploymentFilterable {
 
                     appModule.getClientModules().add(clientModule);
                 } catch (final Exception e) {
-                    logger.error("Unable to load App Client from EAR: " + appId + ", module: " + moduleName + ". Exception: " + e.getMessage(), e);
+                    logger.error("Unable to load App Client from EAR: " + appId + ", module: " + stringURLEntry.getKey() + ". Exception: " + e.getMessage(), e);
                 }
             }
 
             // Resource modules
-            for (final String moduleName : resouceModules.keySet()) {
+            for (final Map.Entry<String, URL> stringURLEntry : resouceModules.entrySet()) {
                 try {
-                    URL rarUrl = resouceModules.get(moduleName);
+                    URL rarUrl = stringURLEntry.getValue();
                     // we should try to use a reference to the temp classloader
                     if (ClassLoaderUtil.isUrlCached(appModule.getJarLocation(), rarUrl)) {
                         try {
@@ -620,22 +620,22 @@ public class DeploymentLoader implements DeploymentFilterable {
                             // no-op
                         }
                     }
-                    final ConnectorModule connectorModule = createConnectorModule(appId, URLs.toFilePath(rarUrl), appClassLoader, moduleName);
+                    final ConnectorModule connectorModule = createConnectorModule(appId, URLs.toFilePath(rarUrl), appClassLoader, stringURLEntry.getKey());
                     if (connectorModule != null) {
                         appModule.getConnectorModules().add(connectorModule);
                     }
                 } catch (final OpenEJBException e) {
-                    logger.error("Unable to load RAR: " + appId + ", module: " + moduleName + ". Exception: " + e.getMessage(), e);
+                    logger.error("Unable to load RAR: " + appId + ", module: " + stringURLEntry.getKey() + ". Exception: " + e.getMessage(), e);
                 }
             }
 
             // Web modules
-            for (final String moduleName : webModules.keySet()) {
+            for (final Map.Entry<String, URL> stringURLEntry : webModules.entrySet()) {
                 try {
-                    final URL warUrl = webModules.get(moduleName);
-                    addWebModule(appModule, warUrl, appClassLoader, webContextRoots.get(moduleName), null);
+                    final URL warUrl = stringURLEntry.getValue();
+                    addWebModule(appModule, warUrl, appClassLoader, webContextRoots.get(stringURLEntry.getKey()), null);
                 } catch (final OpenEJBException e) {
-                    logger.error("Unable to load WAR: " + appId + ", module: " + moduleName + ". Exception: " + e.getMessage(), e);
+                    logger.error("Unable to load WAR: " + appId + ", module: " + stringURLEntry.getKey() + ". Exception: " + e.getMessage(), e);
                 }
             }
 

--- a/container/openejb-core/src/main/java/org/apache/openejb/config/sys/SaxAppCtxConfig.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/config/sys/SaxAppCtxConfig.java
@@ -41,6 +41,7 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -60,15 +61,15 @@ public class SaxAppCtxConfig {
         private static final Collection<String> IMPORT_ALIASES = Arrays.asList("import", "include");
         private static final Collection<String> APPLICATION_ALIASES = Arrays.asList("appcontext", "app-context", "application");
         private static final Collection<String> POJOS_ALIASES = Arrays.asList("pojocontexts", "pojo-contexts", "pojos");
-        private static final Collection<String> POJO_ALIASES = Arrays.asList("pojo");
+        private static final Collection<String> POJO_ALIASES = Collections.singletonList("pojo");
         private static final Collection<String> BEAN_CONTEXTS_ALIASES = Arrays.asList("beancontexts", "bean-contexts", "ejbs");
         private static final Collection<String> WEBAPP_ALIASES = Arrays.asList("webapps", "webcontexts", "web-contexts", "wars");
         private static final Collection<String> MODULE_ALIASES = Arrays.asList("modulecontext", "module");
         private static final Collection<String> BEAN_CONTEXT_ALIASES = Arrays.asList("ejb", "beancontext", "bean-context");
         private static final Collection<String> CONFIGURATION_ALIASES = Arrays.asList("configuration", "properties", "settings");
-        private static final Collection<String> RESOURCES_ALIASES = Arrays.asList("resources");
-        private static final Collection<String> SERVICE_ALIASES = Arrays.asList("service");
-        private static final Collection<String> RESOURCE_ALIASES = Arrays.asList("resource");
+        private static final Collection<String> RESOURCES_ALIASES = Collections.singletonList("resources");
+        private static final Collection<String> SERVICE_ALIASES = Collections.singletonList("service");
+        private static final Collection<String> RESOURCE_ALIASES = Collections.singletonList("resource");
         private static final Collection<String> ENV_ENTRIES_ALIASES = Arrays.asList("enventries", "env-entries");
         private static final Collection<String> ENV_ENTRY_ALIASES = Arrays.asList("enventry", "env-entry");
 

--- a/container/openejb-core/src/main/java/org/apache/openejb/core/BaseSessionContext.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/core/BaseSessionContext.java
@@ -148,8 +148,7 @@ public abstract class BaseSessionContext extends BaseContext implements SessionC
             if (InterfaceType.LOCALBEAN.equals(interfaceType)) {
                 return LocalBeanProxyFactory.constructProxy(di.get(BeanContext.ProxyClass.class).getProxy(), handler);
             } else {
-                final List<Class> interfaces = new ArrayList<>();
-                interfaces.addAll(di.getInterfaces(interfaceType));
+                final List<Class> interfaces = new ArrayList<>(di.getInterfaces(interfaceType));
                 interfaces.add(Serializable.class);
                 interfaces.add(IntraVmProxy.class);
                 if (BeanType.STATEFUL.equals(type) || BeanType.MANAGED.equals(type)) {

--- a/container/openejb-core/src/main/java/org/apache/openejb/core/managed/SimplePassivater.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/core/managed/SimplePassivater.java
@@ -97,8 +97,8 @@ public class SimplePassivater implements PassivationStrategy {
 
     @Override
     public void passivate(final Map hash) throws SystemException {
-        for (final Object id : hash.keySet()) {
-            passivate(id, hash.get(id));
+        for (final Object o : hash.entrySet()) {
+            passivate(((Map.Entry) o).getKey(), ((Map.Entry) o).getValue());
         }
     }
 

--- a/container/openejb-core/src/main/java/org/apache/openejb/core/security/jaas/SQLLoginModule.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/core/security/jaas/SQLLoginModule.java
@@ -102,13 +102,13 @@ public class SQLLoginModule implements LoginModule {
         this.subject = subject;
         this.handler = callbackHandler;
 
-        for (final Object key : options.keySet()) {
-            final Option option = Option.findByName((String) key);
+        for (final Object o : options.entrySet()) {
+            final Option option = Option.findByName((String) ((Map.Entry) o).getKey());
             if (option != null) {
-                final String value = (String) options.get(key);
+                final String value = (String) ((Map.Entry) o).getValue();
                 optionsMap.put(option, value.trim());
             } else {
-                log.warning("Ignoring option: {0}. Not supported.", key);
+                log.warning("Ignoring option: {0}. Not supported.", ((Map.Entry) o).getKey());
             }
         }
 

--- a/container/openejb-core/src/main/java/org/apache/openejb/core/stateful/SimplePassivater.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/core/stateful/SimplePassivater.java
@@ -101,8 +101,8 @@ public class SimplePassivater implements PassivationStrategy {
 
     @Override
     public void passivate(final Map hash) throws SystemException {
-        for (final Object id : hash.keySet()) {
-            passivate(id, hash.get(id));
+        for (final Object o : hash.entrySet()) {
+            passivate(((Map.Entry) o).getKey(), ((Map.Entry) o).getValue());
         }
     }
 

--- a/container/openejb-core/src/main/java/org/apache/openejb/core/timer/EJBCronTrigger.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/core/timer/EJBCronTrigger.java
@@ -971,9 +971,7 @@ public class EJBCronTrigger extends CronTriggerImpl {
 
         private TreeSet<Integer> getNewValuesFromDynamicExpressions(final Calendar calendar) {
 
-            final TreeSet<Integer> newValues = new TreeSet<>();
-
-            newValues.addAll(values);
+            final TreeSet<Integer> newValues = new TreeSet<>(values);
 
             for (final RangeExpression weekDayRangeExpression : weekDayRangeExpressions) {
 

--- a/container/openejb-core/src/main/java/org/apache/openejb/core/timer/MemoryTimerStore.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/core/timer/MemoryTimerStore.java
@@ -225,8 +225,7 @@ public class MemoryTimerStore implements TimerStore {
         @Override
         public Map<Long, TimerData> getTasks() {
             checkThread();
-            final TreeMap<Long, TimerData> allTasks = new TreeMap<>();
-            allTasks.putAll(taskStore);
+            final TreeMap<Long, TimerData> allTasks = new TreeMap<>(taskStore);
             for (final Long key : remove) {
                 allTasks.remove(key);
             }

--- a/container/openejb-core/src/main/java/org/apache/openejb/resource/AutoConnectionTracker.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/resource/AutoConnectionTracker.java
@@ -133,14 +133,14 @@ public class AutoConnectionTracker implements ConnectionTracker {
                         final Map<ManagedConnectionInfo, Map<ConnectionInfo, Object>> txConnections = (Map<ManagedConnectionInfo, Map<ConnectionInfo, Object>>) registry.getResource(KEY);
                         if (txConnections != null && txConnections.size() > 0) {
 
-                            for (final ManagedConnectionInfo managedConnectionInfo : txConnections.keySet()) {
+                            for (final Map.Entry<ManagedConnectionInfo, Map<ConnectionInfo, Object>> managedConnectionInfoMapEntry : txConnections.entrySet()) {
                                 final StringBuilder sb = new StringBuilder();
-                                final Collection<ConnectionInfo> connectionInfos = txConnections.get(managedConnectionInfo).keySet();
+                                final Collection<ConnectionInfo> connectionInfos = managedConnectionInfoMapEntry.getValue().keySet();
                                 for (final ConnectionInfo connectionInfo : connectionInfos) {
                                     sb.append("\n  ").append("Connection handle opened at ").append(stackTraceToString(connectionInfo.getTrace().getStackTrace()));
                                 }
 
-                                logger.warning("Transaction complete, but connection still has handles associated: " + managedConnectionInfo + "\nAbandoned connection information: " + sb);
+                                logger.warning("Transaction complete, but connection still has handles associated: " + managedConnectionInfoMapEntry.getKey() + "\nAbandoned connection information: " + sb);
                             }
                         }
                     }

--- a/container/openejb-core/src/main/java/org/apache/openejb/util/AnnotationFinder.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/util/AnnotationFinder.java
@@ -109,7 +109,7 @@ public class AnnotationFinder {
     }
 
     public AnnotationFinder(final ClassLoader classLoader, final URL url) {
-        this(classLoader, Arrays.asList(url));
+        this(classLoader, Collections.singletonList(url));
     }
 
     public AnnotationFinder(final ClassLoader classLoader, final Collection<URL> urls) {

--- a/container/openejb-core/src/main/java/org/apache/openejb/util/helper/CommandHelper.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/util/helper/CommandHelper.java
@@ -26,6 +26,7 @@ import org.apache.openejb.table.Lines;
 import org.apache.openejb.util.JavaSecurityManagers;
 
 import java.util.Arrays;
+import java.util.Collections;
 
 public final class CommandHelper {
     private CommandHelper() {
@@ -69,14 +70,14 @@ public final class CommandHelper {
             if (!empty) {
                 sb.append(", ");
             }
-            sb.append("Local").append(Arrays.asList(bc.getBusinessLocalInterfaces()));
+            sb.append("Local").append(Collections.singletonList(bc.getBusinessLocalInterfaces()));
             empty = false;
         }
         if (bc.getBusinessRemoteInterface() != null) {
             if (!empty) {
                 sb.append(", ");
             }
-            sb.append("Remote").append(Arrays.asList(bc.getBusinessRemoteInterfaces()));
+            sb.append("Remote").append(Collections.singletonList(bc.getBusinessRemoteInterfaces()));
         }
         return sb.toString();
     }

--- a/container/openejb-core/src/test/java/org/apache/openejb/core/security/SecurityServiceImplTest.java
+++ b/container/openejb-core/src/test/java/org/apache/openejb/core/security/SecurityServiceImplTest.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.lang.reflect.Method;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.util.Collections;
 import java.util.Enumeration;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -36,7 +37,7 @@ public class SecurityServiceImplTest {
         final ClassLoader jaasLoader = new URLClassLoader(new URL[0]) {
             @Override
             public Enumeration<URL> getResources(final String name) throws IOException {
-                return new ArrayEnumeration(asList(new URL("file:/tmp/jaas/folder+with+plus/login.config")));
+                return new ArrayEnumeration(Collections.singletonList(new URL("file:/tmp/jaas/folder+with+plus/login.config")));
             }
         };
         Thread.currentThread().setContextClassLoader(jaasLoader);

--- a/container/openejb-core/src/test/java/org/apache/openejb/core/stateful/StatefulContainerTest.java
+++ b/container/openejb-core/src/test/java/org/apache/openejb/core/stateful/StatefulContainerTest.java
@@ -60,8 +60,7 @@ public class StatefulContainerTest extends TestCase {
     }
 
     public void testBusinessLocalBeanInterface() throws Exception {
-        final List localbeanExpectedLifecycle = new ArrayList();
-        localbeanExpectedLifecycle.addAll(expectedLifecycle);
+        final List localbeanExpectedLifecycle = new ArrayList(expectedLifecycle);
 
         // WAS can't avoid the extra constructor call
         // NOW it was rewritten to avoid it
@@ -162,8 +161,7 @@ public class StatefulContainerTest extends TestCase {
     }
 
     public void testBusinessLocalBeanInterfaceInTx() throws Exception {
-        final List localbeanExpectedLifecycle = new ArrayList();
-        localbeanExpectedLifecycle.addAll(inTxExpectedLifecycle);
+        final List localbeanExpectedLifecycle = new ArrayList(inTxExpectedLifecycle);
 
         // WAS can't avoid the extra constructor call
         // NOW it was rewritten to avoid it

--- a/container/openejb-core/src/test/java/org/apache/openejb/core/stateless/StatelessContainerTest.java
+++ b/container/openejb-core/src/test/java/org/apache/openejb/core/stateless/StatelessContainerTest.java
@@ -74,8 +74,7 @@ public class StatelessContainerTest extends TestCase {
             assertSame("lifecycle", lifecycle, WidgetBean.lifecycle);
 
             // Check the lifecycle of the bean
-            final List localBeanExpected = new ArrayList();
-            localBeanExpected.addAll(expected);
+            final List localBeanExpected = new ArrayList(expected);
             assertEquals(join("\n", localBeanExpected), join("\n", lifecycle));
         }
         {

--- a/container/openejb-core/src/test/java/org/apache/openejb/core/stateless/StatelessInvocationStatsTest.java
+++ b/container/openejb-core/src/test/java/org/apache/openejb/core/stateless/StatelessInvocationStatsTest.java
@@ -285,8 +285,7 @@ public class StatelessInvocationStatsTest {
             expectedOperations.add(new MBeanOperationInfo(s + ".values", "", new MBeanParameterInfo[0], "[D", MBeanOperationInfo.UNKNOWN));
         }
 
-        final List<MBeanOperationInfo> actualOperations1 = new ArrayList<>();
-        actualOperations1.addAll(Arrays.asList(beanInfo.getOperations()));
+        final List<MBeanOperationInfo> actualOperations1 = new ArrayList<>(Arrays.asList(beanInfo.getOperations()));
 
         //Verify invocation operation information and remove bean.
         Assert.assertEquals(expectedOperations, actualOperations1);

--- a/container/openejb-core/src/test/java/org/apache/openejb/core/stateless/StatelessMetaAnnotationTest.java
+++ b/container/openejb-core/src/test/java/org/apache/openejb/core/stateless/StatelessMetaAnnotationTest.java
@@ -85,8 +85,7 @@ public class StatelessMetaAnnotationTest extends TestCase {
             assertSame("lifecycle", lifecycle, WidgetBean.lifecycle);
 
             // Check the lifecycle of the bean
-            final List localBeanExpected = new ArrayList();
-            localBeanExpected.addAll(expected);
+            final List localBeanExpected = new ArrayList(expected);
             assertEquals(join("\n", localBeanExpected), join("\n", lifecycle));
         }
         {

--- a/container/openejb-core/src/test/java/org/apache/openejb/core/stateless/StatelessPoolStatsTest.java
+++ b/container/openejb-core/src/test/java/org/apache/openejb/core/stateless/StatelessPoolStatsTest.java
@@ -199,8 +199,7 @@ public class StatelessPoolStatsTest extends TestCase {
             operations, "void", MBeanOperationInfo.UNKNOWN));
         expectedOperations.add(new MBeanOperationInfo("flush", "", new MBeanParameterInfo[0], "void", MBeanOperationInfo.UNKNOWN));
 
-        final List<MBeanOperationInfo> actualOperations = new ArrayList<>();
-        actualOperations.addAll(Arrays.asList(poolMBeanInfo.getOperations()));
+        final List<MBeanOperationInfo> actualOperations = new ArrayList<>(Arrays.asList(poolMBeanInfo.getOperations()));
         assertEquals(expectedOperations, actualOperations);
     }
 

--- a/container/openejb-core/src/test/java/org/apache/openejb/ivm/naming/IvmContextTest.java
+++ b/container/openejb-core/src/test/java/org/apache/openejb/ivm/naming/IvmContextTest.java
@@ -329,8 +329,8 @@ public class IvmContextTest {
         }
         writer.println();
 
-        for (Context subContext : subContexts.keySet()) {
-            hasErrors |= listContext(subContext, subContexts.get(subContext), writer);
+        for (Map.Entry<Context, String> contextStringEntry : subContexts.entrySet()) {
+            hasErrors |= listContext(contextStringEntry.getKey(), contextStringEntry.getValue(), writer);
         }
 
         return hasErrors;

--- a/container/openejb-core/src/test/java/org/apache/openejb/util/ReferencesTest.java
+++ b/container/openejb-core/src/test/java/org/apache/openejb/util/ReferencesTest.java
@@ -240,9 +240,7 @@ public class ReferencesTest extends TestCase {
         public Bean(final String name, final String... refs) {
             this.name = name;
             this.refs = new LinkedHashSet<>(refs.length);
-            for (final String s : refs) {
-                this.refs.add(s);
-            }
+            this.refs.addAll(Arrays.asList(refs));
         }
 
         public String toString() {

--- a/container/openejb-junit/src/main/java/org/apache/openejb/junit/OpenEjbRunner.java
+++ b/container/openejb-junit/src/main/java/org/apache/openejb/junit/OpenEjbRunner.java
@@ -29,6 +29,7 @@ import org.junit.runners.model.InitializationError;
 
 import java.lang.reflect.Method;
 import java.util.Arrays;
+import java.util.Collections;
 
 public class OpenEjbRunner extends Runner {
     private final Runner delegate;
@@ -54,7 +55,7 @@ public class OpenEjbRunner extends Runner {
         try {
             delegate = getDelegateRunner(testClazz);
         } catch (final Throwable e) {
-            throw new InitializationError(Arrays.asList(e));
+            throw new InitializationError(Collections.singletonList(e));
         }
     }
 


### PR DESCRIPTION
This PR has the Goal to improve performance and save memory on the collections code. To get this goal, we went to different improvements:


1) Use the Constructor in the collection instead of add

```java
Set<String> set = new HashSet<>();
set.addAll(Arrays.asList("alpha", "beta", "gamma"));
```
```java
Set<String> set = new HashSet<>(Arrays.asList("alpha", "beta", "gamma"));
```

 These constructs method is replaced with a single call to a parametrized constructor which simplifies the code. Also for more performant such as [HashSet](https://github.com/dmlloyd/openjdk/blob/jdk/jdk/src/java.base/share/classes/java/util/HashSet.java#L119).

2) Use the addAll instead of add for interactions

Replaces add method to calling a bulk method (e.g. collection.addAll(listOfX). This will produce improvements in the code. Such as [ArrayList](https://github.com/dmlloyd/openjdk/blob/jdk/jdk/src/java.base/share/classes/java/util/ArrayList.java#L700) and [HashMap](https://github.com/dmlloyd/openjdk/blob/jdk/jdk/src/java.base/share/classes/java/util/HashMap.java#L495)

3) Replace Arrays with one element to Collections.singletonList() which will save some memory.

4) Uses EnumSet instead of HashSet

From the [documentation](https://docs.oracle.com/javase/8/docs/api/java/util/EnumSet.html) that says: 
> A specialized Set implementation for use with enum types. All of the elements in an enum set must come from a single enum type that is specified, explicitly or implicitly, when the set is created. Enum sets are represented internally as bit vectors. This representation is extremely compact and efficient. The space and time performance of this class should be good enough to allow its use as a high-quality, typesafe alternative to traditional int-based "bit flags." Even bulk operations (such as containsAll and retainAll) should run very quickly if their argument is also an enum set.

5) Uses the entrySet method:

Replaces interaction over the keySet() of a java.util.Map instance, where the iterated keys are used to retrieve the values from the map. Such iteration may be more efficiently replaced by iteration over the entrySet() of the map. The [Map.Entry](https://docs.oracle.com/javase/7/docs/api/java/util/Map.Entry.html) is an entry within Map, that avoid the get method several times once the key and the value are in the object.

## Benchmarking

Using the [JMH](https://openjdk.java.net/projects/code-tools/jmh/), the OpenJDK benchmarking framework I created the code below:

### List

```java
@Warmup(iterations = 5, time = 1)
@Measurement(iterations = 20, time = 1)
@Fork(3)
@BenchmarkMode(Mode.Throughput)
@OutputTimeUnit(TimeUnit.MILLISECONDS)
@State(Scope.Thread)
public class CollectionBenchmark {


    private static final List<String> FRUITS = Arrays.asList("banana", "apple", "watermelon", "pineapple", "orange");

    @Benchmark
    public List<String> collectionAddAll() {
        List<String> fruits = new ArrayList<>();
        fruits.addAll(FRUITS);
        return fruits;
    }

    @Benchmark
    public List<String> collectionAddInteraction() {
        List<String> fruits = new ArrayList<>();
        for (String fruit : FRUITS) {
            fruits.add(fruit);
        }
        return fruits;
    }

    @Benchmark
    public List<String> collectionConstructor() {
        return new ArrayList<>(FRUITS);
    }
}

```

* CollectionBenchmark.collectionAddInteraction  thrpt   60  19311,748 ops/ms
* CollectionBenchmark.collectionAddAll          thrpt   60  27181,810 ops/ms (around 40,75% faster)
* CollectionBenchmark.collectionConstructor     thrpt   60  48734,599  ops/ms (around 79.29 % faster)


### Map

```java
@Warmup(iterations = 5, time = 1)
@Measurement(iterations = 20, time = 1)
@Fork(3)
@BenchmarkMode(Mode.Throughput)
@OutputTimeUnit(TimeUnit.MILLISECONDS)
@State(Scope.Thread)
public class MapBenchmark {

    private static final Map<String, Integer> NUMBERS = new HashMap<>();


    static {
        NUMBERS.put("one", 1);
        NUMBERS.put("two", 2);
        NUMBERS.put("one", 3);
        NUMBERS.put("four", 4);
        NUMBERS.put("five", 5);
        NUMBERS.put("six", 6);
        NUMBERS.put("seven", 7);
        NUMBERS.put("eight", 8);
        NUMBERS.put("nine", 9);
        NUMBERS.put("ten", 10);
    }


    @Benchmark
    public List<Object> entrySet() {
        List<Object> values = new ArrayList<>();
        for (Map.Entry<String, Integer> entry : NUMBERS.entrySet()) {
            values.add(entry.getKey());
            values.add(entry.getValue());
        }
        return values;
    }

    @Benchmark
    public List<Object> key() {
        List<Object> values = new ArrayList<>();
        for (String key : NUMBERS.keySet()) {
            values.add(key);
            values.add(NUMBERS.get(key));
        }

        return values;
    }
}
```

* MapBenchmark.key       thrpt   60     4571,474 
* MapBenchmark.entrySet  thrpt   60  5630,745 (around 23.17 % faster)

