### PR TITLE
Startup and shutdown fixes - TOMEE-2454

### DIFF
--- a/container/openejb-core/src/main/java/org/apache/openejb/BeanContext.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/BeanContext.java
@@ -1554,9 +1554,6 @@ public class BeanContext extends DeploymentContext {
 
     @SuppressWarnings("unchecked")
     public InstanceContext newInstance() throws Exception {
-        final ThreadContext callContext = new ThreadContext(this, null, Operation.INJECTION);
-        final ThreadContext oldContext = ThreadContext.enter(callContext);
-
         final boolean dynamicallyImplemented = isDynamicallyImplemented();
 
         final WebBeansContext webBeansContext = getWebBeansContext();
@@ -1566,6 +1563,9 @@ public class BeanContext extends DeploymentContext {
                 throw new OpenEJBException("proxy class can only be InvocationHandler");
             }
         }
+
+        final ThreadContext callContext = new ThreadContext(this, null, Operation.INJECTION);
+        final ThreadContext oldContext = ThreadContext.enter(callContext);
 
         try {
             final Context ctx = getJndiEnc();

--- a/container/openejb-core/src/main/java/org/apache/openejb/assembler/classic/Assembler.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/assembler/classic/Assembler.java
@@ -65,6 +65,7 @@ import org.apache.openejb.cdi.OpenEJBBeanInfoService;
 import org.apache.openejb.cdi.OpenEJBJndiService;
 import org.apache.openejb.cdi.OpenEJBTransactionService;
 import org.apache.openejb.cdi.OptimizedLoaderService;
+import org.apache.openejb.cdi.ThreadSingletonService;
 import org.apache.openejb.classloader.ClassLoaderConfigurer;
 import org.apache.openejb.classloader.CompositeClassLoaderConfigurer;
 import org.apache.openejb.component.ClassLoaderEnricher;
@@ -1933,6 +1934,7 @@ public class Assembler extends AssemblerTool implements org.apache.openejb.spi.A
             systemInstance.removeComponent(JtaEntityManagerRegistry.class);
             systemInstance.removeComponent(TransactionSynchronizationRegistry.class);
             systemInstance.removeComponent(EjbResolver.class);
+            systemInstance.removeComponent(ThreadSingletonService.class);
             systemInstance.fireEvent(new AssemblerDestroyed());
             systemInstance.removeObservers();
 

--- a/container/openejb-core/src/main/java/org/apache/openejb/core/ThreadContext.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/core/ThreadContext.java
@@ -24,17 +24,17 @@ import org.apache.openejb.util.Logger;
 
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public class ThreadContext {
 
     private static final Logger log = Logger.getInstance(LogCategory.OPENEJB, "org.apache.openejb.util.resources");
-    private static final ThreadLocal<ThreadContext> threadStorage = new ThreadLocal<ThreadContext>();
-    private static final List<ThreadContextListener> listeners = new CopyOnWriteArrayList<ThreadContextListener>();
-    private static final ThreadLocal<AtomicBoolean> asynchronousCancelled = new ThreadLocal<AtomicBoolean>();
+    private static final ThreadLocal<ThreadContext> threadStorage = new ThreadLocal<>();
+    private static final Set<ThreadContextListener> listeners = new CopyOnWriteArraySet<>();
+    private static final ThreadLocal<AtomicBoolean> asynchronousCancelled = new ThreadLocal<>();
 
     public static ThreadContext getThreadContext() {
         return threadStorage.get();

--- a/container/openejb-core/src/main/java/org/apache/openejb/core/security/AbstractSecurityService.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/core/security/AbstractSecurityService.java
@@ -87,7 +87,7 @@ public abstract class AbstractSecurityService implements DestroyableResource, Se
 
     @Override
     public void destroyResource() {
-        // no-op
+        ThreadContext.removeThreadContextListener(this);
     }
 
     public void onLogout(final HttpServletRequest request) {

--- a/tomee/tomee-catalina/src/main/java/org/apache/tomee/catalina/TomcatLoader.java
+++ b/tomee/tomee-catalina/src/main/java/org/apache/tomee/catalina/TomcatLoader.java
@@ -101,7 +101,9 @@ public class TomcatLoader implements Loader {
     /**
      * other services
      */
-    private static final List<ServerService> services = new ArrayList<ServerService>();
+    private static final List<ServerService> services = new ArrayList<>();
+
+    private static final TomcatThreadContextListener threadContextListener = new TomcatThreadContextListener();
 
     /**
      * this method will be split in two to be able to use SystemInstance in between both invocations
@@ -187,7 +189,7 @@ public class TomcatLoader implements Loader {
         System.setProperty("openejb.base", SystemInstance.get().getBase().getDirectory().getAbsolutePath());
 
         // Install tomcat thread context listener
-        ThreadContext.addThreadContextListener(new TomcatThreadContextListener());
+        ThreadContext.addThreadContextListener(threadContextListener);
 
         // set ignorable libraries from a tomee property instead of using the standard openejb one
         // don't ignore standard openejb exclusions file


### PR DESCRIPTION
Properly clear all registered thread context listeners that are not initialized as static instances.
Run all tests locally on Linux and Windows.
All pass.

Check https://issues.apache.org/jira/projects/TOMEE/issues/TOMEE-2454 for details.

- next is to re-enable EnvEntryTest from arquillian-tomee-jms-tests and see if that will break build on build bot.