### PR TITLE
[TOMEE-2655] [7.1.x] Updates jackson-databind to 2.9.9.3 to mitigate CVE-2019-12384, CVE-2019-12814, CVE-2019-14379 and CVE-2019-14439

### DIFF
--- a/container/openejb-core/pom.xml
+++ b/container/openejb-core/pom.xml
@@ -547,6 +547,10 @@
       <groupId>org.objectweb.howl</groupId>
       <artifactId>howl</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
     <!-- JavaMail -->
     <dependency>
       <groupId>org.apache.geronimo.javamail</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -170,7 +170,7 @@
     <commons-net.version>3.3</commons-net.version>
 
     <bval.version>1.1.2</bval.version>
-    <org.apache.activemq.version>5.15.8</org.apache.activemq.version>
+    <org.apache.activemq.version>5.15.10</org.apache.activemq.version>
     <org.springframework.version>3.1.4.RELEASE</org.springframework.version>
     <junit.version>4.12</junit.version>
     <org.apache.axis2.version>1.4.1</org.apache.axis2.version>
@@ -190,6 +190,8 @@
     <version.hibernate>4.2.18.Final</version.hibernate>
     <version.eclipselink>2.6.4</version.eclipselink>
     <version.groovy>2.4.12</version.groovy>
+
+    <jackson.version>2.9.9.3</jackson.version>
 
     <!-- arquillian related -->
     <version.arquillian.bom>1.1.13.Final</version.arquillian.bom>
@@ -1041,6 +1043,10 @@
             <artifactId>jackson-core-mapper</artifactId>
           </exclusion>
           <exclusion>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+          </exclusion>
+          <exclusion>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-core</artifactId>
           </exclusion>
@@ -1768,6 +1774,11 @@
             <artifactId>xalan</artifactId>
           </exclusion>
         </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-databind</artifactId>
+        <version>${jackson.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/tomee/tomee-plume-webapp/pom.xml
+++ b/tomee/tomee-plume-webapp/pom.xml
@@ -145,7 +145,6 @@
         </exclusion>
       </exclusions>
     </dependency>
-
     <!-- if i'm not mistaken we decided to remove it from our default deliveries
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/tomee/tomee-plus-webapp/pom.xml
+++ b/tomee/tomee-plus-webapp/pom.xml
@@ -144,7 +144,6 @@
       <version>${jcs.version}</version>
       <scope>runtime</scope>
     </dependency>
-
     <!-- if i'm not mistaken we decided to remove it from our default deliveries
     <dependency>
       <groupId>${project.groupId}</groupId>


### PR DESCRIPTION
## What does this MR do?

- Updates jackson-databind to 2.9.9.3 (was 2.9.6), see changelog https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9 (several CVEs are addressed)

- Updates `activemq` to 5.15.10

- Hint: In 7.1.x, "jackson-databind" is a transient dependency of "activemq-broker".

## References

- https://issues.apache.org/jira/browse/TOMEE-2655
- https://www.cvedetails.com/vulnerability-list/vendor_id-15866/product_id-42991/Fasterxml-Jackson-databind.html