### PR TITLE
Ddded missing dependency for microprofile

### DIFF
--- a/tomee/tomee-microprofile/mp-common/pom.xml
+++ b/tomee/tomee-microprofile/mp-common/pom.xml
@@ -158,6 +158,12 @@
       </exclusions>
     </dependency>
 
+    <dependency> <!-- Added in for backwards compatibility with the move to Jakarta EE coordinates -->
+      <groupId>com.sun.activation</groupId>
+      <artifactId>jakarta.activation</artifactId>
+      <version>1.2.1</version>
+    </dependency>
+
     <dependency>
       <groupId>org.eclipse.microprofile.openapi</groupId>
       <artifactId>microprofile-openapi-api</artifactId>


### PR DESCRIPTION
Jira card:  TOMEE-2731

This fixes a missing dependency for microprofile.  This was discussed in the dev email list.

I added:
```
<dependency> <!-- Added in for backwards compatibility with the move to Jakarta EE coordinates -->
        <groupId>com.sun.activation</groupId>                                      
        <artifactId>jakarta.activation</artifactId>                                
        <version>1.2.1</version>                                                   
</dependency> 
```