### PR TITLE
TOMEE-2903 - Application Composer Documentation has reference to old maven coordinates

### DIFF
--- a/examples/application-composer/README.adoc
+++ b/examples/application-composer/README.adoc
@@ -12,9 +12,9 @@ that is used to build the actual applications:
 [source,xml]
 ----
 <dependency>
-  <groupId>org.apache.openejb</groupId>
-  <artifactId>openejb-jee</artifactId>
-  <version>4.0.0-beta-1</version>
+  <groupId>org.apache.tomee</groupId>
+  <artifactId>openejb-core</artifactId>
+  <version>${openejb.version}</version>
 </dependency>
 ----
 

--- a/examples/application-composer/README_pt.adoc
+++ b/examples/application-composer/README_pt.adoc
@@ -10,9 +10,9 @@ Com o `ApplicationComposer` você pode fazer testes idênticos ao que o OpenEJB 
 que é usado para construir as aplicações atuais:
 
     <dependency>
-      <groupId>org.apache.openejb</groupId>
-      <artifactId>openejb-jee</artifactId>
-      <version>4.0.0-beta-1</version>
+      <groupId>org.apache.tomee</groupId>
+      <artifactId>openejb-core</artifactId>
+      <version>${openejb.version}</version>
     </dependency>
 
 == Compondo um aplicativo


### PR DESCRIPTION
Link to jira: https://issues.apache.org/jira/browse/TOMEE-2903
Added new maven coordinates to the openejb-core artifact.