### PR TITLE
[TOMEE-2509] Wrap FileWriter with a BufferedWriter in a loop

### DIFF
--- a/maven/jarstxt-maven-plugin/src/main/java/org/apache/openejb/maven/jarstxt/JarsTxtMojo.java
+++ b/maven/jarstxt-maven-plugin/src/main/java/org/apache/openejb/maven/jarstxt/JarsTxtMojo.java
@@ -40,6 +40,7 @@ import org.apache.openejb.loader.ProvisioningUtil;
 import org.codehaus.plexus.util.FileUtils;
 
 import java.io.File;
+import java.io.BufferedWriter;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.net.MalformedURLException;
@@ -91,9 +92,9 @@ public class JarsTxtMojo extends AbstractMojo {
             FileUtils.mkdir(outputFile.getParentFile().getAbsolutePath());
         }
 
-        FileWriter writer = null;
+        BufferedWriter writer = null;
         try {
-            writer = new FileWriter(outputFile);
+            writer = new BufferedWriter(new FileWriter(outputFile));
 
             final TreeSet<String> set = new TreeSet<>();
 


### PR DESCRIPTION
Fixes ISSUE [#TOMEE-2509](https://issues.apache.org/jira/browse/TOMEE-2509)

BufferedWriter can effectively reduce the times of IO access with caches, especially in a loop, which will be the performance bottleneck of program.