### PR TITLE
TOMEE-2957 - Fix OWASP Checks on ASF Jenkins Environment

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -395,6 +395,9 @@
           <groupId>org.owasp</groupId>
           <artifactId>dependency-check-maven</artifactId>
           <version>6.0.3</version>
+          <configuration>
+            <suppressionFile>owasp-dc-suppression.xml</suppressionFile>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.jacoco</groupId>
@@ -750,7 +753,6 @@
             <configuration>
               <skipProvidedScope>true</skipProvidedScope>
               <skipRuntimeScope>true</skipRuntimeScope>
-              <suppressionFiles>${maven.multiModuleProjectDirectory}/owasp-dc-suppression.xml</suppressionFiles>
             </configuration>
             <executions>
               <execution>
@@ -774,7 +776,6 @@
               <skipProvidedScope>true</skipProvidedScope>
               <skipRuntimeScope>true</skipRuntimeScope>
               <failBuildOnCVSS>8.0</failBuildOnCVSS>
-              <suppressionFiles>${maven.multiModuleProjectDirectory}/owasp-dc-suppression.xml</suppressionFiles>
             </configuration>
             <executions>
               <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -394,7 +394,7 @@
         <plugin>
           <groupId>org.owasp</groupId>
           <artifactId>dependency-check-maven</artifactId>
-          <version>6.0.3</version>
+          <version>6.0.5</version>
           <configuration>
             <suppressionFile>owasp-dc-suppression.xml</suppressionFile>
           </configuration>


### PR DESCRIPTION
# What does this PR do?

Jenkins build for the "master-owasp-check" failed due to an unresolveable maven property `maven.multiModuleProjectDirectory` [1]. This property is indeed for internal use only as it is undocumented.

This PR moves the configuration of the `suppressionFile` to the `pluginManagement` section as suggested in the related project issue [2]. I did a run locally, which worked fine. I guess, that this should also work fine on the asf jenkins.

_Note: Cannot merge it myself yet due to missing write permissions._

# Referenes

[1] https://ci-builds.apache.org/job/Tomee/job/master-owasp-check/20/console
[2] https://github.com/jeremylong/DependencyCheck/issues/2152