### PR TITLE
TOMEE-1395 Invalid package on simple-mdb-with-descriptor

### DIFF
--- a/examples/simple-mdb-with-descriptor/src/test/java/org/superbiz/mdbdesc/ChatBeanTest.java
+++ b/examples/simple-mdb-with-descriptor/src/test/java/org/superbiz/mdbdesc/ChatBeanTest.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 //START SNIPPET: code
-package org.superbiz.mdb;
+package org.superbiz.mdbdesc;
 
 import junit.framework.TestCase;
 


### PR DESCRIPTION
Changed the package name of the test to correspond to the directory
structure.