### PR TITLE
Adds getModuleId method as a fallback when getJarLocation is null at …

### DIFF
--- a/container/openejb-core/src/main/java/org/apache/openejb/config/CmpJpaConversion.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/config/CmpJpaConversion.java
@@ -267,11 +267,9 @@ public class CmpJpaConversion implements DynamicDeployer {
 
     private String getPersistenceModuleId(final AppModule appModule) {
         if (appModule.getModuleId() != null) {
-
             return Optional.ofNullable(appModule.getJarLocation()).orElse(appModule.getModuleId());
         }
         for (final EjbModule ejbModule : appModule.getEjbModules()) {
-            //return ejbModule.getJarLocation();
             return Optional.ofNullable(appModule.getJarLocation()).orElse(appModule.getModuleId());
         }
         throw new IllegalStateException("Comp must be in an ejb module, this one has none: " + appModule);

--- a/container/openejb-core/src/main/java/org/apache/openejb/config/CmpJpaConversion.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/config/CmpJpaConversion.java
@@ -76,7 +76,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;

--- a/container/openejb-core/src/main/java/org/apache/openejb/config/CmpJpaConversion.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/config/CmpJpaConversion.java
@@ -76,6 +76,8 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.TreeMap;
@@ -266,10 +268,12 @@ public class CmpJpaConversion implements DynamicDeployer {
 
     private String getPersistenceModuleId(final AppModule appModule) {
         if (appModule.getModuleId() != null) {
-            return appModule.getJarLocation();
+
+            return Optional.ofNullable(appModule.getJarLocation()).orElse(appModule.getModuleId());
         }
         for (final EjbModule ejbModule : appModule.getEjbModules()) {
-            return ejbModule.getJarLocation();
+            //return ejbModule.getJarLocation();
+            return Optional.ofNullable(appModule.getJarLocation()).orElse(appModule.getModuleId());
         }
         throw new IllegalStateException("Comp must be in an ejb module, this one has none: " + appModule);
     }


### PR DESCRIPTION
It PR adds the getModuleId method as a fallback when getJarLocation is null at CmpJpaConversion, this way it keeps the desired behavior and fixes the when the getJarLocation is null such as the CheckMissingClassTest.