### PR TITLE
TOMEE-2974 - Set file.encoding=UTF-8 for tests executed via surefire

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -446,6 +446,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
+          <argLine>-Dfile.encoding=UTF-8</argLine>
           <trimStackTrace>false</trimStackTrace>
           <reuseForks>false</reuseForks>
           <!-- to be removed when all test lifecycles are fixed -->


### PR DESCRIPTION
# What does this PR do?

Jenkins environment fails with `TomEEJsonbProviderTest` due to encoding issues. This tests uses a German locale to format a date. As we are in March now, it uses a German umlaut, which is wrongly encoded. 

- Enforces `-Dfile.encoding=UTF-8` for surefire executed tests.
- My Ubuntu machine uses a default locale of de_DE and a default encoding of UTF-8. Testing the change via **PR Jenkins builder** (which also uses ISO-8859-1 with en_US locale)

# References

- https://issues.apache.org/jira/browse/TOMEE-2974
- http://mail-archives.apache.org/mod_mbox/tomee-dev/202103.mbox/%3C5c21f88fae20d7fd59d8959171d0f9b529b2fb20.camel%40hs-heilbronn.de%3E