### PR TITLE
Could org.apache.tomee:tomee-server-version:8.0.11-SNAPSHOT drop off redundant dependencies?

### DIFF
--- a/itests/tomee-server-version/pom.xml
+++ b/itests/tomee-server-version/pom.xml
@@ -65,21 +65,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.tomitribe</groupId>
-      <artifactId>tomitribe-util</artifactId>
-      <version>1.2.3</version>
-    </dependency>
-    <dependency>
-      <groupId>org.tomitribe</groupId>
-      <artifactId>swizzle</artifactId>
-      <version>1.0</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-compress</artifactId>
-      <version>1.14</version>
-    </dependency>
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>compile</scope>


### PR DESCRIPTION
Hi! I found the pom file of project **_org.apache.tomee:tomee-server-version:8.0.11-SNAPSHOT_** introduced **_6_** dependencies. However, among them, **_3_** libraries (**_50%_**) are not used by your project. I list the redundant dependencies below (labelled as red ones in the figure):
## Redundant dependencies
org.tomitribe:tomitribe-util:jar:1.2.3:compile
org.tomitribe:swizzle:jar:1.0:compile
org.apache.commons:commons-compress:jar:1.14:compile

---
Removing the redundant dependencies can reduce the size of project and prevent potential dependency conflict issues (i.e., multiple versions of the same library). More importantly, one of the redundant dependencies **_org.apache.commons:commons-compress:jar:1.14:compile_** incorporates a medium-level vulnerability SNYK-JAVA-ORGAPACHECOMMONS-1316639. As such, I suggest a refactoring operation for **_org.apache.tomee:tomee-server-version:8.0.11-SNAPSHOT_**’s pom file.

The attached PR helps resolve the reported problem. It is safe to remove the unused libraries (we considered Java reflection relations when analyzing the dependencies). These changes have passed **_org.apache.tomee:tomee-server-version:8.0.11-SNAPSHOT_**’s maven tests.

Best regards
![image](https://user-images.githubusercontent.com/78527112/158109425-51efed68-6f79-4598-b6c6-1495eb07a69d.png)
