### PR TITLE
TOMEE-2234 fix Bmp finder can only return 256 entities

### DIFF
--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/bmp/local/BigFinder.java
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/bmp/local/BigFinder.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.openejb.arquillian.tests.bmp.local;
+
+import javax.ejb.EJBLocalObject;
+
+public interface BigFinder extends EJBLocalObject {
+}

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/bmp/local/BigFinderBean.java
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/bmp/local/BigFinderBean.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.openejb.arquillian.tests.bmp.local;
+
+import javax.ejb.EntityBean;
+import javax.ejb.EntityContext;
+import javax.ejb.RemoveException;
+import java.rmi.RemoteException;
+import java.util.ArrayList;
+import java.util.Collection;
+
+public class BigFinderBean implements EntityBean {
+
+    public void ejbActivate() throws RemoteException {
+    }
+
+    public void ejbPassivate() throws RemoteException {
+    }
+
+    public void setEntityContext(final EntityContext context) throws RemoteException {
+    }
+
+    public void unsetEntityContext() throws RemoteException {
+    }
+
+    public void ejbLoad() throws RemoteException {
+    }
+
+    public void ejbRemove() throws RemoveException, RemoteException {
+    }
+
+    public void ejbStore() throws RemoteException {
+    }
+
+    public Collection<BigFinderPK> ejbFindN(final int count) {
+        final ArrayList<BigFinderPK> pks = new ArrayList();
+        for (int i = 0; i < count; ++i) {
+            pks.add(new BigFinderPK(i));
+        }
+        return pks;
+    }
+
+}

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/bmp/local/BigFinderHome.java
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/bmp/local/BigFinderHome.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.openejb.arquillian.tests.bmp.local;
+
+import javax.ejb.EJBLocalHome;
+import java.rmi.RemoteException;
+import java.util.Collection;
+
+public interface BigFinderHome extends EJBLocalHome {
+    Collection<BigFinder> findN(int count) throws RemoteException;
+}

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/bmp/local/BigFinderPK.java
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/bmp/local/BigFinderPK.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.openejb.arquillian.tests.bmp.local;
+
+public class BigFinderPK extends IntegerPK {
+
+    public BigFinderPK(final int iKey) {
+        super(iKey);
+    }
+}

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/bmp/local/BmpLocalEntityTest.java
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/bmp/local/BmpLocalEntityTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.openejb.arquillian.tests.bmp.local;
+
+import org.apache.ziplock.IO;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.ClassLoaderAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.net.URL;
+
+/**
+ * @version $Rev$ $Date$
+ */
+@RunWith(Arquillian.class)
+public class BmpLocalEntityTest {
+
+    @ArquillianResource
+    private URL url;
+
+    @Deployment(testable = false)
+    public static WebArchive createDeployment() {
+        WebArchive archive = ShrinkWrap.create(WebArchive.class, BmpLocalEntityTest.class.getSimpleName() + ".war")
+                .addClasses(BigFinder.class, BigFinderBean.class, BigFinderHome.class, BigFinderPK.class,
+                        FinderServlet.class, FinderTest.class, FinderTestBean.class, FinderTestHome.class, IntegerPK.class,
+                        LittleFinder.class, LittleFinderBean.class, LittleFinderHome.class, LittleFinderPK.class, StringPK.class)
+                .addAsWebInfResource(new ClassLoaderAsset("org/apache/openejb/arquillian/tests/bmp/local/ejb-jar.xml"), "ejb-jar.xml")
+                .addAsWebInfResource(new ClassLoaderAsset("org/apache/openejb/arquillian/tests/bmp/local/web.xml"), "web.xml");
+
+        System.out.println(archive.toString(true));
+        return archive;
+    }
+
+    @Test
+    @RunAsClient
+    public void checkBmp() throws Exception {
+        final String output = IO.slurp(new URL(url.toExternalForm()));
+        System.out.println(output);
+        Assert.assertTrue(output.contains("Test succeeded"));
+    }
+}

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/bmp/local/FinderServlet.java
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/bmp/local/FinderServlet.java
@@ -1,0 +1,33 @@
+package org.apache.openejb.arquillian.tests.bmp.local;
+
+import javax.naming.InitialContext;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class FinderServlet extends HttpServlet {
+
+    @Override
+    protected void doGet(final HttpServletRequest req, final HttpServletResponse resp) throws ServletException, IOException {
+        final FinderTestHome testHome;
+        InitialContext ctx = null;
+        try {
+            ctx = new InitialContext();
+            testHome = (FinderTestHome) ctx.lookup("java:comp/env/ejb/FinderTest");
+            resp.getWriter().println(testHome.create().runTest());
+            resp.getWriter().flush();
+        } catch (final Exception e) {
+            throw new ServletException(e);
+        } finally {
+            try {
+                if (ctx != null) {
+                    ctx.close();
+                }
+            } catch (final Exception e) {
+                throw new ServletException(e);
+            }
+        }
+    }
+}

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/bmp/local/FinderTest.java
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/bmp/local/FinderTest.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.openejb.arquillian.tests.bmp.local;
+
+import java.rmi.RemoteException;
+
+import javax.ejb.EJBLocalObject;
+
+public interface FinderTest extends EJBLocalObject {
+    String runTest() throws Exception, RemoteException;
+}

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/bmp/local/FinderTestBean.java
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/bmp/local/FinderTestBean.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.openejb.arquillian.tests.bmp.local;
+
+import javax.ejb.CreateException;
+import javax.ejb.EJBException;
+import javax.ejb.EJBObject;
+import javax.ejb.SessionBean;
+import javax.ejb.SessionContext;
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import java.rmi.RemoteException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Properties;
+
+public class FinderTestBean implements SessionBean {
+
+    public void setSessionContext(final SessionContext context) throws RemoteException {
+    }
+
+    public void ejbRemove() throws RemoteException {
+    }
+
+    public void ejbActivate() throws RemoteException {
+    }
+
+    public void ejbPassivate() throws RemoteException {
+    }
+
+    public void ejbCreate() throws CreateException {
+    }
+
+    public String runTest()
+            throws Exception {
+        final BigFinderHome bigFinderHome = (BigFinderHome) lookup("BigFinderHome");
+        final LittleFinderHome littleFinderHome = (LittleFinderHome) lookup("LittleFinderHome");
+        for (int i = 1; i < 300; ++i) {
+            bigFinderHome.findN(i);
+
+            final Collection littleList = littleFinderHome.findAll();
+            for (final Object obj : littleList) {
+                final StringBuilder msg = new StringBuilder();
+                if (!(obj instanceof LittleFinder)) {
+                    msg.append("Failed with " + i + " records. LittleFinder Remote is actually " + obj.getClass().getName() + " Implemented interfaces " + Arrays.toString(obj.getClass().getInterfaces()));
+                    if (obj instanceof EJBObject) {
+                        final Object pk = ((EJBObject) obj).getPrimaryKey();
+                        msg.append(" Primary key value is " + pk);
+                    }
+
+                    throw new EJBException(msg.toString());
+                }
+            }
+        }
+
+        return "Test succeeded";
+    }
+
+    public static Object lookup(final String s) throws NamingException {
+        final Properties p = new Properties();
+        p.put(Context.INITIAL_CONTEXT_FACTORY, "org.apache.openejb.core.LocalInitialContextFactory");
+        final InitialContext ctx = new InitialContext(p);
+        try {
+            return ctx.lookup("java:comp/env/ejb/" + s);
+        } finally {
+            ctx.close();
+        }
+    }
+
+
+}

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/bmp/local/FinderTestHome.java
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/bmp/local/FinderTestHome.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.openejb.arquillian.tests.bmp.local;
+
+import java.rmi.RemoteException;
+import javax.ejb.CreateException;
+import javax.ejb.EJBLocalHome;
+
+public interface FinderTestHome extends EJBLocalHome {
+    FinderTest create() throws CreateException, RemoteException;
+}

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/bmp/local/IntegerPK.java
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/bmp/local/IntegerPK.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.openejb.arquillian.tests.bmp.local;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Types;
+
+/**
+ * The base class for a primary key for an integer type.
+ */
+public class IntegerPK extends Number {
+    private static final long serialVersionUID = 351946466791640696L;
+    private int m_value;
+
+    public IntegerPK(final int value) {
+        m_value = value;
+    }
+
+    public int getValue() {
+        return m_value;
+    }
+
+    public Object clone() {
+        try {
+            return super.clone();
+        } catch (final CloneNotSupportedException exc) {
+            throw new RuntimeException("Cannot clone", exc);
+        }
+    }
+
+    public boolean equals(final Object o) {
+        if (o == null)
+            return false;
+        return m_value == ((IntegerPK) o).m_value;
+    }
+
+    public int compareTo(final Object o) {
+        return (int) (m_value - ((IntegerPK) o).m_value);
+    }
+
+    public int hashCode() {
+        return m_value;
+    }
+
+    public String toString() {
+        return String.valueOf(m_value);
+    }
+
+    // Number interface
+    public byte byteValue() {
+        return (byte) m_value;
+    }
+
+    public short shortValue() {
+        return (short) m_value;
+    }
+
+    public int intValue() {
+        return m_value;
+    }
+
+    public long longValue() {
+        return m_value;
+    }
+
+    public float floatValue() {
+        return m_value;
+    }
+
+    public double doubleValue() {
+        return m_value;
+    }
+
+    /**
+     * For ParmType interface
+     */
+    public void add(final int i, final PreparedStatement stat) throws SQLException {
+        stat.setInt(i, m_value);
+    }
+
+    public int getType() {
+        return Types.INTEGER;
+    }
+}

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/bmp/local/LittleFinder.java
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/bmp/local/LittleFinder.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.openejb.arquillian.tests.bmp.local;
+
+import javax.ejb.EJBLocalObject;
+
+public interface LittleFinder extends EJBLocalObject {
+}

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/bmp/local/LittleFinderBean.java
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/bmp/local/LittleFinderBean.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.openejb.arquillian.tests.bmp.local;
+
+import java.rmi.RemoteException;
+import java.util.ArrayList;
+import java.util.Collection;
+import javax.ejb.EntityBean;
+import javax.ejb.EntityContext;
+
+public class LittleFinderBean implements EntityBean {
+    private static final long serialVersionUID = -1719910497840449494L;
+
+    public void ejbActivate() throws RemoteException {
+    }
+
+    public void ejbPassivate() throws RemoteException {
+    }
+
+    public void setEntityContext(final EntityContext context) throws RemoteException {
+    }
+
+    public void unsetEntityContext() throws RemoteException {
+    }
+
+    public void ejbLoad() throws RemoteException {
+    }
+
+    public void ejbStore() throws RemoteException {
+    }
+
+    public void ejbRemove() throws RemoteException {
+    }
+
+    public Collection<LittleFinderPK> ejbFindAll() throws Exception {
+        final ArrayList<LittleFinderPK> pks = new ArrayList();
+        pks.add(new LittleFinderPK("1A"));
+        return pks;
+    }
+
+}

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/bmp/local/LittleFinderHome.java
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/bmp/local/LittleFinderHome.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.openejb.arquillian.tests.bmp.local;
+
+import javax.ejb.EJBLocalHome;
+import java.rmi.RemoteException;
+import java.util.Collection;
+
+public interface LittleFinderHome extends EJBLocalHome {
+    Collection<LittleFinder> findAll() throws Exception, RemoteException;
+}

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/bmp/local/LittleFinderPK.java
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/bmp/local/LittleFinderPK.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.openejb.arquillian.tests.bmp.local;
+
+public class LittleFinderPK extends StringPK {
+    private static final long serialVersionUID = 5782590322327281948L;
+
+    public LittleFinderPK(final String s) {
+        super(s);
+    }
+}

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/bmp/local/StringPK.java
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/bmp/local/StringPK.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.openejb.arquillian.tests.bmp.local;
+
+import java.io.Serializable;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Types;
+
+/**
+ * A primary key in a Database table with a String representation (varchar).
+ */
+public class StringPK implements Serializable {
+    private static final long serialVersionUID = -6429314795121119701L;
+    private String m_value;
+
+    public StringPK(final String s) {
+        m_value = s;
+    }
+
+    public String getValue() {
+        return m_value;
+    }
+
+    public boolean equals(final Object o) {
+        if (o instanceof StringPK) {
+            final StringPK s = (StringPK) o;
+            if (m_value == null)
+                return s.m_value == null;
+            return m_value.equals(s.m_value);
+        } else {
+            return false;
+        }
+    }
+
+    public int compareTo(final Object o) {
+        return ("" + m_value).compareTo(((StringPK) o).m_value);
+    }
+
+    public int hashCode() {
+        return ("" + m_value).hashCode();
+    }
+
+    public String toString() {
+        if (m_value == null)
+            return "NULL";
+        return '\'' + m_value + '\'';
+    }
+
+    public void add(final int i, final PreparedStatement stat) throws SQLException {
+        stat.setString(i, m_value);
+    }
+
+    public int getType() {
+        return Types.VARCHAR;
+    }
+}

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/bmp/remote/BigFinder.java
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/bmp/remote/BigFinder.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.openejb.arquillian.tests.bmp.remote;
+
+import javax.ejb.EJBObject;
+
+public interface BigFinder extends EJBObject {
+}

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/bmp/remote/BigFinderBean.java
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/bmp/remote/BigFinderBean.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.openejb.arquillian.tests.bmp.remote;
+
+import javax.ejb.EntityBean;
+import javax.ejb.EntityContext;
+import javax.ejb.RemoveException;
+import java.rmi.RemoteException;
+import java.util.ArrayList;
+import java.util.Collection;
+
+public class BigFinderBean implements EntityBean {
+
+    public void ejbActivate() throws RemoteException {
+    }
+
+    public void ejbPassivate() throws RemoteException {
+    }
+
+    public void setEntityContext(final EntityContext context) throws RemoteException {
+    }
+
+    public void unsetEntityContext() throws RemoteException {
+    }
+
+    public void ejbLoad() throws RemoteException {
+    }
+
+    public void ejbRemove() throws RemoveException, RemoteException {
+    }
+
+    public void ejbStore() throws RemoteException {
+    }
+
+    public Collection<BigFinderPK> ejbFindN(final int count) {
+        final ArrayList<BigFinderPK> pks = new ArrayList();
+        for (int i = 0; i < count; ++i) {
+            pks.add(new BigFinderPK(i));
+        }
+        return pks;
+    }
+
+}

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/bmp/remote/BigFinderHome.java
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/bmp/remote/BigFinderHome.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.openejb.arquillian.tests.bmp.remote;
+
+import javax.ejb.EJBHome;
+import java.rmi.RemoteException;
+import java.util.Collection;
+
+public interface BigFinderHome extends EJBHome {
+    Collection<BigFinder> findN(int count) throws RemoteException;
+}

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/bmp/remote/BigFinderPK.java
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/bmp/remote/BigFinderPK.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.openejb.arquillian.tests.bmp.remote;
+
+public class BigFinderPK extends IntegerPK {
+
+    public BigFinderPK(final int iKey) {
+        super(iKey);
+    }
+}

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/bmp/remote/BmpRemoteEntityTest.java
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/bmp/remote/BmpRemoteEntityTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.openejb.arquillian.tests.bmp.remote;
+
+import org.apache.ziplock.IO;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.ClassLoaderAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.net.URL;
+
+/**
+ * @version $Rev$ $Date$
+ */
+@RunWith(Arquillian.class)
+public class BmpRemoteEntityTest {
+
+    @ArquillianResource
+    private URL url;
+
+    @Deployment(testable = false)
+    public static WebArchive createDeployment() {
+        WebArchive archive = ShrinkWrap.create(WebArchive.class, BmpRemoteEntityTest.class.getSimpleName() + ".war")
+                .addClasses(BigFinder.class, BigFinderBean.class, BigFinderHome.class, BigFinderPK.class,
+                        FinderServlet.class, FinderTest.class, FinderTestBean.class, FinderTestHome.class, IntegerPK.class,
+                        LittleFinder.class, LittleFinderBean.class, LittleFinderHome.class, LittleFinderPK.class, StringPK.class)
+                .addAsWebInfResource(new ClassLoaderAsset("org/apache/openejb/arquillian/tests/bmp/remote/ejb-jar.xml"), "ejb-jar.xml")
+                .addAsWebInfResource(new ClassLoaderAsset("org/apache/openejb/arquillian/tests/bmp/remote/web.xml"), "web.xml");
+
+        System.out.println(archive.toString(true));
+        return archive;
+    }
+
+    @Test
+    @RunAsClient
+    public void checkBmp() throws Exception {
+        final String output = IO.slurp(new URL(url.toExternalForm()));
+        System.out.println(output);
+        Assert.assertTrue(output.contains("Test succeeded"));
+    }
+}

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/bmp/remote/FinderServlet.java
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/bmp/remote/FinderServlet.java
@@ -1,0 +1,33 @@
+package org.apache.openejb.arquillian.tests.bmp.remote;
+
+import javax.naming.InitialContext;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class FinderServlet extends HttpServlet {
+
+    @Override
+    protected void doGet(final HttpServletRequest req, final HttpServletResponse resp) throws ServletException, IOException {
+        final FinderTestHome testHome;
+        InitialContext ctx = null;
+        try {
+            ctx = new InitialContext();
+            testHome = (FinderTestHome) ctx.lookup("java:comp/env/ejb/FinderTest");
+            resp.getWriter().println(testHome.create().runTest());
+            resp.getWriter().flush();
+        } catch (final Exception e) {
+            throw new ServletException(e);
+        } finally {
+            try {
+                if (ctx != null) {
+                    ctx.close();
+                }
+            } catch (final Exception e) {
+                throw new ServletException(e);
+            }
+        }
+    }
+}

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/bmp/remote/FinderTest.java
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/bmp/remote/FinderTest.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.openejb.arquillian.tests.bmp.remote;
+
+import javax.ejb.EJBObject;
+import java.rmi.RemoteException;
+
+public interface FinderTest extends EJBObject {
+    String runTest() throws Exception, RemoteException;
+}

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/bmp/remote/FinderTestBean.java
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/bmp/remote/FinderTestBean.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.openejb.arquillian.tests.bmp.remote;
+
+import javax.ejb.*;
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import java.rmi.RemoteException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Properties;
+
+public class FinderTestBean implements SessionBean {
+
+    public void setSessionContext(final SessionContext context) throws RemoteException {
+    }
+
+    public void ejbRemove() throws RemoteException {
+    }
+
+    public void ejbActivate() throws RemoteException {
+    }
+
+    public void ejbPassivate() throws RemoteException {
+    }
+
+    public void ejbCreate() throws CreateException {
+    }
+
+    public String runTest()
+            throws Exception {
+        final BigFinderHome bigFinderHome = (BigFinderHome) lookup("BigFinderHome");
+        final LittleFinderHome littleFinderHome = (LittleFinderHome) lookup("LittleFinderHome");
+        for (int i = 1; i < 300; ++i) {
+            bigFinderHome.findN(i);
+
+            final Collection littleList = littleFinderHome.findAll();
+            for (final Object obj : littleList) {
+                final StringBuilder msg = new StringBuilder();
+                if (!(obj instanceof LittleFinder)) {
+                    msg.append("Failed with " + i + " records. LittleFinder Remote is actually " + obj.getClass().getName() + " Implemented interfaces " + Arrays.toString(obj.getClass().getInterfaces()));
+                    if (obj instanceof EJBObject) {
+                        final Object pk = ((EJBObject) obj).getPrimaryKey();
+                        msg.append(" Primary key value is " + pk);
+                    }
+
+                    throw new EJBException(msg.toString());
+                }
+            }
+        }
+
+        return "Test succeeded";
+    }
+
+    public static Object lookup(final String s) throws NamingException {
+        final Properties p = new Properties();
+        p.put(Context.INITIAL_CONTEXT_FACTORY, "org.apache.openejb.core.LocalInitialContextFactory");
+        final InitialContext ctx = new InitialContext(p);
+        try {
+            return ctx.lookup("java:comp/env/ejb/" + s);
+        } finally {
+            ctx.close();
+        }
+    }
+
+
+}

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/bmp/remote/FinderTestHome.java
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/bmp/remote/FinderTestHome.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.openejb.arquillian.tests.bmp.remote;
+
+import javax.ejb.CreateException;
+import javax.ejb.EJBHome;
+import java.rmi.RemoteException;
+
+public interface FinderTestHome extends EJBHome {
+    FinderTest create() throws CreateException, RemoteException;
+}

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/bmp/remote/IntegerPK.java
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/bmp/remote/IntegerPK.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.openejb.arquillian.tests.bmp.remote;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Types;
+
+/**
+ * The base class for a primary key for an integer type.
+ */
+public class IntegerPK extends Number {
+    private static final long serialVersionUID = 351946466791640696L;
+    private int m_value;
+
+    public IntegerPK(final int value) {
+        m_value = value;
+    }
+
+    public int getValue() {
+        return m_value;
+    }
+
+    public Object clone() {
+        try {
+            return super.clone();
+        } catch (final CloneNotSupportedException exc) {
+            throw new RuntimeException("Cannot clone", exc);
+        }
+    }
+
+    public boolean equals(final Object o) {
+        if (o == null)
+            return false;
+        return m_value == ((IntegerPK) o).m_value;
+    }
+
+    public int compareTo(final Object o) {
+        return (int) (m_value - ((IntegerPK) o).m_value);
+    }
+
+    public int hashCode() {
+        return m_value;
+    }
+
+    public String toString() {
+        return String.valueOf(m_value);
+    }
+
+    // Number interface
+    public byte byteValue() {
+        return (byte) m_value;
+    }
+
+    public short shortValue() {
+        return (short) m_value;
+    }
+
+    public int intValue() {
+        return m_value;
+    }
+
+    public long longValue() {
+        return m_value;
+    }
+
+    public float floatValue() {
+        return m_value;
+    }
+
+    public double doubleValue() {
+        return m_value;
+    }
+
+    /**
+     * For ParmType interface
+     */
+    public void add(final int i, final PreparedStatement stat) throws SQLException {
+        stat.setInt(i, m_value);
+    }
+
+    public int getType() {
+        return Types.INTEGER;
+    }
+}

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/bmp/remote/LittleFinder.java
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/bmp/remote/LittleFinder.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.openejb.arquillian.tests.bmp.remote;
+
+import javax.ejb.EJBObject;
+
+public interface LittleFinder extends EJBObject {
+}

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/bmp/remote/LittleFinderBean.java
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/bmp/remote/LittleFinderBean.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.openejb.arquillian.tests.bmp.remote;
+
+import javax.ejb.EntityBean;
+import javax.ejb.EntityContext;
+import java.rmi.RemoteException;
+import java.util.ArrayList;
+import java.util.Collection;
+
+public class LittleFinderBean implements EntityBean {
+    private static final long serialVersionUID = -1719910497840449494L;
+
+    public void ejbActivate() throws RemoteException {
+    }
+
+    public void ejbPassivate() throws RemoteException {
+    }
+
+    public void setEntityContext(final EntityContext context) throws RemoteException {
+    }
+
+    public void unsetEntityContext() throws RemoteException {
+    }
+
+    public void ejbLoad() throws RemoteException {
+    }
+
+    public void ejbStore() throws RemoteException {
+    }
+
+    public void ejbRemove() throws RemoteException {
+    }
+
+    public Collection<LittleFinderPK> ejbFindAll() throws Exception {
+        final ArrayList<LittleFinderPK> pks = new ArrayList();
+        pks.add(new LittleFinderPK("1A"));
+        return pks;
+    }
+
+}

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/bmp/remote/LittleFinderHome.java
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/bmp/remote/LittleFinderHome.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.openejb.arquillian.tests.bmp.remote;
+
+import javax.ejb.EJBHome;
+import java.rmi.RemoteException;
+import java.util.Collection;
+
+public interface LittleFinderHome extends EJBHome {
+    Collection<LittleFinder> findAll() throws Exception, RemoteException;
+}

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/bmp/remote/LittleFinderPK.java
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/bmp/remote/LittleFinderPK.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.openejb.arquillian.tests.bmp.remote;
+
+public class LittleFinderPK extends StringPK {
+    private static final long serialVersionUID = 5782590322327281948L;
+
+    public LittleFinderPK(final String s) {
+        super(s);
+    }
+}

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/bmp/remote/StringPK.java
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/java/org/apache/openejb/arquillian/tests/bmp/remote/StringPK.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.openejb.arquillian.tests.bmp.remote;
+
+import java.io.Serializable;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Types;
+
+/**
+ * A primary key in a Database table with a String representation (varchar).
+ */
+public class StringPK implements Serializable {
+    private static final long serialVersionUID = -6429314795121119701L;
+    private String m_value;
+
+    public StringPK(final String s) {
+        m_value = s;
+    }
+
+    public String getValue() {
+        return m_value;
+    }
+
+    public boolean equals(final Object o) {
+        if (o instanceof StringPK) {
+            final StringPK s = (StringPK) o;
+            if (m_value == null)
+                return s.m_value == null;
+            return m_value.equals(s.m_value);
+        } else {
+            return false;
+        }
+    }
+
+    public int compareTo(final Object o) {
+        return ("" + m_value).compareTo(((StringPK) o).m_value);
+    }
+
+    public int hashCode() {
+        return ("" + m_value).hashCode();
+    }
+
+    public String toString() {
+        if (m_value == null)
+            return "NULL";
+        return '\'' + m_value + '\'';
+    }
+
+    public void add(final int i, final PreparedStatement stat) throws SQLException {
+        stat.setString(i, m_value);
+    }
+
+    public int getType() {
+        return Types.VARCHAR;
+    }
+}

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/resources/org/apache/openejb/arquillian/tests/bmp/local/ejb-jar.xml
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/resources/org/apache/openejb/arquillian/tests/bmp/local/ejb-jar.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<ejb-jar>
+    <enterprise-beans>
+        <session>
+            <ejb-name>FinderTestHome</ejb-name>
+            <local-home>org.apache.openejb.arquillian.tests.bmp.local.FinderTestHome</local-home>
+            <local>org.apache.openejb.arquillian.tests.bmp.local.FinderTest</local>
+            <ejb-class>org.apache.openejb.arquillian.tests.bmp.local.FinderTestBean</ejb-class>
+            <session-type>Stateless</session-type>
+            <transaction-type>Container</transaction-type>
+            <ejb-local-ref>
+                <ejb-ref-name>ejb/LittleFinderHome</ejb-ref-name>
+                <ejb-ref-type>Entity</ejb-ref-type>
+                <local-home>org.apache.openejb.arquillian.tests.bmp.local.LittleFinderHome</local-home>
+                <local>org.apache.openejb.arquillian.tests.bmp.local.LittleFinder</local>
+                <ejb-link>LittleFinderHome</ejb-link>
+            </ejb-local-ref>
+            <ejb-local-ref>
+                <ejb-ref-name>ejb/BigFinderHome</ejb-ref-name>
+                <ejb-ref-type>Entity</ejb-ref-type>
+                <local-home>org.apache.openejb.arquillian.tests.bmp.local.BigFinderHome</local-home>
+                <local>org.apache.openejb.arquillian.tests.bmp.local.BigFinder</local>
+                <ejb-link>BigFinderHome</ejb-link>
+            </ejb-local-ref>
+        </session>
+        <entity>
+            <description>LittleFinder</description>
+            <ejb-name>LittleFinderHome</ejb-name>
+            <local-home>org.apache.openejb.arquillian.tests.bmp.local.LittleFinderHome</local-home>
+            <local>org.apache.openejb.arquillian.tests.bmp.local.LittleFinder</local>
+            <ejb-class>org.apache.openejb.arquillian.tests.bmp.local.LittleFinderBean</ejb-class>
+            <persistence-type>Bean</persistence-type>
+            <prim-key-class>org.apache.openejb.arquillian.tests.bmp.local.LittleFinderPK</prim-key-class>
+            <reentrant>False</reentrant>
+        </entity>
+        <entity>
+            <description>BigFinder</description>
+            <ejb-name>BigFinderHome</ejb-name>
+            <local-home>org.apache.openejb.arquillian.tests.bmp.local.BigFinderHome</local-home>
+            <local>org.apache.openejb.arquillian.tests.bmp.local.BigFinder</local>
+            <ejb-class>org.apache.openejb.arquillian.tests.bmp.local.BigFinderBean</ejb-class>
+            <persistence-type>Bean</persistence-type>
+            <prim-key-class>org.apache.openejb.arquillian.tests.bmp.local.BigFinderPK</prim-key-class>
+            <reentrant>False</reentrant>
+        </entity>
+    </enterprise-beans>
+</ejb-jar>
+

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/resources/org/apache/openejb/arquillian/tests/bmp/local/web.xml
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/resources/org/apache/openejb/arquillian/tests/bmp/local/web.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<web-app xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:web="http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee
+        http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
+         id="WebApp_ID" version="2.5">
+
+    <servlet>
+        <servlet-name>TestServlet</servlet-name>
+        <servlet-class>org.apache.openejb.arquillian.tests.bmp.local.FinderServlet</servlet-class>
+    </servlet>
+
+    <servlet-mapping>
+        <servlet-name>TestServlet</servlet-name>
+        <url-pattern>/</url-pattern>
+    </servlet-mapping>
+
+    <ejb-local-ref>
+        <ejb-ref-name>ejb/FinderTest</ejb-ref-name>
+        <ejb-ref-type>Session</ejb-ref-type>
+        <local-home>org.apache.openejb.arquillian.tests.bmp.local.FinderTestHome</local-home>
+        <local>org.apache.openejb.arquillian.tests.bmp.local.FinderTest</local>
+    </ejb-local-ref>
+</web-app>

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/resources/org/apache/openejb/arquillian/tests/bmp/local/web.xml
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/resources/org/apache/openejb/arquillian/tests/bmp/local/web.xml
@@ -30,7 +30,7 @@
 
     <servlet-mapping>
         <servlet-name>TestServlet</servlet-name>
-        <url-pattern>/</url-pattern>
+        <url-pattern>/*</url-pattern>
     </servlet-mapping>
 
     <ejb-local-ref>

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/resources/org/apache/openejb/arquillian/tests/bmp/remote/ejb-jar.xml
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/resources/org/apache/openejb/arquillian/tests/bmp/remote/ejb-jar.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<ejb-jar>
+    <enterprise-beans>
+        <session>
+            <ejb-name>FinderTestHome</ejb-name>
+            <home>org.apache.openejb.arquillian.tests.bmp.remote.FinderTestHome</home>
+            <remote>org.apache.openejb.arquillian.tests.bmp.remote.FinderTest</remote>
+            <ejb-class>org.apache.openejb.arquillian.tests.bmp.remote.FinderTestBean</ejb-class>
+            <session-type>Stateless</session-type>
+            <transaction-type>Container</transaction-type>
+            <ejb-ref>
+                <ejb-ref-name>ejb/LittleFinderHome</ejb-ref-name>
+                <ejb-ref-type>Entity</ejb-ref-type>
+                <home>org.apache.openejb.arquillian.tests.bmp.remote.LittleFinderHome</home>
+                <remote>org.apache.openejb.arquillian.tests.bmp.remote.LittleFinder</remote>
+                <ejb-link>LittleFinderHome</ejb-link>
+            </ejb-ref>
+            <ejb-ref>
+                <ejb-ref-name>ejb/BigFinderHome</ejb-ref-name>
+                <ejb-ref-type>Entity</ejb-ref-type>
+                <home>org.apache.openejb.arquillian.tests.bmp.remote.BigFinderHome</home>
+                <remote>org.apache.openejb.arquillian.tests.bmp.remote.BigFinder</remote>
+                <ejb-link>BigFinderHome</ejb-link>
+            </ejb-ref>
+        </session>
+        <entity>
+            <description>LittleFinder</description>
+            <ejb-name>LittleFinderHome</ejb-name>
+            <home>org.apache.openejb.arquillian.tests.bmp.remote.LittleFinderHome</home>
+            <remote>org.apache.openejb.arquillian.tests.bmp.remote.LittleFinder</remote>
+            <ejb-class>org.apache.openejb.arquillian.tests.bmp.remote.LittleFinderBean</ejb-class>
+            <persistence-type>Bean</persistence-type>
+            <prim-key-class>org.apache.openejb.arquillian.tests.bmp.remote.LittleFinderPK</prim-key-class>
+            <reentrant>False</reentrant>
+        </entity>
+        <entity>
+            <description>BigFinder</description>
+            <ejb-name>BigFinderHome</ejb-name>
+            <home>org.apache.openejb.arquillian.tests.bmp.remote.BigFinderHome</home>
+            <remote>org.apache.openejb.arquillian.tests.bmp.remote.BigFinder</remote>
+            <ejb-class>org.apache.openejb.arquillian.tests.bmp.remote.BigFinderBean</ejb-class>
+            <persistence-type>Bean</persistence-type>
+            <prim-key-class>org.apache.openejb.arquillian.tests.bmp.remote.BigFinderPK</prim-key-class>
+            <reentrant>False</reentrant>
+        </entity>
+    </enterprise-beans>
+</ejb-jar>
+

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/resources/org/apache/openejb/arquillian/tests/bmp/remote/web.xml
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/resources/org/apache/openejb/arquillian/tests/bmp/remote/web.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<web-app xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:web="http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee
+        http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
+         id="WebApp_ID" version="2.5">
+
+    <servlet>
+        <servlet-name>TestServlet</servlet-name>
+        <servlet-class>org.apache.openejb.arquillian.tests.bmp.remote.FinderServlet</servlet-class>
+    </servlet>
+
+    <servlet-mapping>
+        <servlet-name>TestServlet</servlet-name>
+        <url-pattern>/</url-pattern>
+    </servlet-mapping>
+
+    <ejb-ref>
+        <ejb-ref-name>ejb/FinderTest</ejb-ref-name>
+        <ejb-ref-type>Session</ejb-ref-type>
+        <home>org.apache.openejb.arquillian.tests.bmp.remote.FinderTestHome</home>
+        <remote>org.apache.openejb.arquillian.tests.bmp.remote.FinderTest</remote>
+    </ejb-ref>
+</web-app>

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/resources/org/apache/openejb/arquillian/tests/bmp/remote/web.xml
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/resources/org/apache/openejb/arquillian/tests/bmp/remote/web.xml
@@ -30,7 +30,7 @@
 
     <servlet-mapping>
         <servlet-name>TestServlet</servlet-name>
-        <url-pattern>/</url-pattern>
+        <url-pattern>/*</url-pattern>
     </servlet-mapping>
 
     <ejb-ref>

--- a/container/openejb-core/src/main/java/org/apache/openejb/core/ivm/IntraVmArtifact.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/core/ivm/IntraVmArtifact.java
@@ -71,12 +71,12 @@ public class IntraVmArtifact implements Externalizable {
 
     public void writeExternal(final ObjectOutput out) throws IOException {
         out.writeBoolean(staticArtifact);
-        out.write(instanceHandle);
+        out.writeInt(instanceHandle);
     }
 
     public void readExternal(final ObjectInput in) throws IOException {
         staticArtifact = in.readBoolean();
-        instanceHandle = in.read();
+        instanceHandle = in.readInt();
     }
 
     protected Object readResolve() throws ObjectStreamException {


### PR DESCRIPTION
This PR introduces Arquillian tests for BMP finder methods, and addresses an issue when there are more than 256 handles in the stack. The root issue is that when proxies are copied, an `inputstream.read()` and `outputstream.write()` are used to store the handle id, which reads and writes a single byte respectively. This PR flips that to an int.

Local beans do not get cloned in this way, and therefore are not affected by this issue.