### PR TITLE
TOMEE-3832 - JAX-RS TomEEJsonbProvider not registered in tomee-embedded-maven-plugin when MicroProfile is present

### DIFF
--- a/tomee/tomee-microprofile/mp-common/pom.xml
+++ b/tomee/tomee-microprofile/mp-common/pom.xml
@@ -162,7 +162,30 @@
           <groupId>jakarta.activation</groupId>
           <artifactId>jakarta.activation-api</artifactId>
         </exclusion>
+        <!-- exclude in favor of cxf-shade -->
+        <exclusion>
+          <groupId>org.apache.cxf</groupId>
+          <artifactId>cxf-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.cxf</groupId>
+          <artifactId>cxf-rt-transports-http</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.cxf</groupId>
+          <artifactId>cxf-rt-rs-client</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.cxf</groupId>
+          <artifactId>cxf-rt-frontend-jaxrs</artifactId>
+        </exclusion>
       </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.tomee</groupId>
+      <artifactId>cxf-shade</artifactId>
+      <version>${tomee.version}</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
# What does this MR do?

-  Use patched cxf-shade to ensure TomEEJson(b|p)Provider are registered in tomee-embedded-maven-plugin when MicroProfile is present

# References

- https://issues.apache.org/jira/browse/TOMEE-3832