### PR TITLE
Updates the code using new API facilities

### DIFF
--- a/container/openejb-core/src/main/java/org/apache/openejb/Injection.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/Injection.java
@@ -17,6 +17,8 @@
 
 package org.apache.openejb;
 
+import java.util.Objects;
+
 /**
  * @version $Rev$ $Date$
  */
@@ -80,10 +82,10 @@ public class Injection {
 
         final Injection injection = (Injection) o;
 
-        if (name != null ? !name.equals(injection.name) : injection.name != null) {
+        if (!Objects.equals(name, injection.name)) {
             return false;
         }
-        if (classname != null ? !classname.equals(injection.classname) : injection.classname != null) {
+        if (!Objects.equals(classname, injection.classname)) {
             return false;
         }
 

--- a/container/openejb-core/src/main/java/org/apache/openejb/OpenEjbContainer.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/OpenEjbContainer.java
@@ -473,12 +473,7 @@ public final class OpenEjbContainer extends EJBContainer {
 
             if (modules instanceof String) {
                 moduleLocations = configurationFactory.getModulesFromClassPath(null, classLoader);
-                for (final Iterator<File> i = moduleLocations.iterator(); i.hasNext(); ) {
-                    final File file = i.next();
-                    if (!match((String) modules, file)) {
-                        i.remove();
-                    }
-                }
+                moduleLocations.removeIf(file -> !match((String) modules, file));
             } else if (modules instanceof String[]) {
                 // TODO Optimize this so we look specifically for modules by name
                 moduleLocations = configurationFactory.getModulesFromClassPath(null, classLoader);

--- a/container/openejb-core/src/main/java/org/apache/openejb/assembler/classic/Assembler.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/assembler/classic/Assembler.java
@@ -241,6 +241,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
 import java.util.TreeMap;
@@ -3845,7 +3846,7 @@ public class Assembler extends AssemblerTool implements org.apache.openejb.spi.A
 
             final DeploymentListenerObserver that = (DeploymentListenerObserver) o;
 
-            return !(delegate != null ? !delegate.equals(that.delegate) : that.delegate != null);
+            return !(!Objects.equals(delegate, that.delegate));
         }
 
         @Override

--- a/container/openejb-core/src/main/java/org/apache/openejb/assembler/classic/ComparableValidationConfig.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/assembler/classic/ComparableValidationConfig.java
@@ -18,6 +18,7 @@ package org.apache.openejb.assembler.classic;
 
 import java.io.Serializable;
 import java.util.List;
+import java.util.Objects;
 import java.util.Properties;
 
 public class ComparableValidationConfig implements Serializable {
@@ -77,31 +78,31 @@ public class ComparableValidationConfig implements Serializable {
         if (executableValidationEnabled != that.executableValidationEnabled) {
             return false;
         }
-        if (constraintFactoryClass != null ? !constraintFactoryClass.equals(that.constraintFactoryClass) : that.constraintFactoryClass != null) {
+        if (!Objects.equals(constraintFactoryClass, that.constraintFactoryClass)) {
             return false;
         }
-        if (constraintMappings != null ? !constraintMappings.equals(that.constraintMappings) : that.constraintMappings != null) {
+        if (!Objects.equals(constraintMappings, that.constraintMappings)) {
             return false;
         }
-        if (messageInterpolatorClass != null ? !messageInterpolatorClass.equals(that.messageInterpolatorClass) : that.messageInterpolatorClass != null) {
+        if (!Objects.equals(messageInterpolatorClass, that.messageInterpolatorClass)) {
             return false;
         }
-        if (parameterNameProviderClass != null ? !parameterNameProviderClass.equals(that.parameterNameProviderClass) : that.parameterNameProviderClass != null) {
+        if (!Objects.equals(parameterNameProviderClass, that.parameterNameProviderClass)) {
             return false;
         }
-        if (propertyTypes != null ? !propertyTypes.equals(that.propertyTypes) : that.propertyTypes != null) {
+        if (!Objects.equals(propertyTypes, that.propertyTypes)) {
             return false;
         }
-        if (providerClassName != null ? !providerClassName.equals(that.providerClassName) : that.providerClassName != null) {
+        if (!Objects.equals(providerClassName, that.providerClassName)) {
             return false;
         }
-        if (traversableResolverClass != null ? !traversableResolverClass.equals(that.traversableResolverClass) : that.traversableResolverClass != null) {
+        if (!Objects.equals(traversableResolverClass, that.traversableResolverClass)) {
             return false;
         }
-        if (validatedTypes != null ? !validatedTypes.equals(that.validatedTypes) : that.validatedTypes != null) {
+        if (!Objects.equals(validatedTypes, that.validatedTypes)) {
             return false;
         }
-        if (version != null ? !version.equals(that.version) : that.version != null) {
+        if (!Objects.equals(version, that.version)) {
             return false;
         }
         return true;

--- a/container/openejb-core/src/main/java/org/apache/openejb/assembler/classic/MethodInfoUtil.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/assembler/classic/MethodInfoUtil.java
@@ -244,24 +244,25 @@ public class MethodInfoUtil {
 
     private static Class getClassForParam(final String className, final ClassLoader cl) throws ClassNotFoundException {
 
-        if (className.equals("int")) {
-            return Integer.TYPE;
-        } else if (className.equals("double")) {
-            return Double.TYPE;
-        } else if (className.equals("long")) {
-            return Long.TYPE;
-        } else if (className.equals("boolean")) {
-            return Boolean.TYPE;
-        } else if (className.equals("float")) {
-            return Float.TYPE;
-        } else if (className.equals("char")) {
-            return Character.TYPE;
-        } else if (className.equals("short")) {
-            return Short.TYPE;
-        } else if (className.equals("byte")) {
-            return Byte.TYPE;
-        } else {
-            return Class.forName(className, false, cl);
+        switch (className) {
+            case "int":
+                return Integer.TYPE;
+            case "double":
+                return Double.TYPE;
+            case "long":
+                return Long.TYPE;
+            case "boolean":
+                return Boolean.TYPE;
+            case "float":
+                return Float.TYPE;
+            case "char":
+                return Character.TYPE;
+            case "short":
+                return Short.TYPE;
+            case "byte":
+                return Byte.TYPE;
+            default:
+                return Class.forName(className, false, cl);
         }
 
     }

--- a/container/openejb-core/src/main/java/org/apache/openejb/assembler/classic/MethodInfoUtil.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/assembler/classic/MethodInfoUtil.java
@@ -33,6 +33,7 @@ import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import static java.util.Arrays.asList;
 
@@ -403,7 +404,7 @@ public class MethodInfoUtil {
             if (!method.equals(that.method)) {
                 return false;
             }
-            if (view != null ? !view.equals(that.view) : that.view != null) {
+            if (!Objects.equals(view, that.view)) {
                 return false;
             }
 

--- a/container/openejb-core/src/main/java/org/apache/openejb/assembler/classic/ReloadableEntityManagerFactory.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/assembler/classic/ReloadableEntityManagerFactory.java
@@ -368,16 +368,22 @@ public class ReloadableEntityManagerFactory implements EntityManagerFactory, Ser
     public synchronized void setProvider(final String providerRaw) {
         final String provider = providerRaw.trim();
         final String newProvider;
-        if ("hibernate".equals(provider)) {
-            newProvider = "org.hibernate.ejb.HibernatePersistence";
-        } else if ("openjpa".equals(provider)) {
-            newProvider = "org.apache.openjpa.persistence.PersistenceProviderImpl";
-        } else if ("eclipselink".equals(provider)) {
-            newProvider = "org.eclipse.persistence.jpa.PersistenceProvider";
-        } else if ("toplink".equals(provider)) {
-            newProvider = "oracle.toplink.essentials.PersistenceProvider";
-        } else {
-            newProvider = provider;
+        switch (provider) {
+            case "hibernate":
+                newProvider = "org.hibernate.ejb.HibernatePersistence";
+                break;
+            case "openjpa":
+                newProvider = "org.apache.openjpa.persistence.PersistenceProviderImpl";
+                break;
+            case "eclipselink":
+                newProvider = "org.eclipse.persistence.jpa.PersistenceProvider";
+                break;
+            case "toplink":
+                newProvider = "oracle.toplink.essentials.PersistenceProvider";
+                break;
+            default:
+                newProvider = provider;
+                break;
         }
 
         try {

--- a/container/openejb-core/src/main/java/org/apache/openejb/config/ScanUtil.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/config/ScanUtil.java
@@ -53,13 +53,17 @@ public final class ScanUtil {
 
         @Override
         public void startElement(final String uri, final String localName, final String qName, final Attributes attributes) throws SAXException {
-            if (qName.equals("class")) {
-                current = classes;
-            } else if (qName.equals("package")) {
-                current = packages;
-            } else if (qName.equals("scan")) {
-                final String optimized = attributes.getValue("optimized");
-                this.optimized = optimized == null || Boolean.parseBoolean(optimized);
+            switch (qName) {
+                case "class":
+                    current = classes;
+                    break;
+                case "package":
+                    current = packages;
+                    break;
+                case "scan":
+                    final String optimized = attributes.getValue("optimized");
+                    this.optimized = optimized == null || Boolean.parseBoolean(optimized);
+                    break;
             }
         }
 

--- a/container/openejb-core/src/main/java/org/apache/openejb/config/provider/ID.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/config/provider/ID.java
@@ -17,6 +17,8 @@
 
 package org.apache.openejb.config.provider;
 
+import java.util.Objects;
+
 /**
  * IDs are not case-sensitive
  */
@@ -91,7 +93,7 @@ public class ID {
         if (!name.equals(id.name)) {
             return false;
         }
-        if (namespace != null ? !namespace.equals(id.namespace) : id.namespace != null) {
+        if (!Objects.equals(namespace, id.namespace)) {
             return false;
         }
 

--- a/container/openejb-core/src/main/java/org/apache/openejb/config/sys/AbstractService.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/config/sys/AbstractService.java
@@ -26,6 +26,7 @@ import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.XmlValue;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import java.util.Objects;
 import java.util.Properties;
 
 /**
@@ -265,19 +266,19 @@ public abstract class AbstractService implements Service {
 
         final AbstractService that = (AbstractService) o;
 
-        if (id != null ? !id.equals(that.id) : that.id != null) {
+        if (!Objects.equals(id, that.id)) {
             return false;
         }
-        if (jar != null ? !jar.equals(that.jar) : that.jar != null) {
+        if (!Objects.equals(jar, that.jar)) {
             return false;
         }
-        if (type != null ? !type.equals(that.type) : that.type != null) {
+        if (!Objects.equals(type, that.type)) {
             return false;
         }
-        if (provider != null ? !provider.equals(that.provider) : that.provider != null) {
+        if (!Objects.equals(provider, that.provider)) {
             return false;
         }
-        if (properties != null ? !properties.equals(that.properties) : that.properties != null) {
+        if (!Objects.equals(properties, that.properties)) {
             return false;
         }
 

--- a/container/openejb-core/src/main/java/org/apache/openejb/config/sys/Resource.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/config/sys/Resource.java
@@ -25,6 +25,7 @@ import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 
 /**
@@ -139,7 +140,7 @@ public class Resource extends AbstractService {
 
         final Resource resource = (Resource) o;
 
-        if (jndi != null ? !jndi.equals(resource.jndi) : resource.jndi != null) {
+        if (!Objects.equals(jndi, resource.jndi)) {
             return false;
         }
 

--- a/container/openejb-core/src/main/java/org/apache/openejb/core/entity/EntityEjbObjectHandler.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/core/entity/EntityEjbObjectHandler.java
@@ -26,6 +26,7 @@ import org.apache.openejb.util.proxy.ProxyManager;
 import java.io.Serializable;
 import java.lang.reflect.Method;
 import java.util.List;
+import java.util.Objects;
 
 public class EntityEjbObjectHandler extends EjbObjectProxyHandler {
 
@@ -138,7 +139,7 @@ public class EntityEjbObjectHandler extends EjbObjectProxyHandler {
 
             return containerId.equals(that.containerId) &&
                 deploymentId.equals(that.deploymentId) &&
-                !(primaryKey != null ? !primaryKey.equals(that.primaryKey) : that.primaryKey != null);
+                !(!Objects.equals(primaryKey, that.primaryKey));
         }
 
         public int hashCode() {

--- a/container/openejb-core/src/main/java/org/apache/openejb/core/interceptor/InterceptorData.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/core/interceptor/InterceptorData.java
@@ -39,6 +39,7 @@ import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -178,7 +179,7 @@ public class InterceptorData {
 
         final InterceptorData that = (InterceptorData) o;
 
-        if (clazz != null ? !clazz.equals(that.clazz) : that.clazz != null) {
+        if (!Objects.equals(clazz, that.clazz)) {
             return false;
         }
 

--- a/container/openejb-core/src/main/java/org/apache/openejb/core/ivm/BaseEjbProxyHandler.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/core/ivm/BaseEjbProxyHandler.java
@@ -68,6 +68,7 @@ import java.rmi.RemoteException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.WeakHashMap;
 import java.util.concurrent.ConcurrentHashMap;
@@ -538,7 +539,7 @@ public abstract class BaseEjbProxyHandler implements InvocationHandler, Serializ
     }
 
     protected boolean equalHandler(final BaseEjbProxyHandler other) {
-        return (primaryKey == null ? other.primaryKey == null : primaryKey.equals(other.primaryKey))
+        return (Objects.equals(primaryKey, other.primaryKey))
             && deploymentID.equals(other.deploymentID)
             && getMainInterface().equals(other.getMainInterface());
     }

--- a/container/openejb-core/src/main/java/org/apache/openejb/core/ivm/BaseEjbProxyHandler.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/core/ivm/BaseEjbProxyHandler.java
@@ -283,14 +283,15 @@ public abstract class BaseEjbProxyHandler implements InvocationHandler, Serializ
         if (method.getDeclaringClass() == Object.class) {
             final String methodName = method.getName();
 
-            if (methodName.equals("toString")) {
-                return toString();
-            } else if (methodName.equals("equals")) {
-                return equals(args[0]) ? Boolean.TRUE : Boolean.FALSE;
-            } else if (methodName.equals("hashCode")) {
-                return hashCode();
-            } else {
-                throw new UnsupportedOperationException("Unknown method: " + method);
+            switch (methodName) {
+                case "toString":
+                    return toString();
+                case "equals":
+                    return equals(args[0]) ? Boolean.TRUE : Boolean.FALSE;
+                case "hashCode":
+                    return hashCode();
+                default:
+                    throw new UnsupportedOperationException("Unknown method: " + method);
             }
         } else if (method.getDeclaringClass() == IntraVmProxy.class) {
             final String methodName = method.getName();

--- a/container/openejb-core/src/main/java/org/apache/openejb/core/ivm/naming/NameNode.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/core/ivm/naming/NameNode.java
@@ -218,13 +218,7 @@ public class NameNode implements Serializable {
 
 
     public int compareTo(final int otherHash) {
-        if (atomicHash == otherHash) {
-            return 0;
-        } else if (atomicHash > otherHash) {
-            return 1;
-        } else {
-            return -1;
-        }
+        return Integer.compare(atomicHash, otherHash);
     }
 
     private void bind(final NameNode node) {

--- a/container/openejb-core/src/main/java/org/apache/openejb/core/ivm/naming/ParsedName.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/core/ivm/naming/ParsedName.java
@@ -82,13 +82,7 @@ public class ParsedName implements Serializable {
     }
 
     public int compareTo(final int otherHash) {
-        if (hashcode == otherHash) {
-            return 0;
-        } else if (hashcode > otherHash) {
-            return 1;
-        } else {
-            return -1;
-        }
+        return Integer.compare(hashcode, otherHash);
     }
 
     public int getComponentHashCode() {

--- a/container/openejb-core/src/main/java/org/apache/openejb/core/managed/ManagedObjectHandler.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/core/managed/ManagedObjectHandler.java
@@ -27,6 +27,7 @@ import java.io.Serializable;
 import java.lang.reflect.Method;
 import java.rmi.RemoteException;
 import java.util.List;
+import java.util.Objects;
 
 public class ManagedObjectHandler extends EjbObjectProxyHandler {
 
@@ -106,7 +107,7 @@ public class ManagedObjectHandler extends EjbObjectProxyHandler {
 
             return containerId.equals(that.containerId) &&
                 deploymentId.equals(that.deploymentId) &&
-                !(primaryKey != null ? !primaryKey.equals(that.primaryKey) : that.primaryKey != null);
+                !(!Objects.equals(primaryKey, that.primaryKey));
         }
 
         public int hashCode() {

--- a/container/openejb-core/src/main/java/org/apache/openejb/core/mdb/MdbInstanceManager.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/core/mdb/MdbInstanceManager.java
@@ -643,7 +643,7 @@ public class MdbInstanceManager {
                                        final Data data, final InstanceSupplier supplier) {
             this.data = data;
             this.supplier = supplier;
-            this.offset = maxAge > 0 ? (long) (maxAge / maxAgeOffset * min * iteration) % maxAge : 0l;
+            this.offset = maxAge > 0 ? (long) (maxAge / maxAgeOffset * min * iteration) % maxAge : 0L;
         }
 
         @Override

--- a/container/openejb-core/src/main/java/org/apache/openejb/core/security/AbstractSecurityService.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/core/security/AbstractSecurityService.java
@@ -50,6 +50,7 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
 import java.util.UUID;
@@ -507,7 +508,7 @@ public abstract class AbstractSecurityService implements DestroyableResource, Se
             }
 
             final User user = User.class.cast(o);
-            return !(name != null ? !name.equals(user.name) : user.name != null);
+            return !(!Objects.equals(name, user.name));
 
         }
 

--- a/container/openejb-core/src/main/java/org/apache/openejb/core/stateful/StatefulEjbObjectHandler.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/core/stateful/StatefulEjbObjectHandler.java
@@ -27,6 +27,7 @@ import java.io.Serializable;
 import java.lang.reflect.Method;
 import java.rmi.RemoteException;
 import java.util.List;
+import java.util.Objects;
 
 public class StatefulEjbObjectHandler extends EjbObjectProxyHandler {
 
@@ -106,7 +107,7 @@ public class StatefulEjbObjectHandler extends EjbObjectProxyHandler {
 
             return containerId.equals(that.containerId) &&
                 deploymentId.equals(that.deploymentId) &&
-                !(primaryKey != null ? !primaryKey.equals(that.primaryKey) : that.primaryKey != null);
+                !(!Objects.equals(primaryKey, that.primaryKey));
         }
 
         public int hashCode() {

--- a/container/openejb-core/src/main/java/org/apache/openejb/core/stateless/StatelessInstanceManager.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/core/stateless/StatelessInstanceManager.java
@@ -547,7 +547,7 @@ public class StatelessInstanceManager {
         public void run() {
             final Instance obj = supplier.create();
             if (obj != null) {
-                final long offset = maxAge > 0 ? (long) (maxAge / maxAgeOffset * min * iteration) % maxAge : 0l;
+                final long offset = maxAge > 0 ? (long) (maxAge / maxAgeOffset * min * iteration) % maxAge : 0L;
                 data.getPool().add(obj, offset);
             }
         }

--- a/container/openejb-core/src/main/java/org/apache/openejb/math/util/MathUtils.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/math/util/MathUtils.java
@@ -93,13 +93,13 @@ public final class MathUtils {
      * All long-representable factorials
      */
     private static final long[] FACTORIALS = new long[]{
-        1l, 1l, 2l,
-        6l, 24l, 120l,
-        720l, 5040l, 40320l,
-        362880l, 3628800l, 39916800l,
-        479001600l, 6227020800l, 87178291200l,
-        1307674368000l, 20922789888000l, 355687428096000l,
-        6402373705728000l, 121645100408832000l, 2432902008176640000l};
+            1L, 1L, 2L,
+            6L, 24L, 120L,
+            720L, 5040L, 40320L,
+            362880L, 3628800L, 39916800L,
+            479001600L, 6227020800L, 87178291200L,
+            1307674368000L, 20922789888000L, 355687428096000L,
+            6402373705728000L, 121645100408832000L, 2432902008176640000L};
 
     /**
      * Private Constructor
@@ -1600,7 +1600,7 @@ public final class MathUtils {
                 k, e);
         }
 
-        long result = 1l;
+        long result = 1L;
         long k2p = k;
         while (e != 0) {
             if ((e & 0x1) != 0) {
@@ -1631,7 +1631,7 @@ public final class MathUtils {
                 k, e);
         }
 
-        long result = 1l;
+        long result = 1L;
         long k2p = k;
         while (e != 0) {
             if ((e & 0x1) != 0) {

--- a/container/openejb-core/src/main/java/org/apache/openejb/math/util/MathUtils.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/math/util/MathUtils.java
@@ -1434,7 +1434,7 @@ public final class MathUtils {
      * @return +1, 0, or -1, depending on the sign of x
      */
     public static int sign(final int x) {
-        return x == 0 ? 0 : x > 0 ? 1 : -1;
+        return Integer.compare(x, 0);
     }
 
     /**

--- a/container/openejb-core/src/main/java/org/apache/openejb/persistence/CriteriaLogQuery.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/persistence/CriteriaLogQuery.java
@@ -94,18 +94,28 @@ public class CriteriaLogQuery<T> implements TypedQuery<T> {
         }
 
         final String msg = "executing query '" + query + "'";
-        if (logLevel.equals("info")) {
-            LOGGER.info(msg);
-        } else if (logLevel.equals("debug") || logLevel.equals("fine") || logLevel.equals("finest")) {
-            LOGGER.debug(msg);
-        } else if (logLevel.equals("error")) {
-            LOGGER.error(msg);
-        } else if (logLevel.equals("fatal")) {
-            LOGGER.fatal(msg);
-        } else if (logLevel.equals("warning") || logLevel.equals("warn")) {
-            LOGGER.warning(msg);
-        } else {
-            LOGGER.debug(msg);
+        switch (logLevel) {
+            case "info":
+                LOGGER.info(msg);
+                break;
+            case "debug":
+            case "fine":
+            case "finest":
+                LOGGER.debug(msg);
+                break;
+            case "error":
+                LOGGER.error(msg);
+                break;
+            case "fatal":
+                LOGGER.fatal(msg);
+                break;
+            case "warning":
+            case "warn":
+                LOGGER.warning(msg);
+                break;
+            default:
+                LOGGER.debug(msg);
+                break;
         }
     }
 

--- a/container/openejb-core/src/main/java/org/apache/openejb/persistence/PersistenceBootstrap.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/persistence/PersistenceBootstrap.java
@@ -337,12 +337,16 @@ public class PersistenceBootstrap {
             }
 
             public void endElement(final String uri, final String localName, final String qName) {
-                if (localName.equals("persistence-unit")) {
-                    endPersistenceUnit(uri, localName, qName);
-                } else if (localName.equals("provider")) {
-                    endProvider(uri, localName, qName);
-                } else if (localName.equals("class")) {
-                    endClass(uri, localName, qName);
+                switch (localName) {
+                    case "persistence-unit":
+                        endPersistenceUnit(uri, localName, qName);
+                        break;
+                    case "provider":
+                        endProvider(uri, localName, qName);
+                        break;
+                    case "class":
+                        endClass(uri, localName, qName);
+                        break;
                 }
             }
 

--- a/container/openejb-core/src/main/java/org/apache/openejb/resource/activemq/jms2/cdi/JMS2CDIExtension.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/resource/activemq/jms2/cdi/JMS2CDIExtension.java
@@ -60,6 +60,7 @@ import javax.transaction.SystemException;
 import javax.transaction.TransactionScoped;
 import java.io.Serializable;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
 // this extension adds to CDI a producer a JMSContext,
@@ -238,7 +239,7 @@ public class JMS2CDIExtension implements Extension {
             return connectionFactory != null ? connectionFactory.equals(key.connectionFactory) : key.connectionFactory == null
                 && (username != null ? username.equals(key.username) : key.username == null
                 && (password != null ? password.equals(key.password) : key.password == null
-                && (session != null ? session.equals(key.session) : key.session == null)));
+                && (Objects.equals(session, key.session))));
 
         }
 

--- a/container/openejb-core/src/main/java/org/apache/openejb/resource/jdbc/managed/local/ManagedConnection.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/resource/jdbc/managed/local/ManagedConnection.java
@@ -39,6 +39,7 @@ import java.lang.reflect.Proxy;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Wrapper;
+import java.util.Objects;
 
 public class ManagedConnection implements InvocationHandler {
     private final TransactionManager transactionManager;
@@ -313,8 +314,8 @@ public class ManagedConnection implements InvocationHandler {
 
             Key key = Key.class.cast(o);
             return (ds == key.ds || ds.equals(key.ds)) &&
-                    !(user != null ? !user.equals(key.user) : key.user != null) &&
-                    !(pwd != null ? !pwd.equals(key.pwd) : key.pwd != null);
+                    !(!Objects.equals(user, key.user)) &&
+                    !(!Objects.equals(pwd, key.pwd));
         }
 
         @Override

--- a/container/openejb-core/src/main/java/org/apache/openejb/util/Logger.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/util/Logger.java
@@ -423,32 +423,39 @@ public class Logger {
     @SuppressWarnings("UnusedDeclaration")
     public boolean isLevelEnable(final String level) {
         final String levelLowerCase = level.toLowerCase(Locale.ENGLISH);
-        if ("info".equals(levelLowerCase)) {
-            return isInfoEnabled();
-        } else if ("debug".equals(levelLowerCase)) {
-            return isDebugEnabled();
-        } else if ("warning".equals(levelLowerCase)) {
-            return isWarningEnabled();
-        } else if ("fatal".equals(levelLowerCase)) {
-            return isFatalEnabled();
-        } else if ("error".equals(levelLowerCase)) {
-            return isErrorEnabled();
+        switch (levelLowerCase) {
+            case "info":
+                return isInfoEnabled();
+            case "debug":
+                return isDebugEnabled();
+            case "warning":
+                return isWarningEnabled();
+            case "fatal":
+                return isFatalEnabled();
+            case "error":
+                return isErrorEnabled();
         }
         return false;
     }
 
     public void log(final String level, final String message) {
         final String levelLowerCase = level.toLowerCase(Locale.ENGLISH);
-        if ("info".equals(levelLowerCase)) {
-            info(message);
-        } else if ("debug".equals(levelLowerCase)) {
-            debug(message);
-        } else if ("warning".equals(levelLowerCase)) {
-            warning(message);
-        } else if ("fatal".equals(levelLowerCase)) {
-            fatal(message);
-        } else if ("error".equals(levelLowerCase)) {
-            error(message);
+        switch (levelLowerCase) {
+            case "info":
+                info(message);
+                break;
+            case "debug":
+                debug(message);
+                break;
+            case "warning":
+                warning(message);
+                break;
+            case "fatal":
+                fatal(message);
+                break;
+            case "error":
+                error(message);
+                break;
         }
     }
 

--- a/container/openejb-core/src/test/java/org/apache/openejb/config/InheritenceTest.java
+++ b/container/openejb-core/src/test/java/org/apache/openejb/config/InheritenceTest.java
@@ -79,6 +79,7 @@ import javax.sql.DataSource;
 import java.rmi.RemoteException;
 import java.util.List;
 import java.util.ListIterator;
+import java.util.Objects;
 
 /**
  * @version $Rev$ $Date$
@@ -294,8 +295,8 @@ public class InheritenceTest extends TestCase {
         if (a == null && b == null) return true;
         if (a == null || b == null) return false;
 
-        if (a.jndiName != null ? !a.jndiName.equals(b.jndiName) : b.jndiName != null) return false;
-        if (a.jndiProviderId != null ? !a.jndiProviderId.equals(b.jndiProviderId) : b.jndiProviderId != null)
+        if (!Objects.equals(a.jndiName, b.jndiName)) return false;
+        if (!Objects.equals(a.jndiProviderId, b.jndiProviderId))
             return false;
 
         return true;
@@ -325,9 +326,9 @@ public class InheritenceTest extends TestCase {
         if (a == null && b == null) return true;
         if (a == null || b == null) return false;
 
-        if (a.referenceName != null ? !a.referenceName.equals(b.referenceName) : b.referenceName != null) return false;
-        if (a.type != null ? !a.type.equals(b.type) : b.type != null) return false;
-        if (a.value != null ? !a.value.equals(b.value) : b.value != null) return false;
+        if (!Objects.equals(a.referenceName, b.referenceName)) return false;
+        if (!Objects.equals(a.type, b.type)) return false;
+        if (!Objects.equals(a.value, b.value)) return false;
         if (!equals(a.location, b.location)) return false;
         if (!equalsInjectionInfos(a.targets, b.targets)) return false;
 
@@ -358,8 +359,8 @@ public class InheritenceTest extends TestCase {
         if (a == null && b == null) return true;
         if (a == null || b == null) return false;
 
-        if (a.propertyName != null ? !a.propertyName.equals(b.propertyName) : b.propertyName != null) return false;
-        if (a.className != null ? !a.className.equals(b.className) : b.className != null) return false;
+        if (!Objects.equals(a.propertyName, b.propertyName)) return false;
+        if (!Objects.equals(a.className, b.className)) return false;
 
         return true;
     }
@@ -388,13 +389,13 @@ public class InheritenceTest extends TestCase {
         if (a == null && b == null) return true;
         if (a == null || b == null) return false;
 
-        if (a.referenceName != null ? !a.referenceName.equals(b.referenceName) : b.referenceName != null) return false;
-        if (a.homeClassName != null ? !a.homeClassName.equals(b.homeClassName) : b.homeClassName != null) return false;
-        if (a.interfaceClassName != null ? !a.interfaceClassName.equals(b.interfaceClassName) : b.interfaceClassName != null)
+        if (!Objects.equals(a.referenceName, b.referenceName)) return false;
+        if (!Objects.equals(a.homeClassName, b.homeClassName)) return false;
+        if (!Objects.equals(a.interfaceClassName, b.interfaceClassName))
             return false;
-        if (a.ejbDeploymentId != null ? !a.ejbDeploymentId.equals(b.ejbDeploymentId) : b.ejbDeploymentId != null)
+        if (!Objects.equals(a.ejbDeploymentId, b.ejbDeploymentId))
             return false;
-        if (a.link != null ? !a.link.equals(b.link) : b.link != null) return false;
+        if (!Objects.equals(a.link, b.link)) return false;
         if (a.externalReference != b.externalReference) return false;
         if (!equals(a.location, b.location)) return false;
         if (!equalsInjectionInfos(a.targets, b.targets)) return false;
@@ -442,11 +443,11 @@ public class InheritenceTest extends TestCase {
         if (a == null && b == null) return true;
         if (a == null || b == null) return false;
 
-        if (a.referenceName != null ? !a.referenceName.equals(b.referenceName) : b.referenceName != null) return false;
-        if (a.referenceType != null ? !a.referenceType.equals(b.referenceType) : b.referenceType != null) return false;
-        if (a.referenceAuth != null ? !a.referenceAuth.equals(b.referenceAuth) : b.referenceAuth != null) return false;
-        if (a.resourceID != null ? !a.resourceID.equals(b.resourceID) : b.resourceID != null) return false;
-        if (a.properties != null ? !a.properties.equals(b.properties) : b.properties != null) return false;
+        if (!Objects.equals(a.referenceName, b.referenceName)) return false;
+        if (!Objects.equals(a.referenceType, b.referenceType)) return false;
+        if (!Objects.equals(a.referenceAuth, b.referenceAuth)) return false;
+        if (!Objects.equals(a.resourceID, b.resourceID)) return false;
+        if (!Objects.equals(a.properties, b.properties)) return false;
         if (!equals(a.location, b.location)) return false;
         if (!equalsInjectionInfos(a.targets, b.targets)) return false;
 
@@ -477,10 +478,10 @@ public class InheritenceTest extends TestCase {
         if (a == null && b == null) return true;
         if (a == null || b == null) return false;
 
-        if (a.referenceName != null ? !a.referenceName.equals(b.referenceName) : b.referenceName != null) return false;
-        if (a.persistenceUnitName != null ? !a.persistenceUnitName.equals(b.persistenceUnitName) : b.persistenceUnitName != null)
+        if (!Objects.equals(a.referenceName, b.referenceName)) return false;
+        if (!Objects.equals(a.persistenceUnitName, b.persistenceUnitName))
             return false;
-        if (a.unitId != null ? !a.unitId.equals(b.unitId) : b.unitId != null) return false;
+        if (!Objects.equals(a.unitId, b.unitId)) return false;
         if (!equals(a.location, b.location)) return false;
         if (!equalsInjectionInfos(a.targets, b.targets)) return false;
 
@@ -511,10 +512,10 @@ public class InheritenceTest extends TestCase {
         if (a == null && b == null) return true;
         if (a == null || b == null) return false;
 
-        if (a.referenceName != null ? !a.referenceName.equals(b.referenceName) : b.referenceName != null) return false;
-        if (a.persistenceUnitName != null ? !a.persistenceUnitName.equals(b.persistenceUnitName) : b.persistenceUnitName != null)
+        if (!Objects.equals(a.referenceName, b.referenceName)) return false;
+        if (!Objects.equals(a.persistenceUnitName, b.persistenceUnitName))
             return false;
-        if (a.unitId != null ? !a.unitId.equals(b.unitId) : b.unitId != null) return false;
+        if (!Objects.equals(a.unitId, b.unitId)) return false;
         if (a.extended != b.extended) return false;
         if (a.properties != null ? !a.properties.equals(b.properties) : b.properties != null) return false;
         if (!equals(a.location, b.location)) return false;
@@ -547,12 +548,12 @@ public class InheritenceTest extends TestCase {
         if (a == null && b == null) return true;
         if (a == null || b == null) return false;
 
-        if (a.referenceName != null ? !a.referenceName.equals(b.referenceName) : b.referenceName != null)
+        if (!Objects.equals(a.referenceName, b.referenceName))
             return false;
-        if (a.resourceEnvRefType != null ? !a.resourceEnvRefType.equals(b.resourceEnvRefType) : b.resourceEnvRefType != null)
+        if (!Objects.equals(a.resourceEnvRefType, b.resourceEnvRefType))
             return false;
-        if (a.mappedName != null ? !a.mappedName.equals(b.mappedName) : b.mappedName != null) return false;
-        if (a.resourceID != null ? !a.resourceID.equals(b.resourceID) : b.resourceID != null) return false;
+        if (!Objects.equals(a.mappedName, b.mappedName)) return false;
+        if (!Objects.equals(a.resourceID, b.resourceID)) return false;
         if (!equals(a.location, b.location)) return false;
         if (!equalsInjectionInfos(a.targets, b.targets)) return false;
 
@@ -584,15 +585,15 @@ public class InheritenceTest extends TestCase {
         if (a == null && b == null) return true;
         if (a == null || b == null) return false;
 
-        if (a.referenceName != null ? !a.referenceName.equals(b.referenceName) : b.referenceName != null) return false;
-        if (a.serviceQName != null ? !a.serviceQName.equals(b.serviceQName) : b.serviceQName != null) return false;
-        if (a.serviceType != null ? !a.serviceType.equals(b.serviceType) : b.serviceType != null) return false;
-        if (a.portQName != null ? !a.portQName.equals(b.portQName) : b.portQName != null) return false;
-        if (a.referenceType != null ? !a.referenceType.equals(b.referenceType) : b.referenceType != null) return false;
-        if (a.wsdlFile != null ? !a.wsdlFile.equals(b.wsdlFile) : b.wsdlFile != null) return false;
-        if (a.jaxrpcMappingFile != null ? !a.jaxrpcMappingFile.equals(b.jaxrpcMappingFile) : b.jaxrpcMappingFile != null)
+        if (!Objects.equals(a.referenceName, b.referenceName)) return false;
+        if (!Objects.equals(a.serviceQName, b.serviceQName)) return false;
+        if (!Objects.equals(a.serviceType, b.serviceType)) return false;
+        if (!Objects.equals(a.portQName, b.portQName)) return false;
+        if (!Objects.equals(a.referenceType, b.referenceType)) return false;
+        if (!Objects.equals(a.wsdlFile, b.wsdlFile)) return false;
+        if (!Objects.equals(a.jaxrpcMappingFile, b.jaxrpcMappingFile))
             return false;
-        if (a.id != null ? !a.id.equals(b.id) : b.id != null) return false;
+        if (!Objects.equals(a.id, b.id)) return false;
         if (!equalsHandlerChainInfos(a.handlerChains, b.handlerChains)) return false;
         if (!equalsPortRefInfos(a.portRefs, b.portRefs)) return false;
         if (!equals(a.location, b.location)) return false;
@@ -625,9 +626,9 @@ public class InheritenceTest extends TestCase {
         if (a == null && b == null) return true;
         if (a == null || b == null) return false;
 
-        if (a.serviceNamePattern != null ? !a.serviceNamePattern.equals(b.serviceNamePattern) : b.serviceNamePattern != null)
+        if (!Objects.equals(a.serviceNamePattern, b.serviceNamePattern))
             return false;
-        if (a.portNamePattern != null ? !a.portNamePattern.equals(b.portNamePattern) : b.portNamePattern != null)
+        if (!Objects.equals(a.portNamePattern, b.portNamePattern))
             return false;
         if (a.protocolBindings != null ? !a.protocolBindings.equals(b.protocolBindings) : b.protocolBindings != null)
             return false;
@@ -660,8 +661,8 @@ public class InheritenceTest extends TestCase {
         if (a == null && b == null) return true;
         if (a == null || b == null) return false;
 
-        if (a.handlerClass != null ? !a.handlerClass.equals(b.handlerClass) : b.handlerClass != null) return false;
-        if (a.handlerName != null ? !a.handlerName.equals(b.handlerName) : b.handlerName != null) return false;
+        if (!Objects.equals(a.handlerClass, b.handlerClass)) return false;
+        if (!Objects.equals(a.handlerName, b.handlerName)) return false;
         if (a.initParams != null ? !a.initParams.equals(b.initParams) : b.initParams != null) return false;
         if (a.soapHeaders != null ? !a.soapHeaders.equals(b.soapHeaders) : b.soapHeaders != null) return false;
         if (a.soapRoles != null ? !a.soapRoles.equals(b.soapRoles) : b.soapRoles != null) return false;
@@ -693,8 +694,8 @@ public class InheritenceTest extends TestCase {
         if (a == null && b == null) return true;
         if (a == null || b == null) return false;
 
-        if (a.qname != null ? !a.qname.equals(b.qname) : b.qname != null) return false;
-        if (a.serviceEndpointInterface != null ? !a.serviceEndpointInterface.equals(b.serviceEndpointInterface) : b.serviceEndpointInterface != null)
+        if (!Objects.equals(a.qname, b.qname)) return false;
+        if (!Objects.equals(a.serviceEndpointInterface, b.serviceEndpointInterface))
             return false;
         if (a.properties != null ? !a.properties.equals(b.properties) : b.properties != null) return false;
         if (a.enableMtom != b.enableMtom) return false;
@@ -726,8 +727,8 @@ public class InheritenceTest extends TestCase {
     public static boolean equals(final CallbackInfo a, final CallbackInfo b) {
         if (a == null && b == null) return true;
         if (a == null || b == null) return false;
-        if (a.className != null ? !a.className.equals(b.className) : b.className != null) return false;
-        if (a.method != null ? !a.method.equals(b.method) : b.method != null) return false;
+        if (!Objects.equals(a.className, b.className)) return false;
+        if (!Objects.equals(a.method, b.method)) return false;
         return true;
     }
 
@@ -755,8 +756,8 @@ public class InheritenceTest extends TestCase {
         if (a == null && b == null) return true;
         if (a == null || b == null) return false;
 
-        if (a.roleName != null ? !a.roleName.equals(b.roleName) : b.roleName != null) return false;
-        if (a.roleLink != null ? !a.roleLink.equals(b.roleLink) : b.roleLink != null) return false;
+        if (!Objects.equals(a.roleName, b.roleName)) return false;
+        if (!Objects.equals(a.roleLink, b.roleLink)) return false;
         return true;
     }
 
@@ -824,9 +825,9 @@ public class InheritenceTest extends TestCase {
         if (a == null && b == null) return true;
         if (a == null || b == null) return false;
 
-        if (a.id != null ? !a.id.equals(b.id) : b.id != null) return false;
-        if (a.methodName != null ? !a.methodName.equals(b.methodName) : b.methodName != null) return false;
-        if (a.methodParams != null ? !a.methodParams.equals(b.methodParams) : b.methodParams != null) return false;
+        if (!Objects.equals(a.id, b.id)) return false;
+        if (!Objects.equals(a.methodName, b.methodName)) return false;
+        if (!Objects.equals(a.methodParams, b.methodParams)) return false;
         return true;
     }
 

--- a/container/openejb-core/src/test/java/org/apache/openejb/core/cmp/jpa/ComplexId.java
+++ b/container/openejb-core/src/test/java/org/apache/openejb/core/cmp/jpa/ComplexId.java
@@ -17,6 +17,8 @@
  */
 package org.apache.openejb.core.cmp.jpa;
 
+import java.util.Objects;
+
 public class ComplexId {
     public String firstId;
     public String secondId;
@@ -27,8 +29,8 @@ public class ComplexId {
 
         final ComplexId complexId = (ComplexId) o;
 
-        if (secondId != null ? !secondId.equals(complexId.secondId) : complexId.secondId != null) return false;
-        if (firstId != null ? !firstId.equals(complexId.firstId) : complexId.firstId != null) return false;
+        if (!Objects.equals(secondId, complexId.secondId)) return false;
+        if (!Objects.equals(firstId, complexId.firstId)) return false;
 
         return true;
     }

--- a/container/openejb-core/src/test/java/org/apache/openejb/core/stateless/StatelessPoolStatsTest.java
+++ b/container/openejb-core/src/test/java/org/apache/openejb/core/stateless/StatelessPoolStatsTest.java
@@ -461,7 +461,7 @@ public class StatelessPoolStatsTest extends TestCase {
 
         final CounterBean bean = deploy("testAccessTimeouts", properties);
 
-        assertAttribute("AccessTimeouts", 0l);
+        assertAttribute("AccessTimeouts", 0L);
 
         final Checkout checkout = checkout(bean, 10);
 
@@ -475,7 +475,7 @@ public class StatelessPoolStatsTest extends TestCase {
 
         checkout.release();
 
-        assertAttribute("AccessTimeouts", 7l);
+        assertAttribute("AccessTimeouts", 7L);
     }
 
     /**

--- a/container/openejb-core/src/test/java/org/apache/openejb/dyni/DynamicSubclassTest.java
+++ b/container/openejb-core/src/test/java/org/apache/openejb/dyni/DynamicSubclassTest.java
@@ -57,7 +57,7 @@ public class DynamicSubclassTest extends Assert {
         final Class subclass = DynamicSubclass.createSubclass(Blue.class, loader);
 
         final Constructor constructor = subclass.getConstructor(long.class);
-        final Blue blue = (Blue) constructor.newInstance(1l);
+        final Blue blue = (Blue) constructor.newInstance(1L);
 
         final Class<?> generatedClass = blue.getClass();
         assertNotEquals(Blue.class, generatedClass);

--- a/container/openejb-jee-accessors/src/main/java/org/apache/openejb/sxc/TldTaglibXml.java
+++ b/container/openejb-jee-accessors/src/main/java/org/apache/openejb/sxc/TldTaglibXml.java
@@ -75,8 +75,6 @@ public class TldTaglibXml {
                     return "tei-class";
                 case "bodycontent":
                     return "body-content";
-                case "jspversion":
-                    return "jsp-version";
                 case "info":
                     return "description";
             }

--- a/container/openejb-jee-accessors/src/main/java/org/apache/openejb/sxc/TldTaglibXml.java
+++ b/container/openejb-jee-accessors/src/main/java/org/apache/openejb/sxc/TldTaglibXml.java
@@ -62,22 +62,23 @@ public class TldTaglibXml {
         }
 
         protected String fixLocalName(final String localName) {
-            if (localName.equals("tlibversion")) {
-                return "tlib-version";
-            } else if (localName.equals("jspversion")) {
-                return "jsp-version";
-            } else if (localName.equals("shortname")) {
-                return "short-name";
-            } else if (localName.equals("tagclass")) {
-                return "tag-class";
-            } else if (localName.equals("teiclass")) {
-                return "tei-class";
-            } else if (localName.equals("bodycontent")) {
-                return "body-content";
-            } else if (localName.equals("jspversion")) {
-                return "jsp-version";
-            } else if (localName.equals("info")) {
-                return "description";
+            switch (localName) {
+                case "tlibversion":
+                    return "tlib-version";
+                case "jspversion":
+                    return "jsp-version";
+                case "shortname":
+                    return "short-name";
+                case "tagclass":
+                    return "tag-class";
+                case "teiclass":
+                    return "tei-class";
+                case "bodycontent":
+                    return "body-content";
+                case "jspversion":
+                    return "jsp-version";
+                case "info":
+                    return "description";
             }
             return localName;
         }

--- a/container/openejb-jee/src/main/java/org/apache/openejb/jee/InjectionTarget.java
+++ b/container/openejb-jee/src/main/java/org/apache/openejb/jee/InjectionTarget.java
@@ -22,6 +22,7 @@ import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlType;
+import java.util.Objects;
 
 /**
  * javaee6.xsd
@@ -90,9 +91,9 @@ public class InjectionTarget {
 
         final InjectionTarget that = (InjectionTarget) o;
 
-        if (injectionTargetClass != null ? !injectionTargetClass.equals(that.injectionTargetClass) : that.injectionTargetClass != null)
+        if (!Objects.equals(injectionTargetClass, that.injectionTargetClass))
             return false;
-        if (injectionTargetName != null ? !injectionTargetName.equals(that.injectionTargetName) : that.injectionTargetName != null)
+        if (!Objects.equals(injectionTargetName, that.injectionTargetName))
             return false;
 
         return true;

--- a/container/openejb-jee/src/main/java/org/apache/openejb/jee/JaxbJavaee.java
+++ b/container/openejb-jee/src/main/java/org/apache/openejb/jee/JaxbJavaee.java
@@ -450,22 +450,31 @@ public class JaxbJavaee {
         }
 
         private String fixLocalName(String localName) {
-            if (localName.equals("tlibversion")) {
-                localName = "tlib-version";
-            } else if (localName.equals("jspversion")) {
-                localName = "jsp-version";
-            } else if (localName.equals("shortname")) {
-                localName = "short-name";
-            } else if (localName.equals("tagclass")) {
-                localName = "tag-class";
-            } else if (localName.equals("teiclass")) {
-                localName = "tei-class";
-            } else if (localName.equals("bodycontent")) {
-                localName = "body-content";
-            } else if (localName.equals("jspversion")) {
-                localName = "jsp-version";
-            } else if (localName.equals("info")) {
-                localName = "description";
+            switch (localName) {
+                case "tlibversion":
+                    localName = "tlib-version";
+                    break;
+                case "jspversion":
+                    localName = "jsp-version";
+                    break;
+                case "shortname":
+                    localName = "short-name";
+                    break;
+                case "tagclass":
+                    localName = "tag-class";
+                    break;
+                case "teiclass":
+                    localName = "tei-class";
+                    break;
+                case "bodycontent":
+                    localName = "body-content";
+                    break;
+                case "jspversion":
+                    localName = "jsp-version";
+                    break;
+                case "info":
+                    localName = "description";
+                    break;
             }
             return localName;
         }

--- a/container/openejb-jee/src/main/java/org/apache/openejb/jee/JaxbJavaee.java
+++ b/container/openejb-jee/src/main/java/org/apache/openejb/jee/JaxbJavaee.java
@@ -469,9 +469,6 @@ public class JaxbJavaee {
                 case "bodycontent":
                     localName = "body-content";
                     break;
-                case "jspversion":
-                    localName = "jsp-version";
-                    break;
                 case "info":
                     localName = "description";
                     break;

--- a/container/openejb-jee/src/main/java/org/apache/openejb/jee/MethodParams.java
+++ b/container/openejb-jee/src/main/java/org/apache/openejb/jee/MethodParams.java
@@ -29,6 +29,7 @@ import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Arrays;
+import java.util.Objects;
 
 
 /**
@@ -96,7 +97,7 @@ public class MethodParams {
 
         final MethodParams that = (MethodParams) o;
 
-        if (methodParam != null ? !methodParam.equals(that.methodParam) : that.methodParam != null) return false;
+        if (!Objects.equals(methodParam, that.methodParam)) return false;
 
         return true;
     }

--- a/container/openejb-jee/src/main/java/org/apache/openejb/jee/NamedMethod.java
+++ b/container/openejb-jee/src/main/java/org/apache/openejb/jee/NamedMethod.java
@@ -27,6 +27,7 @@ import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.XmlTransient;
 import javax.xml.bind.annotation.adapters.CollapsedStringAdapter;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import java.util.Objects;
 
 
 /**
@@ -132,11 +133,11 @@ public class NamedMethod {
 
         final NamedMethod that = (NamedMethod) o;
 
-        if (methodName != null ? !methodName.equals(that.methodName) : that.methodName != null) return false;
+        if (!Objects.equals(methodName, that.methodName)) return false;
 
         if (nullOrEmpty(this.methodParams) && nullOrEmpty(that.methodParams)) return true;
 
-        if (methodParams != null ? !methodParams.equals(that.methodParams) : that.methodParams != null) return false;
+        if (!Objects.equals(methodParams, that.methodParams)) return false;
 
         return true;
     }

--- a/container/openejb-jee/src/main/java/org/apache/openejb/jee/RemoveMethod.java
+++ b/container/openejb-jee/src/main/java/org/apache/openejb/jee/RemoveMethod.java
@@ -26,6 +26,7 @@ import javax.xml.bind.annotation.XmlID;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.adapters.CollapsedStringAdapter;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import java.util.Objects;
 
 
 /**
@@ -111,7 +112,7 @@ public class RemoveMethod {
 
         final RemoveMethod that = (RemoveMethod) o;
 
-        if (beanMethod != null ? !beanMethod.equals(that.beanMethod) : that.beanMethod != null) return false;
+        if (!Objects.equals(beanMethod, that.beanMethod)) return false;
 
         return true;
     }


### PR DESCRIPTION
## Updates the API

This PR has the goal to update the code using the newest API until Java 8. These improvements are:



* Use switch instead of multiple if/else: The switch is faster because there are special bytecodes that allow efficient switch statement evaluation when there are a lot of cases.

* Simplifies code using Objects.equals: It reduces the number of lines of code using the [Objects.equals ](https://docs.oracle.com/javase/8/docs/api/java/util/Objects.html#equals-java.lang.Object-java.lang.Object-)also it will be faster considering the JIT factor.

* Simplifies the primitive compare using [Integer.compare](https://docs.oracle.com/javase/8/docs/api/java/lang/Integer.html#compare-int-int-)

* Reduces code using removeif condition in the collection.

* from the JVM specification it repleaces [`L` instead of `l`](https://docs.oracle.com/javase/specs/jls/se8/html/jls-3.html#jls-3.10).