### PR TITLE
TOMEE-2363 Introduces OWASP dependency check via profile

### DIFF
--- a/owasp-dc-suppression.xml
+++ b/owasp-dc-suppression.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.2.xsd">
+    <suppress>
+        <notes><![CDATA[
+   file name: self dependencies...
+   ]]></notes>
+        <gav regex="true">^org\.apache\.tomee:.*$</gav>
+        <cve>CVE-2018-8031</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+   file name: self dependencies...
+   ]]></notes>
+        <gav regex="true">^org\.apache\.tomee:.*$</gav>
+        <cve>CVE-2010-1151</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+   file name: false positive apache http server
+   ]]></notes>
+        <gav regex="true">^org\.apache\.tomee:.*$</gav>
+        <cpe>cpe:/a:apache:apache_http_server</cpe>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+   file name: false positive apache http server
+   ]]></notes>
+        <gav regex="true">^org\.apache\.tomee:.*$</gav>
+        <cpe>cpe:/a:apache:http_server</cpe>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+   file name: ziplock-*.jar
+   ]]></notes>
+        <gav regex="true">^org\.apache\.tomee:ziplock:.*$</gav>
+        <cpe>cpe:/a:zip_project:zip</cpe>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+   file name: eclipselink-*jar
+   ]]></notes>
+        <gav regex="true">^org\.eclipse\.persistence:eclipselink:.*$</gav>
+        <cpe>cpe:/a:git:git</cpe>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+   file name: eclipselink-*.jar
+   ]]></notes>
+        <gav regex="true">^org\.eclipse\.persistence:eclipselink:.*$</gav>
+        <cpe>cpe:/a:git_project:git</cpe>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+   file name: javax.persistence-*.jar
+   ]]></notes>
+        <gav regex="true">^org\.eclipse\.persistence:javax\.persistence:.*$</gav>
+        <cpe>cpe:/a:git_project:git</cpe>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+   file name: javax.persistence-*.jar
+   ]]></notes>
+        <gav regex="true">^org\.eclipse\.persistence:javax\.persistence:.*$</gav>
+        <cpe>cpe:/a:git:git</cpe>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+   file name: commonj.sdo-*.jar
+   ]]></notes>
+        <gav regex="true">^org\.eclipse\.persistence:commonj\.sdo:.*$</gav>
+        <cpe>cpe:/a:git:git</cpe>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+   file name: commonj.sdo-*.jar
+   ]]></notes>
+        <gav regex="true">^org\.eclipse\.persistence:commonj\.sdo:.*$</gav>
+        <cpe>cpe:/a:git_project:git</cpe>
+    </suppress>
+</suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -369,6 +369,11 @@
           <artifactId>maven-compiler-plugin</artifactId>
           <version>3.6.2</version>
         </plugin>
+        <plugin>
+          <groupId>org.owasp</groupId>
+          <artifactId>dependency-check-maven</artifactId>
+          <version>4.0.0</version>
+        </plugin>
       </plugins>
     </pluginManagement>
 
@@ -656,6 +661,53 @@
     </profile>
 
     <profile>
+      <id>owasp-report</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.owasp</groupId>
+            <artifactId>dependency-check-maven</artifactId>
+            <configuration>
+              <skipProvidedScope>true</skipProvidedScope>
+              <skipRuntimeScope>true</skipRuntimeScope>
+              <suppressionFiles>${maven.multiModuleProjectDirectory}/owasp-dc-suppression.xml</suppressionFiles>
+            </configuration>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>aggregate</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>owasp-check</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.owasp</groupId>
+            <artifactId>dependency-check-maven</artifactId>
+            <configuration>
+              <skipProvidedScope>true</skipProvidedScope>
+              <skipRuntimeScope>true</skipRuntimeScope>
+              <failBuildOnCVSS>8.0</failBuildOnCVSS>
+              <suppressionFiles>${maven.multiModuleProjectDirectory}/owasp-dc-suppression.xml</suppressionFiles>
+            </configuration>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>check</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
       <id>rat</id>
       <modules>
         <module>itests</module>
@@ -686,7 +738,7 @@
               <reportFile>${project.build.directory}/${project.build.finalName}.rat</reportFile>
               <excludes>
                 <exclude>**/target/**/*</exclude>
-		            <exclude>**/js/livereload.js</exclude>
+                <exclude>**/js/livereload.js</exclude>
 
                 <!-- left around after creating the site -->
                 <exclude>**/cobertura.ser</exclude>
@@ -1727,8 +1779,8 @@
         <version>1.2.5</version>
         <exclusions>
           <exclusion>
-              <groupId>xalan</groupId>
-              <artifactId>xalan</artifactId>
+            <groupId>xalan</groupId>
+            <artifactId>xalan</artifactId>
           </exclusion>
         </exclusions>
       </dependency>
@@ -1742,4 +1794,3 @@
     </site>
   </distributionManagement>
 </project>
-


### PR DESCRIPTION
This PR introduces the [OWASP Dependency Check Maven Plugin](https://jeremylong.github.io/DependencyCheck/index.html) in a basic configuration at the parent pom level of the project.

As the dependency checking is quite expensive (see time below), I added it is a separate profile `owasp`. To enable it in the Maven build process, you just need to add `-Powasp-report` or `-Powasp-check`. 
An aggregated report `dependency-check-report.html` is created in the target directory of the root project (only in acse you enabled `-Powasp-report`)

I also added some exclusions related to false positives (see `owasp-dc-suppression.xml`).
I also added the aggregated output for the run on my second system: [dependency-check-report.zip](https://github.com/apache/tomee/files/2690169/dependency-check-report.zip)

Some timings for my system (here Windows, on Linux it is a  lot faster...)

QuickBuild without OWASP: 07:08 min
QuickBuild with OWASP 1st RUN: 26:02 min (pre-caching vulnerabilities)
QuickBuild with OWASP 2nd+ RUN: 13:06 min

Note, with `-Powasp-check` the  the build will fail for a CVE score >= 8.0. However, we should decide on a common CVE score value to do so on the CI systems. 

f this PR holds your expectations, I can backport this to 7.0.x and 7.1.x branches. In a next step, we can analyze the outcomes and create JIRA issue and/or enhance the supress configuration for false positives.
