### PR TITLE
TOMEE-2252 Update Apache Johnzon to v1.1.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
     <openjpa.version>3.0.0</openjpa.version>
     <openwebbeans.version>2.0.8</openwebbeans.version>
     <jcs.version>2.1</jcs.version>
-    <johnzon.version>1.1.10</johnzon.version>
+    <johnzon.version>1.1.11</johnzon.version>
 
     <!-- Maven module versions -->
     <maven-bundle-plugin.version>3.3.0</maven-bundle-plugin.version>


### PR DESCRIPTION
This PR updates Johnzon to version [1.1.11](https://search.maven.org/artifact/org.apache.johnzon/johnzon/1.1.11/pom) (from 1.1.10) resolving TOMEE-2252. 

All relevant JUnit tests in the module `openejb-cxf-rs` passed successfully on my local dev machine, platform: MacOS 10.14.2, OpenJDK 64-Bit 1.8, Maven 3.5.3.

For reference and details, see Johnzon's [changelog](http://johnzon.apache.org/changelog.html) of version 1.1.11.