### PR TITLE
Restore missing Inline quoted text for tomee-maven-plugin.adoc

### DIFF
--- a/docs/tomee-maven-plugin.adoc
+++ b/docs/tomee-maven-plugin.adoc
@@ -12,7 +12,7 @@ feature-rich plugin that allows for:
 * Server start and stop
 * Application deployment and undeployment
 
-Simply add the following to the , and optionally the ), section of your
+Simply add the following to the `<plugins>`, and optionally the `<pluginManagement>`), section of your
 `pom.xml`
 
 [source,xml]


### PR DESCRIPTION
Inline quoted text seems to have been lost in the conversion from MD to adoc.   For unknown reasons it's missing on the web page but visible in view-source for https://tomee.apache.org/tomee-maven-plugin.html, which makes me wonder if this is really the source file or if the web page hasn't been redeployed since the conversion.