### PR TITLE
TOMEE-2467 - When MP is enabled CXF JAX-RS filter is also enabled. Fix...

### DIFF
--- a/server/openejb-cxf-rs/src/main/java/org/apache/openejb/server/cxf/rs/CxfRsHttpListener.java
+++ b/server/openejb-cxf-rs/src/main/java/org/apache/openejb/server/cxf/rs/CxfRsHttpListener.java
@@ -35,6 +35,7 @@ import org.apache.cxf.jaxrs.model.ClassResourceInfo;
 import org.apache.cxf.jaxrs.model.MethodDispatcher;
 import org.apache.cxf.jaxrs.model.OperationResourceInfo;
 import org.apache.cxf.jaxrs.model.ProviderInfo;
+import org.apache.cxf.jaxrs.model.URITemplate;
 import org.apache.cxf.jaxrs.provider.ProviderFactory;
 import org.apache.cxf.jaxrs.provider.ServerProviderFactory;
 import org.apache.cxf.jaxrs.utils.JAXRSUtils;
@@ -106,6 +107,8 @@ import javax.ws.rs.RuntimeType;
 import javax.ws.rs.core.Application;
 import javax.ws.rs.core.Configuration;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.MessageBodyReader;
@@ -326,6 +329,28 @@ public class CxfRsHttpListener implements RsHttpListener {
             }
         }
         return true;
+    }
+    
+    public boolean isCXFResource(final HttpServletRequest request) {
+        final JAXRSServiceImpl service;
+        try {
+            service = (JAXRSServiceImpl)server.getEndpoint().getService();
+        } finally { }
+        if( service == null ) {
+            return false;
+        }
+        final List<ClassResourceInfo> resources = service.getClassResourceInfos();
+        for (final ClassResourceInfo info : resources) {
+            if (info.getResourceClass() == null || info.getURITemplate() == null) { // possible?
+                continue;
+            }
+
+            final MultivaluedMap<String, String> parameters = new MultivaluedHashMap<>();
+            if (info.getURITemplate().match(request.getServletPath(), parameters)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override

--- a/tomee/tomee-jaxrs/src/main/java/org/apache/tomee/webservices/CXFJAXRSFilter.java
+++ b/tomee/tomee-jaxrs/src/main/java/org/apache/tomee/webservices/CXFJAXRSFilter.java
@@ -78,6 +78,11 @@ public class CXFJAXRSFilter implements Filter {
         final HttpServletRequest httpServletRequest = HttpServletRequest.class.cast(request);
         final HttpServletResponse httpServletResponse = HttpServletResponse.class.cast(response);
 
+        if (!this.delegate.isCXFResource(httpServletRequest)) {
+            chain.doFilter(request, response);
+            return;
+        }
+
         if (CxfRsHttpListener.TRY_STATIC_RESOURCES) { // else 100% JAXRS
             if (servletMappingIsUnderRestPath(httpServletRequest)) {
                 chain.doFilter(request, response);
@@ -121,7 +126,7 @@ public class CXFJAXRSFilter implements Filter {
             accept = false;
             if (!"org.apache.catalina.servlets.DefaultServlet".equals(wrapper.getServletClass())) {
                 for (final String mapping : wrapper.findMappings()) {
-                    if (!mapping.isEmpty() && !"/*".equals(mapping) && !"/".equals(mapping) && !mapping.equals("*")
+                    if (!mapping.isEmpty() && !"/*".equals(mapping) && !"/".equals(mapping) && !mapping.startsWith("*")
                             && mapping.startsWith(this.mapping)) {
                         accept = true;
                         break;


### PR DESCRIPTION
es the filter which was treating ALL endpoint resources as CXF resources and trying to serve various scenarios itself.  This commit makes the filter only process it's own CXF resources and pass everything else down the chain.  Existing behaviour for a CXF resource which may have static content or non-default servlet class is left untouched.