### PR TITLE
TOMEE-2930 - MoviesArquillianHtmlUnitTest -> Invalid byte 2 of 2-byte UTF-8 sequence. error.

### DIFF
--- a/examples/simple-ear/moviefun-functional-tests/pom.xml
+++ b/examples/simple-ear/moviefun-functional-tests/pom.xml
@@ -34,6 +34,19 @@
     <version.shrinkwrap.resolver>2.0.0</version.shrinkwrap.resolver>
   </properties>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <systemPropertyVariables>
+            <project.version>${project.parent.version}</project.version>
+          </systemPropertyVariables>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
   <dependencyManagement>
     <dependencies>
       <!-- Override dependency resolver with test version. This must go *BEFORE*

--- a/examples/simple-ear/moviefun-functional-tests/src/test/java/org/superbiz/moviefun/DeployInWebAppsDirectoryTest.java
+++ b/examples/simple-ear/moviefun-functional-tests/src/test/java/org/superbiz/moviefun/DeployInWebAppsDirectoryTest.java
@@ -46,7 +46,7 @@ public class DeployInWebAppsDirectoryTest {
         configuration.setGroupId("org.apache.tomee");
         configuration.setArtifactId("apache-tomee");
         configuration.setClassifier("plus");
-        configuration.setVersion("7.0.10-SNAPSHOT");
+        configuration.setVersion(System.getProperty("project.version", "7.0.10-SNAPSHOT"));
         configuration.setHttpPort(-1);
 
         final RemoteTomEEContainer container = new RemoteTomEEContainer();
@@ -58,7 +58,7 @@ public class DeployInWebAppsDirectoryTest {
             final File webapps = new File(configuration.getDir(), "apache-tomee-" + configuration.getClassifier() + "-" + configuration.getVersion() + "/webapps");
             webapps.mkdirs();
 
-            final File enterpriseArchive = Maven.resolver().resolve("org.superbiz:moviefun-ear:ear:7.0.10-SNAPSHOT")
+            final File enterpriseArchive = Maven.resolver().resolve("org.superbiz:moviefun-ear:ear:" + System.getProperty("project.version", "7.0.10-SNAPSHOT"))
                     .withoutTransitivity().asSingleFile();
 
             IO.copy(enterpriseArchive, new File(webapps, "moviefun-ear.ear"));

--- a/examples/simple-ear/moviefun-functional-tests/src/test/java/org/superbiz/moviefun/DeployInWebAppsDirectoryTest.java
+++ b/examples/simple-ear/moviefun-functional-tests/src/test/java/org/superbiz/moviefun/DeployInWebAppsDirectoryTest.java
@@ -46,7 +46,7 @@ public class DeployInWebAppsDirectoryTest {
         configuration.setGroupId("org.apache.tomee");
         configuration.setArtifactId("apache-tomee");
         configuration.setClassifier("plus");
-        configuration.setVersion("7.0.8-SNAPSHOT");
+        configuration.setVersion("7.0.10-SNAPSHOT");
         configuration.setHttpPort(-1);
 
         final RemoteTomEEContainer container = new RemoteTomEEContainer();
@@ -58,7 +58,7 @@ public class DeployInWebAppsDirectoryTest {
             final File webapps = new File(configuration.getDir(), "apache-tomee-" + configuration.getClassifier() + "-" + configuration.getVersion() + "/webapps");
             webapps.mkdirs();
 
-            final File enterpriseArchive = Maven.resolver().resolve("org.superbiz:moviefun-ear:ear:7.0.8-SNAPSHOT")
+            final File enterpriseArchive = Maven.resolver().resolve("org.superbiz:moviefun-ear:ear:7.0.10-SNAPSHOT")
                     .withoutTransitivity().asSingleFile();
 
             IO.copy(enterpriseArchive, new File(webapps, "moviefun-ear.ear"));

--- a/examples/simple-ear/moviefun-functional-tests/src/test/java/org/superbiz/moviefun/MoviesArquillianHtmlUnitTest.java
+++ b/examples/simple-ear/moviefun-functional-tests/src/test/java/org/superbiz/moviefun/MoviesArquillianHtmlUnitTest.java
@@ -37,7 +37,7 @@ public class MoviesArquillianHtmlUnitTest {
 
     @Deployment
     public static EnterpriseArchive createDeployment() {
-        final EnterpriseArchive enterpriseArchive = Maven.resolver().resolve("org.superbiz:moviefun-ear:ear:7.0.10-SNAPSHOT")
+        final EnterpriseArchive enterpriseArchive = Maven.resolver().resolve("org.superbiz:moviefun-ear:ear:" + System.getProperty("project.version", "7.0.10-SNAPSHOT"))
                 .withoutTransitivity().asSingle(EnterpriseArchive.class);
 
         System.out.println(enterpriseArchive.toString(true));

--- a/examples/simple-ear/moviefun-functional-tests/src/test/java/org/superbiz/moviefun/MoviesArquillianHtmlUnitTest.java
+++ b/examples/simple-ear/moviefun-functional-tests/src/test/java/org/superbiz/moviefun/MoviesArquillianHtmlUnitTest.java
@@ -37,7 +37,7 @@ public class MoviesArquillianHtmlUnitTest {
 
     @Deployment
     public static EnterpriseArchive createDeployment() {
-        final EnterpriseArchive enterpriseArchive = Maven.resolver().resolve("org.superbiz:moviefun-ear:ear:7.0.8-SNAPSHOT")
+        final EnterpriseArchive enterpriseArchive = Maven.resolver().resolve("org.superbiz:moviefun-ear:ear:7.0.10-SNAPSHOT")
                 .withoutTransitivity().asSingle(EnterpriseArchive.class);
 
         System.out.println(enterpriseArchive.toString(true));


### PR DESCRIPTION
# What does this PR do?

As discussed on the mailing list [3], we found test errors in `MoviesArquillianHtmlUnitTest`. 

While trying to reproduce it on my Linux machine, I found, that the dependencies used for setting up the unit tests do not match with the current project version. 

CI does not cover this as it can retrieve the old snapshot artifacts (either from local disk cache or from an apache snapshot repo).

With the version adjustments, the tests can be executed and do not throw the exception mentioned above

Question, @cesarhernandezgt : Can we run this PR on the CI environment to check, if the issue persists?

# References

- [1] https://issues.apache.org/jira/browse/TOMEE-2930
- [2] https://ci-builds.apache.org/job/Tomee/job/tomee-7.0.x/org.superbiz$moviefun-functional-test/3/testReport/junit/org.superbiz.moviefun/MoviesArquillianHtmlUnitTest/org_superbiz_moviefun_MoviesArquillianHtmlUnitTest/
- [3] https://openejb.markmail.org/search/?q=type:development#query:type%3Adevelopment+page:1+mid:yagkenymmvojwqvh+state:results
