### PR TITLE
Fix for https://issues.apache.org/jira/browse/TOMEE-2448

### DIFF
--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-jms-tests/src/test/java/org/apache/openejb/arquillian/tests/jms/EnvEntryTest.java
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-jms-tests/src/test/java/org/apache/openejb/arquillian/tests/jms/EnvEntryTest.java
@@ -33,7 +33,6 @@ import java.util.concurrent.Callable;
 
 import static org.junit.Assert.assertEquals;
 
-@Ignore
 @RunWith(Arquillian.class)
 public class EnvEntryTest {
     @EJB

--- a/container/openejb-core/src/main/java/org/apache/openejb/assembler/classic/Assembler.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/assembler/classic/Assembler.java
@@ -925,7 +925,7 @@ public class Assembler extends AssemblerTool implements org.apache.openejb.spi.A
                     factory.register();
                 }
 
-                logger.debug("Loaded peristence units: " + units);
+                logger.debug("Loaded persistence units: " + units);
 
                 // Connectors
                 for (final ConnectorInfo connector : appInfo.connectors) {

--- a/container/openejb-core/src/main/java/org/apache/openejb/cdi/OWBContextThreadListener.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/cdi/OWBContextThreadListener.java
@@ -45,29 +45,33 @@ public class OWBContextThreadListener implements ThreadContextListener {
         final AppContext appContext = moduleContext.getAppContext();
         final WebBeansContext owbContext = appContext.getWebBeansContext();
         final Object oldOWBContext;
+        final OWBContextHolder holder;
         if (owbContext != null) {
             oldOWBContext = singletonService.contextEntered(owbContext);
+            holder = new OWBContextHolder(oldOWBContext);
         } else {
-            oldOWBContext = null;
+            holder = OWBContextHolder.EMPTY_CONTEXT;
         }
-        final OWBContextHolder holder = new OWBContextHolder(oldOWBContext);
         newContext.set(OWBContextHolder.class, holder);
     }
 
     @Override
     public void contextExited(final ThreadContext exitedContext, final ThreadContext reenteredContext) {
-        final OWBContextHolder oldOWBContext = exitedContext.get(OWBContextHolder.class);
-        if (oldOWBContext == null) {
+        final OWBContextHolder holder = exitedContext.get(OWBContextHolder.class);
+        if (holder == null) {
             throw new NullPointerException("OWBContext not set in this thread");
         }
 
-        final Object oldOWBContextContext = oldOWBContext.getContext();
-        if (oldOWBContextContext != null) {
+        if (holder != OWBContextHolder.EMPTY_CONTEXT) {
+            final Object oldOWBContextContext = holder.getContext();
             singletonService.contextExited(oldOWBContextContext);
         }
     }
 
     private static final class OWBContextHolder {
+
+        static OWBContextHolder EMPTY_CONTEXT = new OWBContextHolder(null);
+
         private final Object context;
 
         private OWBContextHolder(final Object context) {


### PR DESCRIPTION
Now new code checks if there is no WebBeansContext it places special holder as marker so when contextExited is called it will know that there is no need to restore previous context.
I've also enabled the EnvEntryTest which works.
There is also one typo fix in Assembler class in openejb-core.