### PR TITLE
TOMEE-2934 Handle public inner classes when looking for a class in classpath

### DIFF
--- a/container/openejb-core/src/main/java/org/apache/openejb/config/rules/ValidationBase.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/config/rules/ValidationBase.java
@@ -149,8 +149,17 @@ public abstract class ValidationBase implements ValidationRule {
         final ClassLoader cl = module.getClassLoader();
         try {
             return Classes.forName(clazz, cl);
-        } catch (final ClassNotFoundException cnfe) {
-            throw new OpenEJBException(messages().format("cl0007", clazz, module.getJarLocation()), cnfe);
+        } catch (final ClassNotFoundException cnfe1) {
+			try {
+				String innerClazz = clazz;
+				int pos = innerClazz.lastIndexOf(".");
+				if (pos >= 0) {
+					innerClazz = innerClazz.substring(0,pos) + "$" + innerClazz.substring(pos+1);
+				}
+				return Classes.forName(innerClazz, cl);
+			} catch (final ClassNotFoundException cnfe2) {
+				throw new OpenEJBException(messages().format("cl0007", clazz, module.getJarLocation()), cnfe1);
+			}
         }
     }
 


### PR DESCRIPTION
When trying to start up the ejbContainer `EJBContainer.createEJBContainer`
If a bean contains an inner class, used like this:
```java
@Asynchronous
	@TransactionAttribute(TransactionAttributeType.REQUIRES_NEW)
	public Future<Contract> processAsynchronously(Contract r) 
```
Then you get an Exception stating that:
```Cannot locate the class {0} from the codebase [{1}]```
This attept to handle this case, if it also fails then the original exception is thrown.