### PR TITLE
Enhanced docker-compose.yml for non-root user build and debug

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,22 +19,73 @@ version: '2'
 volumes:
         m2:
 services:
-    mvn:
+    # This service is a workaround to set volume permissions so that they are correct for non-root user build
+    volume_perms:
+        image: alpine
+        command: "chown -R 1000:1000 /var/maven"
+        volumes:
+            - m2:/var/maven/.m2
+    # Build+test. Stops on first test failure
+    build:
         image: "maven:3.3.9-jdk-8"
+        command: ["-Duser.home=/var/maven", "-Pall-adapters", "-Dsurefire.useFile=false", "-DdisableXmlReport=true", "clean", "install"]
         entrypoint: "mvn"
         working_dir: /opt/project
+        user: 1000:1000
         environment:
             - MAVEN_OPTS=-Xmx768m -XX:ReservedCodeCacheSize=64m -Xss2048k
+            - MAVEN_CONFIG=/var/maven/.m2
         volumes:
-            - m2:/root/.m2
+            - m2:/var/maven/.m2
             - .:/opt/project
-    quickbuild:
+        depends_on:
+            - volume_perms
+    # Build+test. Does not stop on test failures
+    build-all:
         image: "maven:3.3.9-jdk-8"
-        command: ["mvn", "-Pquick", "-Dsurefire.useFile=false", "-DdisableXmlReport=true", "-DuniqueVersion=false", "-ff", "-Dassemble", "-DskipTests", "-DfailIfNoTests=false", "clean", "install"]
+        command: ["--fail-at-end", "-Duser.home=/var/maven", "-Pall-adapters", "-Dsurefire.useFile=false", "-DdisableXmlReport=true", "clean", "install"]
+        entrypoint: "mvn"
         working_dir: /opt/project
+        user: 1000:1000
+        ports:
+            - 5005:5005
         environment:
             - MAVEN_OPTS=-Xmx768m -XX:ReservedCodeCacheSize=64m -Xss2048k
+            - MAVEN_CONFIG=/var/maven/.m2
         volumes:
-            - m2:/root/.m2
+            - m2:/var/maven/.m2
             - .:/opt/project
-
+        depends_on:
+            - volume_perms
+        # Just build (no tests)
+    build-quick:
+        image: "maven:3.3.9-jdk-8"
+        command: ["-Duser.home=/var/maven", "-Pquick", "-Dsurefire.useFile=false", "-DdisableXmlReport=true", "-DuniqueVersion=false", "-ff", "-Dassemble", "-DskipTests", "-DfailIfNoTests=false", "clean", "install"]
+        entrypoint: "mvn"
+        working_dir: /opt/project
+        user: 1000:1000
+        environment:
+            - MAVEN_OPTS=-Xmx768m -XX:ReservedCodeCacheSize=64m -Xss2048k
+            - MAVEN_CONFIG=/var/maven/.m2
+        volumes:
+            - m2:/var/maven/.m2
+            - .:/opt/project
+        depends_on:
+            - volume_perms
+    # Build+test. Waits for debugger on port 5005. Stops on first test failure
+    debug:
+        image: "maven:3.3.9-jdk-8"
+        command: ["-Duser.home=/var/maven", "-Pall-adapters", "-Dsurefire.useFile=false", "-DdisableXmlReport=true", "-Dopenejb.server.debug", "-Dmaven.surefire.debug", "-Dopenejb.arquillian.debug=true", "clean", "install"]
+        entrypoint: "mvn"
+        working_dir: /opt/project
+        user: 1000:1000
+        ports:
+            - 5005:5005
+        environment:
+            - MAVEN_OPTS=-Xmx768m -XX:ReservedCodeCacheSize=64m -Xss2048k
+            - MAVEN_CONFIG=/var/maven/.m2
+        volumes:
+            - m2:/var/maven/.m2
+            - .:/opt/project
+        depends_on:
+            - volume_perms


### PR DESCRIPTION
As an example to try out, improved docker-compose file.

This docker-compose.yml file runs as non-root user (some tests depend on this and fail if root).  To enable that there is a utility (volume_perms) that sets the file permissions to user 1000 which is the user id that runs the builds/tests.

Supported services:

(Fail on first failure)
docker-compose up build

(Build all regardless of failures)
docker-compose up build-all

(No tests)
docker-compose up build-quick

(Wait for debugger to connect. Usually want to specify -pl parameter first)
docker-compose up debug
