### PR TITLE
Translate to Spanish: example/simple-singlento  

### DIFF
--- a/examples/simple-singleton/README_es.adoc
+++ b/examples/simple-singleton/README_es.adoc
@@ -1,0 +1,364 @@
+:index-group: Session Beans
+:jbake-type: page
+:jbake-status: status=published
+= Simple Singleton
+
+Como su nombre lo indica, un `javax.ejb.Singleton`, es un bean de sesión con la garantía de que existe  como máximo una instancia en la aplicación.
+
+Lo que falta por completo en EJB 3.0 y versiones anteriores, es la capacidad de tener un EJB que se notifique cuando la aplicación se inicia y cuando se detiene. Por lo tanto, puede hacer todo tipo de cosas que anteriormente solo podía hacer con un servlet de carga al inicio. También le brinda un lugar para almacenar datos que pertenecen a toda la aplicación y a todos los usuarios que la utilizan, sin la necesidad de un estático. Además, los beans Singleton pueden ser invocados por múltiples hilos
+al mismo tiempo similar a un servlet.
+
+Vea link:../../singleton-beans.html[Singleton Beans] para obtener una página completa de la descripción de la API javax.ejb.Singleton.
+
+#El codigo
+
+== Concurrencia Bean-Managed de PropertyRegistry 
+Aquí vemos un bean que usa la opción de concurrencia Bean-Managed, así como la anotación @Startup que hace que el bean sea confirmado por el contenedor cuando se inicia la aplicación. 
+Los beans Singleton con @ConcurrencyManagement(BEAN) son responsables de su propia seguridad de subprocesos. El bean que se muestra es un simple ``registry'' de propiedad y proporciona un lugar donde todos los beans de aplicación podrían establecer y recuperar opciones.
+
+....
+package org.superbiz.registry;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.ejb.ConcurrencyManagement;
+import javax.ejb.Singleton;
+import javax.ejb.Startup;
+import java.util.Properties;
+
+import static javax.ejb.ConcurrencyManagementType.BEAN;
+
+@Singleton
+@Startup
+@ConcurrencyManagement(BEAN)
+public class PropertyRegistry {
+
+
+// Tenga en cuenta que el objeto java.util.Properties es una 
+// colección segura para subprocesos que utiliza sincronización. Si no fuera así,
+// tendría que usar alguna forma de sincronización para asegurarse 
+// de que PropertyRegistryBean sea seguro para subprocesos.
+    private final Properties properties = new Properties();
+
+// La anotación @Startup garantiza que se 
+// llame a este método cuando se inicia la aplicación.
+    @PostConstruct
+    public void applicationStartup() {
+        properties.putAll(System.getProperties());
+    }
+
+    @PreDestroy
+    public void applicationShutdown() {
+        properties.clear();
+    }
+
+    public String getProperty(final String key) {
+        return properties.getProperty(key);
+    }
+
+    public String setProperty(final String key, final String value) {
+        return (String) properties.setProperty(key, value);
+    }
+
+    public String removeProperty(final String key) {
+        return (String) properties.remove(key);
+    }
+}
+....
+
+== ComponentRegistry Container-Managed Concurrency
+
+Aquí vemos un bean que usa la opción de concurrencia 'Container-Managed', el valor predeterminado. Con `@ConcurrencyManagement(CONTAINER)` el contenedor controla si se debe permitir el acceso multiproceso al bean
+(`@Lock(READ)`) o si se debe forzar el acceso de un solo subproceso
+(`@Lock(WRITE)`).
+
+....
+package org.superbiz.registry;
+
+import javax.ejb.Lock;
+import javax.ejb.Singleton;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import static javax.ejb.LockType.READ;
+import static javax.ejb.LockType.WRITE;
+
+@Singleton
+@Lock(READ)
+public class ComponentRegistry {
+
+    private final Map<Class, Object> components = new HashMap<Class, Object>();
+
+    public <T> T getComponent(final Class<T> type) {
+        return (T) components.get(type);
+    }
+
+    public Collection<?> getComponents() {
+        return new ArrayList(components.values());
+    }
+
+    @Lock(WRITE)
+    public <T> T setComponent(final Class<T> type, final T value) {
+        return (T) components.put(type, value);
+    }
+
+    @Lock(WRITE)
+    public <T> T removeComponent(final Class<T> type) {
+        return (T) components.remove(type);
+    }
+}
+....
+
+A menos que se especifique explícitamente en la clase de bean o un método, el valor predeterminado `@Lock` es `@Lock(WRITE)`. El código anterior utiliza la anotación `@Lock(READ)` en la clase bean para cambiar el valor predeterminado, de modo que se otorgue el acceso multiproceso por defecto. Entonces solo necesitamos aplicar la anotación `@Lock(WRITE)` a los métodos que modifican el estado del bean.
+
+Esencialmente, `@Lock(READ)` permite el acceso multiproceso a la instancia del bean Singleton, a menos que alguien invoque un método `@Lock(WRITE)`. Con `@Lock(WRITE)`, se garantizará que el subproceso que invoca el bean tendrá acceso exclusivo a la instancia del bean Singleton mientras dure su invocación. Esta combinación permite que la instancia de bean use tipos de datos que normalmente no son seguros para subprocesos.  Se debe tener mucho cuidado.
+
+En el ejemplo vemos `ComponentRegistryBean` usando un
+`java.util.HashMap` que no está sincronizado. Para hacer esto bien, hacemos
+tres cosas:
+
+[arabic]
+. Encapsulación. No exponemos la instancia de HashMap directamente; incluidos sus iteradores, conjunto de claves, conjunto de valores o conjunto de entradas.
+. Usamos `@Lock(WRITE)` en los métodos que mutan el mapa, como los métodos `put()` y `remove()`.
+. Utilizamos `@Lock(READ)` en los métodos `get()` y `values()` ya que no cambian el estado del mapa y se garantiza que no se invocarán al mismo tiempo que cualquiera de los `@Lock(WRITE)`, por lo que sabemos que el estado de HashMap no está siendo mutado y, por lo tanto, es seguro para la lectura.
+
+
+El resultado final, el modelo de subprocesos para este bean cambiará de acceso, de subprocesos múltiples a acceso de subprocesos dinámicos, según sea necesario, dependiendo del método que se invoque. Esto le da a los singleton, una ventaja sobre los Servlets, para procesar solicitudes de subprocesos múltiples.
+
+Vea link:../../singleton-beans.html[Singleton Beans] página para obtener detalles más avanzados sobre la concurrencia Container-Managed.
+
+== Testing
+
+=== ComponentRegistryTest
+
+....
+package org.superbiz.registry;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.ejb.embeddable.EJBContainer;
+import javax.naming.Context;
+import java.net.URI;
+import java.util.Collection;
+import java.util.Date;
+
+public class ComponentRegistryTest {
+
+    private final static EJBContainer ejbContainer = EJBContainer.createEJBContainer();
+
+    @Test
+    public void oneInstancePerMultipleReferences() throws Exception {
+
+        final Context context = ejbContainer.getContext();
+
+        // Las dos referencias a continuación apuntan a la misma instancia exacta
+        final ComponentRegistry one = (ComponentRegistry) context.lookup("java:global/simple-singleton/ComponentRegistry");
+        final ComponentRegistry two = (ComponentRegistry) context.lookup("java:global/simple-singleton/ComponentRegistry");
+
+        final URI expectedUri = new URI("foo://bar/baz");
+        one.setComponent(URI.class, expectedUri);
+        final URI actualUri = two.getComponent(URI.class);
+        Assert.assertSame(expectedUri, actualUri);
+
+        two.removeComponent(URI.class);
+        URI uri = one.getComponent(URI.class);
+        Assert.assertNull(uri);
+
+        one.removeComponent(URI.class);
+        uri = two.getComponent(URI.class);
+        Assert.assertNull(uri);
+
+        final Date expectedDate = new Date();
+        two.setComponent(Date.class, expectedDate);
+        final Date actualDate = one.getComponent(Date.class);
+        Assert.assertSame(expectedDate, actualDate);
+
+        Collection<?> collection = one.getComponents();
+        System.out.println(collection);
+        Assert.assertEquals("Reference 'one' - ComponentRegistry contains one record", collection.size(), 1);
+
+        collection = two.getComponents();
+        Assert.assertEquals("Reference 'two' - ComponentRegistry contains one record", collection.size(), 1);
+    }
+
+    @AfterClass
+    public static void closeEjbContainer() {
+        ejbContainer.close();
+    }
+}
+....
+
+=== PropertiesRegistryTest
+
+....
+package org.superbiz.registry;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.ejb.embeddable.EJBContainer;
+import javax.naming.Context;
+
+public class PropertiesRegistryTest {
+
+    private final static EJBContainer ejbContainer = EJBContainer.createEJBContainer();
+
+    @Test
+    public void oneInstancePerMultipleReferences() throws Exception {
+
+        final Context context = ejbContainer.getContext();
+
+        final PropertyRegistry one = (PropertyRegistry) context.lookup("java:global/simple-singleton/PropertyRegistry");
+        final PropertyRegistry two = (PropertyRegistry) context.lookup("java:global/simple-singleton/PropertyRegistry");
+
+        one.setProperty("url", "http://superbiz.org");
+        String url = two.getProperty("url");
+        Assert.assertSame("http://superbiz.org", url);
+
+        two.removeProperty("url");
+        url = one.getProperty("url");
+        Assert.assertNull(url);
+
+        two.setProperty("version", "1.0.5");
+        String version = one.getProperty("version");
+        Assert.assertSame("1.0.5", version);
+
+        one.removeProperty("version");
+        version = two.getProperty("version");
+        Assert.assertNull(version);
+    }
+
+    @AfterClass
+    public static void closeEjbContainer() {
+        ejbContainer.close();
+    }
+}
+....
+
+#Ejecutar
+
+Ejecutar el ejemplo es bastante simple. En el directorio `simple-singleton`
+ ejecutar:
+
+....
+$ mvn clean install
+....
+
+Lo que debería crear resultados como los siguientes.
+
+....
+-------------------------------------------------------
+ T E S T S
+-------------------------------------------------------
+Running org.superbiz.registry.ComponentRegistryTest
+INFO - ********************************************************************************
+INFO - OpenEJB http://tomee.apache.org/
+INFO - Startup: Sun Jun 09 03:46:51 IDT 2013
+INFO - Copyright 1999-2013 (C) Apache OpenEJB Project, All Rights Reserved.
+INFO - Version: 7.0.0-SNAPSHOT
+INFO - Build date: 20130608
+INFO - Build time: 04:07
+INFO - ********************************************************************************
+INFO - openejb.home = C:\Users\Oz\Desktop\ee-examples\simple-singleton
+INFO - openejb.base = C:\Users\Oz\Desktop\ee-examples\simple-singleton
+INFO - Created new singletonService org.apache.openejb.cdi.ThreadSingletonServiceImpl@448ad367
+INFO - Succeeded in installing singleton service
+INFO - Using 'javax.ejb.embeddable.EJBContainer=true'
+INFO - Cannot find the configuration file [conf/openejb.xml].  Will attempt to create one for the beans deployed.
+INFO - Configuring Service(id=Default Security Service, type=SecurityService, provider-id=Default Security Service)
+INFO - Configuring Service(id=Default Transaction Manager, type=TransactionManager, provider-id=Default Transaction Manager)
+INFO - Creating TransactionManager(id=Default Transaction Manager)
+INFO - Creating SecurityService(id=Default Security Service)
+INFO - Found EjbModule in classpath: c:\users\oz\desktop\ee-examples\simple-singleton\target\classes
+INFO - Beginning load: c:\users\oz\desktop\ee-examples\simple-singleton\target\classes
+INFO - Configuring enterprise application: C:\Users\Oz\Desktop\ee-examples\simple-singleton
+INFO - Auto-deploying ejb PropertyRegistry: EjbDeployment(deployment-id=PropertyRegistry)
+INFO - Auto-deploying ejb ComponentRegistry: EjbDeployment(deployment-id=ComponentRegistry)
+INFO - Configuring Service(id=Default Singleton Container, type=Container, provider-id=Default Singleton Container)
+INFO - Auto-creating a container for bean PropertyRegistry: Container(type=SINGLETON, id=Default Singleton Container)
+INFO - Creating Container(id=Default Singleton Container)
+INFO - Configuring Service(id=Default Managed Container, type=Container, provider-id=Default Managed Container)
+INFO - Auto-creating a container for bean org.superbiz.registry.ComponentRegistryTest: Container(type=MANAGED, id=Default Managed Container)
+INFO - Creating Container(id=Default Managed Container)
+INFO - Using directory C:\Users\Oz\AppData\Local\Temp for stateful session passivation
+INFO - Enterprise application "C:\Users\Oz\Desktop\ee-examples\simple-singleton" loaded.
+INFO - Assembling app: C:\Users\Oz\Desktop\ee-examples\simple-singleton
+INFO - Jndi(name="java:global/simple-singleton/PropertyRegistry!org.superbiz.registry.PropertyRegistry")
+INFO - Jndi(name="java:global/simple-singleton/PropertyRegistry")
+INFO - Jndi(name="java:global/simple-singleton/ComponentRegistry!org.superbiz.registry.ComponentRegistry")
+INFO - Jndi(name="java:global/simple-singleton/ComponentRegistry")
+INFO - Existing thread singleton service in SystemInstance(): org.apache.openejb.cdi.ThreadSingletonServiceImpl@448ad367
+INFO - OpenWebBeans Container is starting...
+INFO - Adding OpenWebBeansPlugin : [CdiPlugin]
+INFO - All injection points were validated successfully.
+INFO - OpenWebBeans Container has started, it took 68 ms.
+INFO - Created Ejb(deployment-id=PropertyRegistry, ejb-name=PropertyRegistry, container=Default Singleton Container)
+INFO - Created Ejb(deployment-id=ComponentRegistry, ejb-name=ComponentRegistry, container=Default Singleton Container)
+INFO - Started Ejb(deployment-id=PropertyRegistry, ejb-name=PropertyRegistry, container=Default Singleton Container)
+INFO - Started Ejb(deployment-id=ComponentRegistry, ejb-name=ComponentRegistry, container=Default Singleton Container)
+INFO - Deployed Application(path=C:\Users\Oz\Desktop\ee-examples\simple-singleton)
+[Sun Jun 09 03:46:52 IDT 2013]
+INFO - Undeploying app: C:\Users\Oz\Desktop\ee-examples\simple-singleton
+INFO - Destroying OpenEJB container
+Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.431 sec
+Running org.superbiz.registry.PropertiesRegistryTest
+INFO - ********************************************************************************
+INFO - OpenEJB http://tomee.apache.org/
+INFO - Startup: Sun Jun 09 03:46:52 IDT 2013
+INFO - Copyright 1999-2013 (C) Apache OpenEJB Project, All Rights Reserved.
+INFO - Version: 7.0.0-SNAPSHOT
+INFO - Build date: 20130608
+INFO - Build time: 04:07
+INFO - ********************************************************************************
+INFO - openejb.home = C:\Users\Oz\Desktop\ee-examples\simple-singleton
+INFO - openejb.base = C:\Users\Oz\Desktop\ee-examples\simple-singleton
+INFO - Created new singletonService org.apache.openejb.cdi.ThreadSingletonServiceImpl@448ad367
+INFO - Succeeded in installing singleton service
+INFO - Using 'javax.ejb.embeddable.EJBContainer=true'
+INFO - Cannot find the configuration file [conf/openejb.xml].  Will attempt to create one for the beans deployed.
+INFO - Configuring Service(id=Default Security Service, type=SecurityService, provider-id=Default Security Service)
+INFO - Configuring Service(id=Default Transaction Manager, type=TransactionManager, provider-id=Default Transaction Manager)
+INFO - Creating TransactionManager(id=Default Transaction Manager)
+INFO - Creating SecurityService(id=Default Security Service)
+INFO - Using 'java.security.auth.login.config=jar:file:/C:/Users/Oz/.m2/repository/org/apache/openejb/openejb-core/7.0.0-SNAPSHOT/openejb-core-7.0.0-SNAPSHOT.jar!/login.config'
+INFO - Found EjbModule in classpath: c:\users\oz\desktop\ee-examples\simple-singleton\target\classes
+INFO - Beginning load: c:\users\oz\desktop\ee-examples\simple-singleton\target\classes
+INFO - Configuring enterprise application: C:\Users\Oz\Desktop\ee-examples\simple-singleton
+INFO - Auto-deploying ejb ComponentRegistry: EjbDeployment(deployment-id=ComponentRegistry)
+INFO - Auto-deploying ejb PropertyRegistry: EjbDeployment(deployment-id=PropertyRegistry)
+INFO - Configuring Service(id=Default Singleton Container, type=Container, provider-id=Default Singleton Container)
+INFO - Auto-creating a container for bean ComponentRegistry: Container(type=SINGLETON, id=Default Singleton Container)
+INFO - Creating Container(id=Default Singleton Container)
+INFO - Configuring Service(id=Default Managed Container, type=Container, provider-id=Default Managed Container)
+INFO - Auto-creating a container for bean org.superbiz.registry.PropertiesRegistryTest: Container(type=MANAGED, id=Default Managed Container)
+INFO - Creating Container(id=Default Managed Container)
+INFO - Using directory C:\Users\Oz\AppData\Local\Temp for stateful session passivation
+INFO - Enterprise application "C:\Users\Oz\Desktop\ee-examples\simple-singleton" loaded.
+INFO - Assembling app: C:\Users\Oz\Desktop\ee-examples\simple-singleton
+INFO - Jndi(name="java:global/simple-singleton/ComponentRegistry!org.superbiz.registry.ComponentRegistry")
+INFO - Jndi(name="java:global/simple-singleton/ComponentRegistry")
+INFO - Jndi(name="java:global/simple-singleton/PropertyRegistry!org.superbiz.registry.PropertyRegistry")
+INFO - Jndi(name="java:global/simple-singleton/PropertyRegistry")
+INFO - Existing thread singleton service in SystemInstance(): org.apache.openejb.cdi.ThreadSingletonServiceImpl@448ad367
+INFO - OpenWebBeans Container is starting...
+INFO - Adding OpenWebBeansPlugin : [CdiPlugin]
+INFO - All injection points were validated successfully.
+INFO - OpenWebBeans Container has started, it took 4 ms.
+INFO - Created Ejb(deployment-id=PropertyRegistry, ejb-name=PropertyRegistry, container=Default Singleton Container)
+INFO - Created Ejb(deployment-id=ComponentRegistry, ejb-name=ComponentRegistry, container=Default Singleton Container)
+INFO - Started Ejb(deployment-id=PropertyRegistry, ejb-name=PropertyRegistry, container=Default Singleton Container)
+INFO - Started Ejb(deployment-id=ComponentRegistry, ejb-name=ComponentRegistry, container=Default Singleton Container)
+INFO - Deployed Application(path=C:\Users\Oz\Desktop\ee-examples\simple-singleton)
+INFO - Undeploying app: C:\Users\Oz\Desktop\ee-examples\simple-singleton
+INFO - Destroying OpenEJB container
+Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.171 sec
+
+Results :
+
+Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
+....


### PR DESCRIPTION
Translate into Spanish the README file using a suffix `_es` (simple-singleton/README.adoc into file simple-singleton/README_es.adoc). [TOMEE-2858](https://issues.apache.org/jira/browse/TOMEE-2858)
