### PR TITLE
TOMEE-2555 Brought DeltaSpike versions up to latest released version

### DIFF
--- a/examples/deltaspike-configproperty/pom.xml
+++ b/examples/deltaspike-configproperty/pom.xml
@@ -28,7 +28,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <version.deltaspike>1.3.0</version.deltaspike>
+    <version.deltaspike>1.9.0</version.deltaspike>
   </properties>
 
   <build>

--- a/examples/deltaspike-exception-handling/pom.xml
+++ b/examples/deltaspike-exception-handling/pom.xml
@@ -28,6 +28,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <version.deltaspike>1.9.0</version.deltaspike>
   </properties>
 
   <build>
@@ -61,12 +62,12 @@
     <dependency>
       <groupId>org.apache.deltaspike.core</groupId>
       <artifactId>deltaspike-core-impl</artifactId>
-      <version>1.0.0</version>
+      <version>${version.deltaspike}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.deltaspike.core</groupId>
       <artifactId>deltaspike-core-api</artifactId>
-      <version>1.0.0</version>
+      <version>${version.deltaspike}</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/examples/deltaspike-fullstack/pom.xml
+++ b/examples/deltaspike-fullstack/pom.xml
@@ -22,7 +22,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <version.myfaces2>2.3.0</version.myfaces2>
-    <version.deltaspike>1.3.0</version.deltaspike>
+    <version.deltaspike>1.9.0</version.deltaspike>
     <version.extval>2.0.8</version.extval>
     <tomee.version>8.0.0-SNAPSHOT</tomee.version>
   </properties>

--- a/examples/deltaspike-i18n/pom.xml
+++ b/examples/deltaspike-i18n/pom.xml
@@ -28,7 +28,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <version.deltaspike>1.0.0</version.deltaspike>
+    <version.deltaspike>1.9.0</version.deltaspike>
   </properties>
 
   <build>


### PR DESCRIPTION
Updated DeltaSpike examples to use version 1.9.0 of DeltaSpike and enabled version to be read as a property for all DeltaSpike examples rather than defining the version number in the dependency itself.