### PR TITLE
TOMEE-2932 - Fixes javax.ws.rs.NotSupportedException: HTTP 415 Unsupported Media Type

### DIFF
--- a/examples/tomee-webprofile-embedded/src/test/java/org/superbiz/movie/MovieServiceTest.java
+++ b/examples/tomee-webprofile-embedded/src/test/java/org/superbiz/movie/MovieServiceTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import javax.ws.rs.core.MediaType;
 import java.net.URI;
 
+import static javax.ws.rs.client.Entity.entity;
 import static org.junit.Assert.assertEquals;
 
 public class MovieServiceTest {
@@ -66,8 +67,8 @@ public class MovieServiceTest {
         final WebClient client = WebClient.create(serverURI).accept(MediaType.APPLICATION_JSON);
 
         final Movie movie = new Movie("Shanghai Noon", "Tom Dey", "Comedy", 7, 2000);
-        final Movie posted = client.path("/api/movies").post(movie, Movie.class);
 
+        final Movie posted = client.path("/api/movies").post(entity(movie, MediaType.APPLICATION_JSON_TYPE)).readEntity(Movie.class);
 
         assertEquals("Tom Dey", posted.getDirector());
         assertEquals("Shanghai Noon", posted.getTitle());


### PR DESCRIPTION
# What does this PR do?

As discussed on the mailing list [1], we found test errors in `MovieServiceTest`. 

The root cause is, that the server only accepts `application/json` but the test was sending `text/xml` instead resulting in the exception in the PR's title.

I adjusted the test-case similar to the corresponding one on the [master](https://github.com/apache/tomee/blob/142f035e454b43192c51db7a66b9395982502d47/examples/serverless-tomee-webprofile/src/test/java/org/superbiz/movie/wp/MovieServiceTest.java) branch.

# References

- [1] https://openejb.markmail.org/search/?q=type:development#query:type%3Adevelopment+page:1+mid:yagkenymmvojwqvh+state:results
- [2] https://issues.apache.org/jira/browse/TOMEE-2932
