### PR TITLE
increase the time to wait for sweeps. 

### DIFF
--- a/container/openejb-core/src/test/java/org/apache/openejb/core/stateless/StatelessPoolStatsTest.java
+++ b/container/openejb-core/src/test/java/org/apache/openejb/core/stateless/StatelessPoolStatsTest.java
@@ -493,7 +493,7 @@ public class StatelessPoolStatsTest extends TestCase {
 
         deploy("testSweeps", properties);
 
-        Thread.sleep(200);
+        Thread.sleep(300);
 
         final Long sweeps = (Long) (server.getAttribute(objectName, "Sweeps"));
         assertTrue("sweeps=" + sweeps, sweeps >= 1L);

--- a/container/openejb-core/src/test/java/org/apache/openejb/core/stateless/StatelessPoolStatsTest.java
+++ b/container/openejb-core/src/test/java/org/apache/openejb/core/stateless/StatelessPoolStatsTest.java
@@ -487,7 +487,7 @@ public class StatelessPoolStatsTest extends TestCase {
      */
     public void testSweeps() throws Exception {
         final Properties properties = new Properties();
-        properties.setProperty("SweepInterval", "100");
+        properties.setProperty("SweepInterval", "100 MS");
 
         final Date expectedDate = new Date(); // now
 


### PR DESCRIPTION
This will guarantee that there will be at least two sweeps.

- When only one sweep is executed it's LatestTime might be equal to expectedDate. The reason for that it is that sweep event is triggered at the beginning of the sweep and test might need less then 1ms to reach that code.