### PR TITLE
 TOMEE-2917 - Change All WrappingMessage to become serializable

### DIFF
--- a/container/openejb-core/src/main/java/org/apache/openejb/resource/activemq/jms2/WrappingByteMessage.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/resource/activemq/jms2/WrappingByteMessage.java
@@ -16,12 +16,14 @@
  */
 package org.apache.openejb.resource.activemq.jms2;
 
+import java.io.Serializable;
 import org.apache.activemq.command.ActiveMQBytesMessage;
 
 import javax.jms.BytesMessage;
 import javax.jms.JMSException;
 
-public class WrappingByteMessage extends DelegateMessage implements BytesMessage {
+public class WrappingByteMessage extends DelegateMessage implements BytesMessage, Serializable {
+    private static final long serialVersionUID = 3667074820757131045L;
     private final BytesMessage message;
 
     public WrappingByteMessage(final BytesMessage message) {

--- a/container/openejb-core/src/main/java/org/apache/openejb/resource/activemq/jms2/WrappingMapMessage.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/resource/activemq/jms2/WrappingMapMessage.java
@@ -16,6 +16,7 @@
  */
 package org.apache.openejb.resource.activemq.jms2;
 
+import java.io.Serializable;
 import org.apache.activemq.command.ActiveMQMapMessage;
 
 import javax.jms.JMSException;
@@ -24,7 +25,8 @@ import javax.jms.MessageFormatException;
 import java.util.Enumeration;
 import java.util.Map;
 
-public class WrappingMapMessage extends DelegateMessage implements MapMessage {
+public class WrappingMapMessage extends DelegateMessage implements MapMessage, Serializable {
+    private static final long serialVersionUID = 1825581452359766628L;
     private final MapMessage message;
 
     public WrappingMapMessage(final MapMessage message) {

--- a/container/openejb-core/src/main/java/org/apache/openejb/resource/activemq/jms2/WrappingObjectMessage.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/resource/activemq/jms2/WrappingObjectMessage.java
@@ -20,7 +20,8 @@ import javax.jms.JMSException;
 import javax.jms.ObjectMessage;
 import java.io.Serializable;
 
-public class WrappingObjectMessage extends DelegateMessage implements ObjectMessage {
+public class WrappingObjectMessage extends DelegateMessage implements ObjectMessage, Serializable {
+    private static final long serialVersionUID = -8022300929742786216L;
     private final ObjectMessage message;
 
     public WrappingObjectMessage(final ObjectMessage message) {

--- a/container/openejb-core/src/main/java/org/apache/openejb/resource/activemq/jms2/WrappingStreamMessage.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/resource/activemq/jms2/WrappingStreamMessage.java
@@ -16,11 +16,13 @@
  */
 package org.apache.openejb.resource.activemq.jms2;
 
+import java.io.Serializable;
 import javax.jms.JMSException;
 import javax.jms.MessageFormatException;
 import javax.jms.StreamMessage;
 
-public class WrappingStreamMessage extends DelegateMessage implements StreamMessage {
+public class WrappingStreamMessage extends DelegateMessage implements StreamMessage, Serializable {
+    private static final long serialVersionUID = 529457360378030114L;
     private final StreamMessage message;
 
     public WrappingStreamMessage(final StreamMessage message) {

--- a/container/openejb-core/src/main/java/org/apache/openejb/resource/activemq/jms2/WrappingTextMessage.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/resource/activemq/jms2/WrappingTextMessage.java
@@ -16,10 +16,11 @@
  */
 package org.apache.openejb.resource.activemq.jms2;
 
+import java.io.Serializable;
 import javax.jms.JMSException;
 import javax.jms.TextMessage;
 
-public class WrappingTextMessage extends DelegateMessage implements TextMessage {
+public class WrappingTextMessage extends DelegateMessage implements TextMessage, Serializable {
     private final TextMessage message;
 
     public WrappingTextMessage(final TextMessage message) {

--- a/container/openejb-core/src/main/java/org/apache/openejb/resource/activemq/jms2/WrappingTextMessage.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/resource/activemq/jms2/WrappingTextMessage.java
@@ -21,6 +21,7 @@ import javax.jms.JMSException;
 import javax.jms.TextMessage;
 
 public class WrappingTextMessage extends DelegateMessage implements TextMessage, Serializable {
+    private static final long serialVersionUID = -6024351262070855992L;
     private final TextMessage message;
 
     public WrappingTextMessage(final TextMessage message) {


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/TOMEE-2917

Fix Summary: Change all WrappingMessage to implements Serializable and add unique serialVersionUID.

Notes:
There is a business use case which need to persist WrappingTextMessage (or TextMessage) into database. Required WrappingTextMessage to become serializable.
TextMessage implementation by both IBM Websphere and Weblogic are serializable.
https://www.ibm.com/support/knowledgecenter/en/SSFKSJ_7.5.0/com.ibm.mq.javadoc.doc/WMQJMSClasses/com/ibm/jms/JMSMessage.html
https://docs.oracle.com/middleware/12213/wls/WLAPI/weblogic/jms/common/TextMessageImpl.html