### PR TITLE
TOMEE-2968: Postgres connection error when a password contains "}"

### DIFF
--- a/container/openejb-core/src/main/java/org/apache/openejb/classloader/ProvisioningClassLoaderConfigurer.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/classloader/ProvisioningClassLoaderConfigurer.java
@@ -80,7 +80,7 @@ public class ProvisioningClassLoaderConfigurer implements ClassLoaderConfigurer 
 
             String line;
             while ((line = reader.readLine()) != null) {
-                line = PropertyPlaceHolderHelper.SUBSTITUTOR.replace(line.trim());
+                line = PropertyPlaceHolderHelper.replace(line.trim());
                 if (line.startsWith("#") || line.isEmpty()) {
                     continue;
                 }

--- a/tomee/tomee-jdbc/src/test/java/org/apache/tomee/jdbc/TomcatDataSourceConfigurationTest.java
+++ b/tomee/tomee-jdbc/src/test/java/org/apache/tomee/jdbc/TomcatDataSourceConfigurationTest.java
@@ -55,11 +55,12 @@ public class TomcatDataSourceConfigurationTest {
                 .p(prefix + ".MaxWait", "5000")
                 .p(prefix + ".MinEvictableIdleTimeMillis", "7200000")
                 .p(prefix + ".TimeBetweenEvictionRuns", "7300000")
+                .p(prefix + ".password", "tiger...}")
                 .build();
     }
 
     /*
-     * TOMEE-2125
+     * TOMEE-2125 and TOMEE-2968
      */
     @Test
     public void testPoolConfiguration() {
@@ -77,6 +78,7 @@ public class TomcatDataSourceConfigurationTest {
         assertEquals(5000, poolConfig.getMaxWait());
         assertEquals(7200000, poolConfig.getMinEvictableIdleTimeMillis());
         assertEquals(7300000, poolConfig.getTimeBetweenEvictionRunsMillis());
+        assertEquals("tiger...}", poolConfig.getPassword());
     }
 
 


### PR DESCRIPTION
# What does this PR do?

- Adds unit tests to reproduce TOMEE-2968 (also affects 7.0.x and 7.1.x)
- Single opening curly braces are stripped away in property values as we treat them as suffix placeholders (even in the case, we did not have an opening curly brace). PR proposes a related fix.

# References

- https://issues.apache.org/jira/browse/TOMEE-2968
- https://markmail.org/message/vxmm7t5sl33zr4wq

