### PR TITLE
TOMEE-2408 Resolve MP JWT producer always being started or duplicated

### DIFF
--- a/container/openejb-core/src/main/resources/default.exclusions
+++ b/container/openejb-core/src/main/resources/default.exclusions
@@ -156,6 +156,7 @@ maven-
 mbean-annotation-api-
 mimepull-
 mina-
+mp-jwt-
 mqtt-client-
 myfaces-api
 myfaces-impl

--- a/mp-jwt/src/main/java/org/apache/tomee/microprofile/jwt/cdi/MPJWTCDIExtension.java
+++ b/mp-jwt/src/main/java/org/apache/tomee/microprofile/jwt/cdi/MPJWTCDIExtension.java
@@ -132,7 +132,8 @@ public class MPJWTCDIExtension implements Extension {
         return (T) beanManager.getReference(bean, type, creationalContext);
     }
 
-    static {
-        SystemInstance.get().addObserver(new MPJWPProviderRegistration());
-    }
+//** Scanning now happens automatically
+//    static {
+//        SystemInstance.get().addObserver(new MPJWPProviderRegistration());
+//    }
 }


### PR DESCRIPTION
Fixes JWT Filter being added in ALL cases even when tomee.mp.scan=none is set and fixes duplicate JWT Filter when tomee.mp.scan=all is set.