### PR TITLE
TOMEE-2586 Fix examples/webservices-ws-security to work on Java 11

### DIFF
--- a/examples/webservice-ws-security/create-keystores.xml
+++ b/examples/webservice-ws-security/create-keystores.xml
@@ -46,6 +46,7 @@
   <property name="client.file" value="${basedir}/target/test-classes/META-INF/clientKey.rsa"/>
 
   <property name="keyalg" value="RSA"/>
+  <property name="storetype" value="jks"/>
 
   <!-- now create our JDK specific targets -->
   <target name="do.ibm.jdk" if="is.ibm.jdk">
@@ -131,6 +132,7 @@
       <arg line="-storepass ${server.storepass}"/>
       <arg line="-dname ${server.dname}"/>
       <arg line="-keyalg ${keyalg}"/>
+      <arg line="-storetype ${storetype}"/>
     </java>
     <java classname="${is.sun.jdk}" fork="true">
       <arg line="-selfcert"/>
@@ -157,6 +159,7 @@
       <arg line="-storepass ${client.storepass}"/>
       <arg line="-dname ${client.dname}"/>
       <arg line="-keyalg ${keyalg}"/>
+      <arg line="-storetype ${storetype}"/>
     </java>
     <java classname="${is.sun.jdk}" fork="true">
       <arg line="-selfcert"/>


### PR DESCRIPTION
Changed the keystore to be in JKS format so it works with both Java 8
and Java 11.