### PR TITLE
TOMEE-2330 fix issue with incorrect base URL for generated persistenc…

### DIFF
--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/cmp/CmpMappingTest.java
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/cmp/CmpMappingTest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.openejb.arquillian.tests.cmp;
+
+import org.apache.ziplock.IO;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.ClassLoaderAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.net.URL;
+
+/**
+ * @version $Rev$ $Date$
+ */
+@RunWith(Arquillian.class)
+public class CmpMappingTest {
+
+    @ArquillianResource
+    private URL url;
+
+    @Deployment(testable = false)
+    public static WebArchive createDeployment() {
+        WebArchive archive = ShrinkWrap.create(WebArchive.class, CmpMappingTest.class.getSimpleName() + ".war")
+                .addClasses(CmpServlet.class, MyCmpBean.class, MyLocalHome.class, MyLocalObject.class, MyRemoteHome.class, MyRemoteObject.class)
+                .addAsWebInfResource(new ClassLoaderAsset("org/apache/openejb/arquillian/tests/cmp/openejb-cmp-orm.xml"), "openejb-cmp-orm.xml")
+                .addAsWebInfResource(new ClassLoaderAsset("org/apache/openejb/arquillian/tests/cmp/ejb-jar.xml"), "ejb-jar.xml");
+
+        System.out.println(archive.toString(true));
+        return archive;
+    }
+
+    @Test
+    @RunAsClient
+    public void checkCmpJpaEntityORMMappings() throws Exception {
+        final String output = IO.readString(new URL(url.toExternalForm()));
+        System.out.println(output);
+    }
+}

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/cmp/CmpServlet.java
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/cmp/CmpServlet.java
@@ -21,7 +21,7 @@ public class CmpServlet extends HttpServlet {
         final Collection<AppInfo> deployedApplications = assembler.getDeployedApplications();
 
         for (final AppInfo deployedApplication : deployedApplications) {
-            if ("CmpMappingTestIgnoreMe".equals(deployedApplication.appId)) {
+            if ("CmpMappingTest".equals(deployedApplication.appId)) {
                 final String cmpMappingsXml = deployedApplication.cmpMappingsXml;
                 resp.getWriter().write(cmpMappingsXml == null ? "null" : cmpMappingsXml);
             }

--- a/container/openejb-core/src/main/java/org/apache/openejb/config/CmpJpaConversion.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/config/CmpJpaConversion.java
@@ -266,10 +266,10 @@ public class CmpJpaConversion implements DynamicDeployer {
 
     private String getPersistenceModuleId(final AppModule appModule) {
         if (appModule.getModuleId() != null) {
-            return appModule.getModuleId();
+            return appModule.getJarLocation();
         }
         for (final EjbModule ejbModule : appModule.getEjbModules()) {
-            return ejbModule.getModuleId();
+            return ejbModule.getJarLocation();
         }
         throw new IllegalStateException("Comp must be in an ejb module, this one has none: " + appModule);
     }


### PR DESCRIPTION
…e units

This uses the full path for the module as opposed to just the module ID. The doesn't seem to affect OpenJPA based distros, but does affect EclipseLink - i.e. Plume.