### PR TITLE
[TOMEE-2655] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439

### DIFF
--- a/container/openejb-core/pom.xml
+++ b/container/openejb-core/pom.xml
@@ -551,6 +551,10 @@
       <groupId>org.objectweb.howl</groupId>
       <artifactId>howl</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
     <!-- JavaMail -->
     <dependency>
       <groupId>org.apache.geronimo.specs</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -177,7 +177,7 @@
     <commons-net.version>3.3</commons-net.version>
 
     <bval.version>2.0.3</bval.version>
-    <org.apache.activemq.version>5.15.6</org.apache.activemq.version>
+    <org.apache.activemq.version>5.15.10</org.apache.activemq.version>
     <org.springframework.version>3.1.4.RELEASE</org.springframework.version>
     <junit.version>4.12</junit.version>
     <org.apache.axis2.version>1.4.1</org.apache.axis2.version>
@@ -225,7 +225,8 @@
     <opentracing.api>0.31.0</opentracing.api>
 
     <!-- Jackson required by OpenAPI Impl -->
-    <jackson.version>2.9.4</jackson.version>
+    <jackson.version>2.9.9.3</jackson.version>
+    <jackson.dataformat.version>2.9.9</jackson.dataformat.version>
 
     <!-- Javadoc & Asciidoclet -->
     <javadoc.version>3.0.1</javadoc.version>
@@ -1857,6 +1858,18 @@
             <artifactId>xalan</artifactId>
           </exclusion>
         </exclusions>
+      </dependency>
+      <!-- Jackson required by OpenAPI Impl and ActiveMQ Broker -->
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-databind</artifactId>
+        <version>${jackson.version}</version>
+      </dependency>
+      <!-- Jackson required by OpenAPI Impl -->
+      <dependency>
+        <groupId>com.fasterxml.jackson.dataformat</groupId>
+        <artifactId>jackson-dataformat-yaml</artifactId>
+        <version>${jackson.dataformat.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/tomee/tomee-microprofile/mp-common/pom.xml
+++ b/tomee/tomee-microprofile/mp-common/pom.xml
@@ -168,13 +168,10 @@
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-yaml</artifactId>
-      <version>${jackson.version}</version>
     </dependency>
-
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>${jackson.version}</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
## What does this MR do?

- Updates jackson-databind to 2.9.9.3 (was 2.9.4), see changelog https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9 (several CVEs are addressed)

- Updates activemq to 5.15.10 (also requires  jackson-databind in v 2.9.9.3)

- Hint: As micro-patches were applied (see changelog), the version number now differs from jackson-dataformat. Thus, a new version property was introduced.

## References

- https://issues.apache.org/jira/browse/TOMEE-2655
- https://www.cvedetails.com/vulnerability-list/vendor_id-15866/product_id-42991/Fasterxml-Jackson-databind.html