### PR TITLE
Revert missed dependency versions

### DIFF
--- a/examples/polling-parent/pom.xml
+++ b/examples/polling-parent/pom.xml
@@ -31,7 +31,7 @@
     <xbean.version>4.8</xbean.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <tomee.version>8.0.0-SNAPSHOT</tomee.version>
-    <cxf.version>3.3.0</cxf.version>
+    <cxf.version>3.2.7</cxf.version>
   </properties>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -208,7 +208,7 @@
     <microprofile.health.impl.version>1.0.1</microprofile.health.impl.version>
     <microprofile.metrics.version>1.1.1</microprofile.metrics.version>
     <microprofile.metrics.impl.version>1.0.2</microprofile.metrics.impl.version>
-    <microprofile.rest-client.version>1.2.0</microprofile.rest-client.version>
+    <microprofile.rest-client.version>1.1</microprofile.rest-client.version>
     <microprofile.rest-client.impl.version>${cxf.version}</microprofile.rest-client.impl.version>
     <microprofile.openapi.version>1.0.1</microprofile.openapi.version>
     <microprofile.openapi.impl.version>1.0.6</microprofile.openapi.impl.version>


### PR DESCRIPTION
Slowness is fixed, so buildbot is happier but not quite happy.  Just for awareness to avoid someone else looking at it too...

1. I forgot to update the CXF version in the examples\polling-parent.  So polling-web failed.

2. Also, it turns out CXF didn't add support for mp rest client 1.2.0 until 3.3.0 either.

So I've updated those to dependency versions based on moving back to CXF 3.2.7 until that is fixed back up to 3.3.0.