### PR TITLE
On Windows getJarLocation returns path like x:\tomee\bla\bla\bla

### DIFF
--- a/container/openejb-core/src/main/java/org/apache/openejb/config/CmpJpaConversion.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/config/CmpJpaConversion.java
@@ -267,10 +267,12 @@ public class CmpJpaConversion implements DynamicDeployer {
 
     private String getPersistenceModuleId(final AppModule appModule) {
         if (appModule.getModuleId() != null) {
-            return Optional.ofNullable(appModule.getJarLocation()).orElse(appModule.getModuleId());
+            return Optional.ofNullable(appModule.getModuleUri().toString()).orElse(appModule.getModuleId());
         }
         for (final EjbModule ejbModule : appModule.getEjbModules()) {
-            return Optional.ofNullable(appModule.getJarLocation()).orElse(appModule.getModuleId());
+            if (ejbModule.getModuleId() != null) {
+                return Optional.ofNullable(ejbModule.getModuleUri().toString()).orElse(ejbModule.getModuleId());
+            }
         }
         throw new IllegalStateException("Comp must be in an ejb module, this one has none: " + appModule);
     }


### PR DESCRIPTION
This is not ok for the code that uses this path and tries to convert it to URL.

For that reason a valid URL string must be returned from this method.

Also the cycle below cycles on ejb modules but generates result from appModule which is already covered before that. Am I wrong here on my assumption?