### PR TITLE
TOMEE-3876 - Fixed BOM generation under windows

### DIFF
--- a/tomee/apache-tomee/src/test/java/org/apache/tomee/bootstrap/GenerateBoms.java
+++ b/tomee/apache-tomee/src/test/java/org/apache/tomee/bootstrap/GenerateBoms.java
@@ -538,7 +538,7 @@ public class GenerateBoms {
             final String groupId = artifactDir.getParentFile()
                     .getAbsolutePath()
                     .substring(path.getAbsolutePath().length() + 1)
-                    .replace("/", ".");
+                    .replace(File.separatorChar, '.');
 
             return Artifact.builder()
                     .artifactId(artifactDir.getName())


### PR DESCRIPTION
now group and artifact ids have dots instead of slashes. now ok under windows like its was already ok on linux and mac