### PR TITLE
 [7.1.x] TOMEE-2565 - Fixes a regression with missing TomEEJsonbProvider in CXF Providers

### DIFF
--- a/server/openejb-cxf-rs/src/main/java/org/apache/openejb/server/cxf/rs/CxfRSService.java
+++ b/server/openejb-cxf-rs/src/main/java/org/apache/openejb/server/cxf/rs/CxfRSService.java
@@ -227,7 +227,7 @@ public class CxfRSService extends RESTService {
             String userConfiguredJsonProviders = SystemInstance.get().getProperty("openejb.jaxrs.jsonProviders");
             if (userConfiguredJsonProviders == null) {
                 jsonProviders = asList(
-                        "org.apache.openejb.server.cxf.rs.johnzon.TomEEJohnzonProvider",
+                        "org.apache.openejb.server.cxf.rs.johnzon.TomEEJsonbProvider",
                         "org.apache.openejb.server.cxf.rs.johnzon.TomEEJsonpProvider");
             } else {
                 jsonProviders = asList(userConfiguredJsonProviders.split(","));


### PR DESCRIPTION
# What does this PR do?

This PR fixes a regression introduced with https://github.com/apache/tomee/commit/4302acab62bb64c2d77cce3a66b92ae7e9cff7c5 for TomEE 7.1.x with wrong values in the default CXF provider list. It was already fixed for TomEE 8 (see https://github.com/apache/tomee/commit/1bfb65a1837235f4e9ad4458f67aabcab5eff829), but was not backported to TomEE 7.1.x 

# Additional Remarks

As described in the JIRA, affected end-users can workaround this issue by overriding the default list of providers using the `openejb.jaxrs.jsonProviders` system property witth the following value: 

```
"org.apache.openejb.server.cxf.rs.johnzon.TomEEJsonbProvider","org.apache.openejb.server.cxf.rs.johnzon.TomEEJsonpProvider"
```
Thanks to @cesarhernandezgt for showing me the magic of `git bisect` and finding the related commit in the first place!

# Related JIRA

- https://issues.apache.org/jira/browse/TOMEE-2565