### PR TITLE
Update exception message for MDB without an interface

### DIFF
--- a/container/openejb-core/src/main/java/org/apache/openejb/cdi/CdiEjbBean.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/cdi/CdiEjbBean.java
@@ -250,7 +250,7 @@ public class CdiEjbBean<T> extends BaseEjbBean<T> implements InterceptedMarker, 
             } else if (remote != null) {
                 instance = (T) remote.create();
             } else { // shouldn't be called for an MDB
-                throw new IllegalStateException("no interface to proxy for ejb " + beanContext.getEjbName() + ", is this is a @MessageDriven bean, maybe you shouldn't use a scope?");
+                throw new IllegalStateException("No interface to proxy for ejb " + beanContext.getEjbName() + ", if this is a @MessageDriven bean, try not using a scope?");
             }
 
             if (isDependentAndStateful) {

--- a/container/openejb-core/src/main/java/org/apache/openejb/cdi/CdiEjbBean.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/cdi/CdiEjbBean.java
@@ -250,7 +250,7 @@ public class CdiEjbBean<T> extends BaseEjbBean<T> implements InterceptedMarker, 
             } else if (remote != null) {
                 instance = (T) remote.create();
             } else { // shouldn't be called for an MDB
-                throw new IllegalStateException("no interface to proxy for ejb " + beanContext.getEjbName() + ", is this is a MDB maybe you shouldn't use a scope?");
+                throw new IllegalStateException("no interface to proxy for ejb " + beanContext.getEjbName() + ", is this is a @MessageDriven bean, maybe you shouldn't use a scope?");
             }
 
             if (isDependentAndStateful) {


### PR DESCRIPTION
I don't actually know what a `MDB` is, after a quick google i'm guessing it a `MessageDriven` bean".  Either way, the error message should spell it out.

> **NOTE:** I updated this through GitHub's web view, if CI fails, and this change is _valid_ I'll try to fix the patch.