### PR TITLE
Copy dependency with base version

### DIFF
--- a/examples/simple-cmp2/pom.xml
+++ b/examples/simple-cmp2/pom.xml
@@ -69,6 +69,7 @@
               <goal>copy</goal>
             </goals>
             <configuration>
+              <useBaseVersion>true</useBaseVersion>
               <artifactItems>
                 <artifactItem>
                   <groupId>org.apache.tomee</groupId>


### PR DESCRIPTION
When running against snapshot build dependency must be copied with it's base version.