### PR TITLE
Fix logic in assertProperties method. Fixes TOMEE-1417

### DIFF
--- a/container/openejb-core/src/test/java/org/apache/openejb/util/PropertiesTest.java
+++ b/container/openejb-core/src/test/java/org/apache/openejb/util/PropertiesTest.java
@@ -359,7 +359,7 @@ public class PropertiesTest extends TestCase {
             } else {
                 final Object expectedValue = expected.get(key);
                 final Object actualValue = actual.get(key);
-                if (expectedValue != expectedValue && (expectedValue == null || !expectedValue.equals(actual))) {
+                if (actualValue != expectedValue && (expectedValue == null || !expectedValue.equals(actualValue))) {
                     message.append("C ").append(key).append("=").append(expectedValue).append("\n");
                     message.append("  ").append(key).append("=").append(actualValue).append("\n");
                 }


### PR DESCRIPTION
In the assertProperties() methodf, the logic for comparing when a property exists in both collections, but has a different value, the logic is incorrect and never fails.

I've changed the logic now so that it will fail as appropriate and catch any future errors.