### PR TITLE
added Docker to mp metrics counted example

### DIFF
--- a/examples/mp-metrics-counted/Dockerfile
+++ b/examples/mp-metrics-counted/Dockerfile
@@ -1,0 +1,14 @@
+FROM tomee:8-jre-8.0.0-M1-microprofile
+
+RUN rm -Rf /usr/local/tomee/webapps/ROOT/
+COPY target/mp-metrics-counted-8.0.0-SNAPSHOT.war /usr/local/tomee/webapps/ROOT.war
+
+RUN groupadd --gid 1001 tomee
+RUN useradd --uid 1001 -g tomee tomee
+
+RUN chmod g=u /etc/passwd
+RUN mkdir -p /home/tomee
+RUN chown -R 1001:0 /home/tomee
+RUN chown -R 1001:0 /usr/local/tomee
+
+USER 1001

--- a/examples/mp-metrics-counted/README.adoc
+++ b/examples/mp-metrics-counted/README.adoc
@@ -11,6 +11,13 @@ This is an example on how to use microprofile metrics in TomEE.
 mvn clean install tomee:run 
 ....
 
+== Alternatively run the application via Docker:
+
+....
+mvn docker:build
+docker run -it --rm -p 8080:8080 --name=tomee-test tomee/mp-metrics-counted
+....
+
 Within the application there is an endpoint that will give you weather
 status for the day and week.
 
@@ -18,6 +25,12 @@ status for the day and week.
 
 ....
 GET http://localhost:8080/mp-metrics-counted/weather/week/status
+....
+
+== If running via Docker, because the application is installed as the ROOT application, remove the application name such as:
+
+....
+GET http://localhost:8080/weather/week/status
 ....
 
 == Response:

--- a/examples/mp-metrics-counted/README.adoc
+++ b/examples/mp-metrics-counted/README.adoc
@@ -17,7 +17,7 @@ status for the day and week.
 == For the day status call:
 
 ....
-GET http://localhost:8080/rest-mp-metrics/weather/day/status
+GET http://localhost:8080/mp-metrics-counted/weather/week/status
 ....
 
 == Response:

--- a/examples/mp-metrics-counted/pom.xml
+++ b/examples/mp-metrics-counted/pom.xml
@@ -35,6 +35,8 @@
         <version.arquillian.bom>1.1.13.Final</version.arquillian.bom>
         <tomee.version>${project.version}</tomee.version>
         <junit.version>4.12</junit.version>
+        <docker.image.name>tomee/${artifactId}</docker.image.name>
+        <docker.file.name>Dockerfile</docker.file.name>
     </properties>
 
     <dependencies>
@@ -102,6 +104,43 @@
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
+                <version>0.28.0</version>
+                <executions>
+                    <execution>
+                        <id>start</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>build</goal>
+                            <goal>start</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>stop</id>
+                        <phase>post-integration-test</phase>
+                        <goals>
+                            <goal>stop</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <pushRegistry>somename</pushRegistry>
+                    <images>
+                        <image>
+                            <name>${docker.image.name}</name>
+                            <build>
+                                <tags>
+                                    <tag>${project.version}</tag>
+                                    <tag>latest</tag>
+                                </tags>
+                                <dockerFile>${project.basedir}/${docker.file.name}</dockerFile >
+                            </build>
+                        </image>
+                    </images>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
This adds Docker to the example.  It does not require the root user and the application is installed as the ROOT application.  It also corrects one of the URLs .