### PR TITLE
TOMEE-2694  - Unifying MicroProfile Spanish Translation

### DIFF
--- a/examples/mp-metrics-counted/README_es.adoc
+++ b/examples/mp-metrics-counted/README_es.adoc
@@ -54,7 +54,7 @@ Hi, today is a sunny day!
 
 == Usando `@Counted`
 
-Las métricas de Microprofile tienen una función que se puede usar para contar
+Las métricas de MicroProfile tienen una función que se puede usar para contar
 solicitudes a un servicio.
 
 Para utilizar esta función, debe anotar los métodos de los recursos JAX-RS con

--- a/examples/mp-metrics-counted/README_es.adoc
+++ b/examples/mp-metrics-counted/README_es.adoc
@@ -3,7 +3,7 @@
 :jbake-type: page
 :jbake-status: published
 
-Este es un ejemplo sobre cómo utilizar las métricas de microperfil en TomEE. El
+Este es un ejemplo sobre cómo utilizar las métricas de Microprofile en TomEE. El
 proyecto incluye un perfil de Docker que se puede usar para crear una imagen de
 Docker.
 
@@ -54,7 +54,7 @@ Hi, today is a sunny day!
 
 == Usando `@Counted`
 
-Las métricas de MicroProfile tienen una función que se puede usar para contar
+Las métricas de Microprofile tienen una función que se puede usar para contar
 solicitudes a un servicio.
 
 Para utilizar esta función, debe anotar los métodos de los recursos JAX-RS con

--- a/examples/mp-metrics-counted/README_es.adoc
+++ b/examples/mp-metrics-counted/README_es.adoc
@@ -3,7 +3,7 @@
 :jbake-type: page
 :jbake-status: published
 
-Este es un ejemplo sobre cómo utilizar las métricas de Microprofile en TomEE. El
+Este es un ejemplo sobre cómo utilizar las métricas de MicroProfile en TomEE. El
 proyecto incluye un perfil de Docker que se puede usar para crear una imagen de
 Docker.
 

--- a/examples/mp-metrics-gauge/README_es.adoc
+++ b/examples/mp-metrics-gauge/README_es.adoc
@@ -4,7 +4,7 @@
 :jbake-type: page
 :jbake-status: published
 
-Este es un ejemplo sobre cómo utilizar las métricas de microperfil en TomEE.
+Este es un ejemplo sobre cómo utilizar las métricas de MicroProfile en TomEE.
 
 == Ejecute la aplicación:
 

--- a/examples/mp-metrics-histogram/README_es.adoc
+++ b/examples/mp-metrics-histogram/README_es.adoc
@@ -3,7 +3,7 @@
 :jbake-type: page
 :jbake-status: published
 
-Este es un ejemplo sobre cómo utilizar las métricas de Microprofile en TomEE.
+Este es un ejemplo sobre cómo utilizar las métricas de MicroProfile en TomEE.
 
 == Ejecute la aplicación:
 
@@ -43,7 +43,7 @@ $ curl -X GET http://localhost:8080/mp-metrics-histogram/weather/histogram
 
 == Usando `@Histogram`
 
-Las métricas de Microprofile tienen una función que te permite crear un histograma datos.
+Las métricas de MicroProfile tienen una función que te permite crear un histograma datos.
 
 Para utilizar esta función, injecta un objeto `MetricRegistry`, registra el Histograma, and agrega datos al histograma como se muestra a continuación.
 

--- a/examples/mp-metrics-histogram/README_es.adoc
+++ b/examples/mp-metrics-histogram/README_es.adoc
@@ -3,7 +3,7 @@
 :jbake-type: page
 :jbake-status: published
 
-Este es un ejemplo sobre cómo utilizar las métricas de microperfil en TomEE.
+Este es un ejemplo sobre cómo utilizar las métricas de Microprofile en TomEE.
 
 == Ejecute la aplicación:
 
@@ -43,7 +43,7 @@ $ curl -X GET http://localhost:8080/mp-metrics-histogram/weather/histogram
 
 == Usando `@Histogram`
 
-Las métricas de MicroProfile tienen una función que te permite crear un histograma datos.
+Las métricas de Microprofile tienen una función que te permite crear un histograma datos.
 
 Para utilizar esta función, injecta un objeto `MetricRegistry`, registra el Histograma, and agrega datos al histograma como se muestra a continuación.
 

--- a/examples/mp-metrics-metered/README_es.adoc
+++ b/examples/mp-metrics-metered/README_es.adoc
@@ -3,7 +3,7 @@
 :jbake-type: page
 :jbake-status: published
 
-Este es un ejemplo sobre cómo utilizar las métricas de Microprofile en TomEE.
+Este es un ejemplo sobre cómo utilizar las métricas de MicroProfile en TomEE.
 
 == Ejecute la aplicación:
 
@@ -31,7 +31,7 @@ Hi, today is a sunny day!
 
 == Usando `@Metered`
 
-Las métricas de Microprofile tienen una función que se puede usar para medir
+Las métricas de MicroProfile tienen una función que se puede usar para medir
 solicitudes a un servicio.
 
 Para utilizar esta función, debe anotar los métodos de los recursos JAX-RS con

--- a/examples/mp-metrics-metered/README_es.adoc
+++ b/examples/mp-metrics-metered/README_es.adoc
@@ -3,7 +3,7 @@
 :jbake-type: page
 :jbake-status: published
 
-Este es un ejemplo sobre cómo utilizar las métricas de microperfil en TomEE.
+Este es un ejemplo sobre cómo utilizar las métricas de Microprofile en TomEE.
 
 == Ejecute la aplicación:
 
@@ -31,7 +31,7 @@ Hi, today is a sunny day!
 
 == Usando `@Metered`
 
-Las métricas de MicroProfile tienen una función que se puede usar para medir
+Las métricas de Microprofile tienen una función que se puede usar para medir
 solicitudes a un servicio.
 
 Para utilizar esta función, debe anotar los métodos de los recursos JAX-RS con

--- a/examples/mp-metrics-timed/README_es.adoc
+++ b/examples/mp-metrics-timed/README_es.adoc
@@ -3,7 +3,7 @@
 :jbake-type: page
 :jbake-status: published
 
-Este es un ejemplo sobre cómo utilizar las métricas de Microprofile en TomEE.
+Este es un ejemplo sobre cómo utilizar las métricas de MicroProfile en TomEE.
 
 == Ejecute la aplicación:
 
@@ -31,7 +31,7 @@ Hi, today is a sunny day!
 
 == Usando `@Timed`
 
-Las métricas de Microprofile tienen una función que se puede usar para tracker
+Las métricas de MicroProfile tienen una función que se puede usar para tracker
 el tiempo de un evento.
 
 Para utilizar esta función, debe anotar los métodos de los recursos JAX-RS con

--- a/examples/mp-metrics-timed/README_es.adoc
+++ b/examples/mp-metrics-timed/README_es.adoc
@@ -3,7 +3,7 @@
 :jbake-type: page
 :jbake-status: published
 
-Este es un ejemplo sobre cómo utilizar las métricas de microperfil en TomEE.
+Este es un ejemplo sobre cómo utilizar las métricas de Microprofile en TomEE.
 
 == Ejecute la aplicación:
 
@@ -31,7 +31,7 @@ Hi, today is a sunny day!
 
 == Usando `@Timed`
 
-Las métricas de MicroProfile tienen una función que se puede usar para tracker
+Las métricas de Microprofile tienen una función que se puede usar para tracker
 el tiempo de un evento.
 
 Para utilizar esta función, debe anotar los métodos de los recursos JAX-RS con


### PR DESCRIPTION
Using proper English name:  **Microprofile** Instead of:  **Microperfil**
