### PR TITLE
embedded.Main#main: typo on 'exit'

### DIFF
--- a/tomee/tomee-embedded/src/main/java/org/apache/tomee/embedded/Main.java
+++ b/tomee/tomee-embedded/src/main/java/org/apache/tomee/embedded/Main.java
@@ -193,7 +193,7 @@ public class Main {
                         case "exit":
                             return;
                         default:
-                            System.out.println("Unknown command '" + l + "', supported commands: 'quit', 'exist'");
+                            System.out.println("Unknown command '" + l + "', supported commands: 'quit', 'exit'");
                     }
                 }
             }


### PR DESCRIPTION
`supported commands: 'quit', 'exist'` -> `supported commands: 'quit', 'exit'`