### PR TITLE
TOMEE-4014 - Unable to see TomEE version in Tomcat home page with Java 17

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ tck/**/temp
 examples/jaxrs-json-provider-jettison/temp/
 transformer/jakartaee-prototype/
 transformer/transformer-0.1.0-SNAPSHOT/
+/tomee/apache-tomee/src/patch/java/org/apache/catalina/util/ServerInfo.properties

--- a/tomee/apache-tomee/pom.xml
+++ b/tomee/apache-tomee/pom.xml
@@ -499,6 +499,31 @@
           </plugin>
 
           <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <executions>
+              <execution>
+                <phase>package</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <target>
+                    <tstamp>
+                      <format property="today" pattern="MMM d yyyy" locale="en" timezone="UTC"/>
+                      <format property="tstamp" pattern="HH:mm:ss" locale="en" timezone="UTC"/>
+                    </tstamp>
+                    <copy file="src/template/patch/java/org/apache/catalina/util/ServerInfo.properties" tofile="src/patch/java/org/apache/catalina/util/ServerInfo.properties"/>
+                    <replace file="src/patch/java/org/apache/catalina/util/ServerInfo.properties" token="@TOMCAT-VERSION-REPLACED-BY-MAVEN@" value="${tomcat.version}" />
+                    <replace file="src/patch/java/org/apache/catalina/util/ServerInfo.properties" token="@TOMEE-VERSION-REPLACED-BY-MAVEN@" value="${tomee.version}" />
+                    <replace file="src/patch/java/org/apache/catalina/util/ServerInfo.properties" token="@DATE-REPLACED-BY-MAVEN@" value="${today} ${tstamp} UTC" />
+                  </target>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+
+          <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>build-helper-maven-plugin</artifactId>
             <executions>

--- a/tomee/apache-tomee/src/template/patch/java/org/apache/catalina/util/ServerInfo.properties
+++ b/tomee/apache-tomee/src/template/patch/java/org/apache/catalina/util/ServerInfo.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+server.info=Apache Tomcat (TomEE)/@TOMCAT-VERSION-REPLACED-BY-MAVEN@ (@TOMEE-VERSION-REPLACED-BY-MAVEN@)
+server.number=@TOMCAT-VERSION-REPLACED-BY-MAVEN@.0
+server.built=@DATE-REPLACED-BY-MAVEN@


### PR DESCRIPTION
# What does this PR do?

- Avoid reflectional access to modify ServerInfo in Tomcat, which doesn't work in Java 17 anymore
- Use the patch plugin to provide a patched ServerInfo.properties which is bootstrapped during the TomEE build process