### PR TITLE
TOMEE-2481 - Move code using PropertyEditors (deprecated class) to PropertyEditorRegistry

### DIFF
--- a/container/openejb-core/src/main/java/org/apache/openejb/monitoring/ManagedMBean.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/monitoring/ManagedMBean.java
@@ -19,7 +19,7 @@ package org.apache.openejb.monitoring;
 
 import org.apache.openejb.util.Classes;
 import org.apache.xbean.finder.ClassFinder;
-import org.apache.xbean.propertyeditor.PropertyEditors;
+import org.apache.xbean.propertyeditor.PropertyEditorRegistry;
 
 import javax.management.Attribute;
 import javax.management.AttributeList;
@@ -71,6 +71,7 @@ public class ManagedMBean implements DynamicMBean {
     private boolean filterAttributes;
     private MBeanParameterInfo excludeInfo;
     private MBeanParameterInfo includeInfo;
+    private PropertyEditorRegistry propertyEditorRegistry = new PropertyEditorRegistry();
 
     public ManagedMBean(final Object managed) {
         this(managed, "");
@@ -93,6 +94,8 @@ public class ManagedMBean implements DynamicMBean {
             operationsMap.put(filterOperation.getName(), new MethodMember(method, this, ""));
 
             filterAttributes = true;
+
+            propertyEditorRegistry.registerDefaults();
         } catch (final NoSuchMethodException e) {
             throw new IllegalStateException(e);
         }
@@ -200,7 +203,7 @@ public class ManagedMBean implements DynamicMBean {
             final Class<?> expectedType = method.getParameterTypes()[i];
             if (value instanceof String && expectedType != Object.class) {
                 final String stringValue = (String) value;
-                value = PropertyEditors.getValue(expectedType, stringValue);
+                value = propertyEditorRegistry.getValue(expectedType, stringValue);
             }
             args[i] = value;
         }

--- a/container/openejb-core/src/main/java/org/apache/openejb/resource/activemq/ActiveMQ5Factory.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/resource/activemq/ActiveMQ5Factory.java
@@ -36,7 +36,7 @@ import org.apache.openejb.spi.ContainerSystem;
 import org.apache.openejb.util.LogCategory;
 import org.apache.openejb.util.Logger;
 import org.apache.xbean.propertyeditor.PropertyEditorException;
-import org.apache.xbean.propertyeditor.PropertyEditors;
+import org.apache.xbean.propertyeditor.PropertyEditorRegistry;
 import org.apache.xbean.recipe.ObjectRecipe;
 
 import javax.naming.Context;
@@ -65,6 +65,7 @@ public class ActiveMQ5Factory implements BrokerFactoryHandler {
     protected static final Map<URI, BrokerService> brokers = new HashMap<URI, BrokerService>();
     private static Throwable throwable;
     private static final AtomicBoolean started = new AtomicBoolean(false);
+    private static PropertyEditorRegistry propertyEditorRegistry = new PropertyEditorRegistry().registerDefaults();
 
     public static void setThreadProperties(final Properties p) {
         properties = p;
@@ -433,7 +434,7 @@ public class ActiveMQ5Factory implements BrokerFactoryHandler {
                     final Object field = params.remove(key);
                     if (field != null) {
                         try {
-                            final Object toSet = PropertyEditors.getValue(m.getParameterTypes()[0], field.toString());
+                            final Object toSet = propertyEditorRegistry.getValue(m.getParameterTypes()[0], field.toString());
                             m.invoke(persistenceAdapter, toSet);
                         } catch (final PropertyEditorException cantConvertException) {
                             throw new IllegalArgumentException("can't convert " + field + " for " + m.getName(), cantConvertException);

--- a/container/openejb-core/src/main/java/org/apache/openejb/resource/activemq/jms2/JMSProducerImpl.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/resource/activemq/jms2/JMSProducerImpl.java
@@ -17,7 +17,7 @@
 package org.apache.openejb.resource.activemq.jms2;
 
 import org.apache.xbean.propertyeditor.PropertyEditorException;
-import org.apache.xbean.propertyeditor.PropertyEditors;
+import org.apache.xbean.propertyeditor.PropertyEditorRegistry;
 
 import javax.jms.BytesMessage;
 import javax.jms.CompletionListener;
@@ -52,10 +52,12 @@ class JMSProducerImpl implements JMSProducer {
     private String jmsHeaderCorrelationID;
     private byte[] jmsHeaderCorrelationIDAsBytes;
     private String jmsHeaderType;
+    private PropertyEditorRegistry propertyEditorRegistry = new PropertyEditorRegistry();
 
     JMSProducerImpl(final JMSContextImpl jmsContext, final MessageProducer innerProducer) {
         this.context = jmsContext;
         this.producer = innerProducer;
+        this.propertyEditorRegistry.registerDefaults();
     }
 
     private <T> T getProperty(final String key, final Class<T> type) {
@@ -64,7 +66,7 @@ class JMSProducerImpl implements JMSProducer {
             return type.cast(val);
         }
         try {
-            return type.cast(PropertyEditors.getValue(type, val.toString()));
+            return type.cast(propertyEditorRegistry.getValue(type, val.toString()));
         } catch (final PropertyEditorException pee) {
             throw new MessageFormatRuntimeException(pee.getMessage());
         }

--- a/mp-jwt/src/main/java/org/apache/tomee/microprofile/jwt/cdi/ClaimBean.java
+++ b/mp-jwt/src/main/java/org/apache/tomee/microprofile/jwt/cdi/ClaimBean.java
@@ -18,7 +18,6 @@ package org.apache.tomee.microprofile.jwt.cdi;
 
 import org.apache.openejb.cdi.ManagedSecurityService;
 import org.apache.xbean.propertyeditor.PropertyEditorRegistry;
-import org.apache.xbean.propertyeditor.PropertyEditors;
 import org.eclipse.microprofile.jwt.Claim;
 import org.eclipse.microprofile.jwt.ClaimValue;
 import org.eclipse.microprofile.jwt.Claims;
@@ -250,7 +249,7 @@ public class ClaimBean<T> implements Bean<T>, PassivationCapable {
             // handle JsonValue<T> (number, string, etc)
             return (T) toJson(key);
 
-        } else if (PropertyEditors.canConvert((Class<?>) ip.getType())) {
+        } else if (propertyEditorRegistry.findConverter((Class<?>) ip.getType()) != null) {
             final Class<?> type = (Class<?>) ip.getType();
             try {
                 final Object claimObject = getClaimValue(key);

--- a/server/openejb-common-cli/src/main/java/org/apache/openejb/server/cli/command/LocalJMXCommand.java
+++ b/server/openejb-common-cli/src/main/java/org/apache/openejb/server/cli/command/LocalJMXCommand.java
@@ -29,7 +29,7 @@ import javax.management.ObjectName;
 import javax.management.RuntimeMBeanException;
 
 import org.apache.openejb.monitoring.LocalMBeanServer;
-import org.apache.xbean.propertyeditor.PropertyEditors;
+import org.apache.xbean.propertyeditor.PropertyEditorRegistry;
 
 // TODO: maybe find a better way to invoker get/set/invoke because currently we limit a bit possible values
 @Command(name = "jmx", description = "consult/update a jmx information", usage = "jmx <operation> <options>. " +
@@ -41,6 +41,13 @@ import org.apache.xbean.propertyeditor.PropertyEditors;
     "\n\t\t\tjmx set MyAttributeName foo:type=bar NewValue" +
     "\n\t\t\tjmx invoke myMethod(arg1,arg2) foo:type=bar")
 public class LocalJMXCommand extends AbstractCommand {
+
+    private final PropertyEditorRegistry propertyEditorRegistry = new PropertyEditorRegistry();
+
+    public LocalJMXCommand() {
+        this.propertyEditorRegistry.registerDefaults();
+    }
+
     @Override
     public void execute(final String cmd) {
         final String jmxCmd = cmd.trim();
@@ -117,7 +124,7 @@ public class LocalJMXCommand extends AbstractCommand {
             for (int i = 0; i < passedArgs.length; i++) {
                 final String expected = operation.getSignature()[i].getType();
                 if (!String.class.getName().equals(expected)) {
-                    passedArgs[i] = PropertyEditors.getValue(expected, args[i], Thread.currentThread().getContextClassLoader());
+                    passedArgs[i] = propertyEditorRegistry.getValue(expected, args[i], Thread.currentThread().getContextClassLoader());
                 } else {
                     passedArgs[i] = args[i];
                 }
@@ -173,7 +180,7 @@ public class LocalJMXCommand extends AbstractCommand {
                 }
             }
 
-            final Object valueObj = PropertyEditors.getValue(type, newValue, Thread.currentThread().getContextClassLoader());
+            final Object valueObj = propertyEditorRegistry.getValue(type, newValue, Thread.currentThread().getContextClassLoader());
             mBeanServer.setAttribute(oname, new Attribute(split[0], valueObj));
             streamManager.writeOut("done");
         } catch (Exception ex) {


### PR DESCRIPTION
Hi,

this PR is a follow up of the discussion in https://github.com/apache/tomee/pull/427 and reflects the changes requested by @jgallimore 

I tied the changes to the lifecycle of the components using the `PropertyEditorRegistry` in each case.

