### PR TITLE
Fixes TOMEE-2261 Make service.bat compatible with JDK11+

### DIFF
--- a/tomee/apache-tomee/src/main/resources/service.bat
+++ b/tomee/apache-tomee/src/main/resources/service.bat
@@ -90,7 +90,7 @@ if not exist "%JRE_HOME%\bin\java.exe" goto noJavaHome
 if not exist "%JRE_HOME%\bin\javaw.exe" goto noJavaHome
 goto okJavaHome
 :gotJdkHome
-for /f tokens^=2-5^ delims^=.-_^" %%j in ('%JAVA_HOME%\bin\java.exe -fullversion 2^>^&1') do set "JAVA_MAJOR_VERSION=%%j"
+for /f tokens^=2^ delims^=.-_^" %%j in ('"%JAVA_HOME%\bin\java.exe" -fullversion 2^>^&1') do set "JAVA_MAJOR_VERSION=%%j"
 if JAVA_MAJOR_VERSION lss 11 (
     if not exist "%JAVA_HOME%\jre\bin\java.exe" goto noJavaHome
     if not exist "%JAVA_HOME%\jre\bin\javaw.exe" goto noJavaHome


### PR DESCRIPTION
When JAVA_HOME is set to a path with a space (e.g. C:\Program Files\Java\jdk11.0.1), I get this error:
```
C:\Program Files\TomEE\bin>service install
11 was unexpected at this time.
```
This is introduced with #178. I fixed it by adding quotes to the path.

Bonus: removal of superfluous tokens which are not used.