### PR TITLE
Fix example adoc typo

### DIFF
--- a/examples/rest-cdi/README.adoc
+++ b/examples/rest-cdi/README.adoc
@@ -175,6 +175,7 @@ $ mvn clean install
 Which should create output like the following.
 
 [source,java]
+----
 -------------------------------------------------------
  T E S T S
 -------------------------------------------------------


### PR DESCRIPTION
For comparison check last tests block https://github.com/Dexmaster/tomee/blob/master/examples/rest-cdi/README.adoc vs https://github.com/apache/tomee/blob/master/examples/rest-cdi/README.adoc