### PR TITLE
TOMEE-2436 Get code coverage report from JaCoCo

### DIFF
--- a/container/openejb-core/pom.xml
+++ b/container/openejb-core/pom.xml
@@ -323,6 +323,7 @@
           <forkCount>1</forkCount>
           <testNGArtifactName>none:none</testNGArtifactName>
           <argLine>
+            @{argLine}
             -javaagent:${project.basedir}/target/openejb-javaagent-${project.version}.jar
             -Dopenejb.classloader.forced-skip=org.apache.openejb.jee.,org.apache.openejb.api.
             -Dopenejb.classloader.forced-load=org.apache.openejb
@@ -363,6 +364,26 @@
                 <include>org/apache/openejb/cdi/**</include>
               </includes>
             </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>0.8.2</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+          <!-- attached to Maven test phase -->
+          <execution>
+            <id>report</id>
+            <phase>test</phase>
+            <goals>
+              <goal>report</goal>
+            </goals>
           </execution>
         </executions>
       </plugin>

--- a/container/openejb-core/pom.xml
+++ b/container/openejb-core/pom.xml
@@ -227,6 +227,7 @@
       org.apache.openejb*;version=${openejb.osgi.export.version},
       org.apache.openejb;version=${openejb.osgi.export.version}
     </openejb.osgi.export>
+    <jacocoArgLine></jacocoArgLine>
   </properties>
 
   <build>
@@ -323,7 +324,7 @@
           <forkCount>1</forkCount>
           <testNGArtifactName>none:none</testNGArtifactName>
           <argLine>
-            @{argLine}
+            ${jacocoArgLine}
             -javaagent:${project.basedir}/target/openejb-javaagent-${project.version}.jar
             -Dopenejb.classloader.forced-skip=org.apache.openejb.jee.,org.apache.openejb.api.
             -Dopenejb.classloader.forced-load=org.apache.openejb
@@ -364,26 +365,6 @@
                 <include>org/apache/openejb/cdi/**</include>
               </includes>
             </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.jacoco</groupId>
-        <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.8.2</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>prepare-agent</goal>
-            </goals>
-          </execution>
-          <!-- attached to Maven test phase -->
-          <execution>
-            <id>report</id>
-            <phase>test</phase>
-            <goals>
-              <goal>report</goal>
-            </goals>
           </execution>
         </executions>
       </plugin>
@@ -754,6 +735,20 @@
                 <openejb.home>${project.basedir}/target/test-classes</openejb.home>
               </systemPropertyVariables>
             </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>coverage</id>
+      <properties>
+        <jacocoArgLine>@{argLine}</jacocoArgLine>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.jacoco</groupId>
+            <artifactId>jacoco-maven-plugin</artifactId>
           </plugin>
         </plugins>
       </build>

--- a/pom.xml
+++ b/pom.xml
@@ -379,6 +379,26 @@
           <artifactId>dependency-check-maven</artifactId>
           <version>4.0.0</version>
         </plugin>
+        <plugin>
+          <groupId>org.jacoco</groupId>
+          <artifactId>jacoco-maven-plugin</artifactId>
+          <version>0.8.2</version>
+          <executions>
+            <execution>
+              <goals>
+                <goal>prepare-agent</goal>
+              </goals>
+            </execution>
+            <!-- attached to Maven test phase -->
+            <execution>
+              <id>report</id>
+              <phase>test</phase>
+              <goals>
+                <goal>report</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
       </plugins>
     </pluginManagement>
 


### PR DESCRIPTION
This starts this task off, introducing the plugin at the root level under pluginManagement, and using it in a `coverage` profile on openejb-core.

There's a handful of tests that fail with Jacoco, so we may wish to either find a fix, or split them into a separate execution that does not include jacoco.