### PR TITLE
TOMEE-4023 Comparison pages with wrong specs per profile

### DIFF
--- a/docs/comparison.adoc
+++ b/docs/comparison.adoc
@@ -88,7 +88,7 @@ https://hibernate.org/validator/[Hibernate Validator^] 7.0.x *(in TomEE 9.x and 
 |Jakarta Enterprise Beans (EJB)|https://openejb.apache.org/[Apache OpenEJB^]
 |Jakarta Persistence (JPA)|
 https://openjpa.apache.org/[Apache OpenJPA^] 3.2.x with classifier (in all TomEE flavors) +
-https://www.eclipse.org/eclipselink/[EclipseLink^] 3.1.x *(in TomEE Plume only)*
+https://www.eclipse.org/eclipselink/[EclipseLink^] 3.x *(in TomEE Plume only)*
 |Jakarta Transactions (JTA)|Apache{nbsp}Geronimo{nbsp}Transaction{nbsp}Manager
 |Jakarta Mail (JavaMail)|Apache Geronimo JavaMail
 |MicroProfile|

--- a/docs/comparison.adoc
+++ b/docs/comparison.adoc
@@ -73,9 +73,8 @@ xref:../../comparison.adoc[See main comparison page.]
 [options="header",cols="1,1"]
 |===
 |Specifications|Implementations included by TomEE
-|Jakarta Annotations, Servlet, Server Pages (JSP), +
-Jakarta Expression Language (EL), WebSocket, +
-Jakarta Authentication (JASPIC), Security, ...|
+|Jakarta Servlet, Server Pages (JSP), Expression Language (EL), +
+Jakarta Annotations, Authentication (JASPIC), WebSocket, ... |
 https://tomcat.apache.org/[Apache Tomcat^] 10.0.x
 |Jakarta{nbsp}Standard{nbsp}Tag{nbsp}Library{nbsp}(JSTL)|https://tomcat.apache.org/taglibs.html[Apache Standard Taglib Implementation^] 2.0.x
 |Jakarta Faces (JSF)|

--- a/docs/comparison.adoc
+++ b/docs/comparison.adoc
@@ -82,8 +82,8 @@ https://tomcat.apache.org/[Apache Tomcat^] 10.0.x
 https://myfaces.apache.org/[Apache MyFaces^] *(in all TomEE flavors except Plume)* +
 https://projects.eclipse.org/projects/ee4j.mojarra[Eclipse Mojarra^] *(in TomEE Plume only)*
 |Jakarta Bean Validation|
-[.line-through]#https://bval.apache.org/[Apache BVal^]# *(in TomEE 8.x and earlier)* +
-https://hibernate.org/validator/[Hibernate Validator^] 7.0.x *(in TomEE 9.x and later)*
+https://bval.apache.org/[Apache BVal^] *(in TomEE 8.x and earlier)* +
+https://hibernate.org/validator/[Hibernate Validator^] 7.0.x *(in TomEE 9.x)*
 |Jakarta Contexts and Dependency Injection (CDI)|https://openwebbeans.apache.org/[Apache OpenWebBeans^]
 |Jakarta Enterprise Beans (EJB)|https://openejb.apache.org/[Apache OpenEJB^]
 |Jakarta Persistence (JPA)|
@@ -92,7 +92,7 @@ https://www.eclipse.org/eclipselink/[EclipseLink^] 3.x *(in TomEE Plume only)*
 |Jakarta Transactions (JTA)|Apache{nbsp}Geronimo{nbsp}Transaction{nbsp}Manager
 |Jakarta Mail (JavaMail)|Apache Geronimo JavaMail
 |MicroProfile|
-[.line-through]#Apache Geronimo MicroProfile# *(in TomEE 7.1.x and 8.x)* +
+Apache Geronimo MicroProfile *(in TomEE 7.1.x and 8.x)* +
 https://smallrye.io/[SmallRye MicroProfile^] *(in TomEE 9.x and later)*
 |Jakarta JSON Binding (JSON-B), +
 Jakarta JSON Processing (JSON-P)|

--- a/docs/comparison.adoc
+++ b/docs/comparison.adoc
@@ -18,11 +18,8 @@ xref:../../comparison.adoc[See main comparison page.]
 // TOMCAT
 |https://jakarta.ee/specifications/annotations/2.0/[Jakarta Annotations^] 2.0|{y}|{y}|{y}|{y}|{y}
 |https://jakarta.ee/specifications/authentication/2.0/[Jakarta Authentication^] (JASPIC) 2.0|{y}|{y}|{y}|{y}|{y}
-|https://jakarta.ee/specifications/debugging/2.0/[Jakarta Debugging Support for Other Languages^] 2.0|{y}|{y}|{y}|{y}|{y}
-|https://jakarta.ee/specifications/security/2.0/[Jakarta Security^] (Java EE Enterprise Security) 2.0|{y}|{y}|{y}|{y}|{y}
 |https://jakarta.ee/specifications/servlet/5.0/[Jakarta Servlet^] 5.0|{y}|{y}|{y}|{y}|{y}
 |https://jakarta.ee/specifications/pages/3.0/[Jakarta Server Pages^] (JSP) 3.0|{y}|{y}|{y}|{y}|{y}
-|https://jakarta.ee/specifications/tags/2.0/[Jakarta Standard Tag Library^] (JSTL) 2.0|{y}|{y}|{y}|{y}|{y}
 |https://jakarta.ee/specifications/expression-language/4.0/[Jakarta Expression Language^] (EL) 4.0|{y}|{y}|{y}|{y}|{y}
 |https://jakarta.ee/specifications/websocket/2.0/[Jakarta WebSocket^] 2.0|{y}|{y}|{y}|{y}|{y}
 // WEB PROFILE
@@ -31,6 +28,7 @@ xref:../../comparison.adoc[See main comparison page.]
 |https://jakarta.ee/specifications/bean-validation/3.0/[Jakarta Bean Validation^] 3.0||{y}|{y}|{y}|{y}
 |https://jakarta.ee/specifications/cdi/3.0/[Jakarta Contexts and Dependency Injection^] (CDI) 3.0||{y}|{y}|{y}|{y}
 |https://jakarta.ee/specifications/dependency-injection/2.0/[Jakarta Dependency Injection^] (@Inject) 2.0||{y}|{y}|{y}|{y}
+|https://jakarta.ee/specifications/debugging/2.0/[Jakarta Debugging Support for Other Languages^] 2.0||{y}|{y}|{y}|{y}
 |https://jakarta.ee/specifications/enterprise-beans/4.0/[Jakarta Enterprise Beans^] (EJB) 4.0||{y}|{y}|{y}|{y}
 |https://jakarta.ee/specifications/faces/3.0/[Jakarta Faces^] (JSF) 3.0||{y}|{y}|{y}|{y}
 |https://jakarta.ee/specifications/interceptors/2.0/[Jakarta Interceptors^] 2.0||{y}|{y}|{y}|{y}
@@ -40,6 +38,8 @@ xref:../../comparison.adoc[See main comparison page.]
 |https://jakarta.ee/specifications/managedbeans/2.0/[Jakarta Managed Beans^] 2.0||{y}|{y}|{y}|{y}
 |https://jakarta.ee/specifications/persistence/3.0/[Jakarta Persistence^] (JPA) 3.0||{y}|{y}|{y}|{y}
 |https://jakarta.ee/specifications/restful-ws/3.0/[Jakarta RESTful Web Services^] (JAX-RS) 3.0||{y}|{y}|{y}|{y}
+|https://jakarta.ee/specifications/security/2.0/[Jakarta Security^] (Enterprise Security) 2.0||{y}|{y}|{y}|{y}
+|https://jakarta.ee/specifications/tags/2.0/[Jakarta Standard Tag Library^] (JSTL) 2.0||{y}|{y}|{y}|{y}
 |https://jakarta.ee/specifications/transactions/2.0/[Jakarta Transactions^] (JTA) 2.0||{y}|{y}|{y}|{y}
 |https://jakarta.ee/specifications/xml-binding/3.0/[Jakarta XML Binding^] (JAXB) 3.0||{y}|{y}|{y}|{y}
 // MICRO PROFILE
@@ -60,38 +60,44 @@ xref:../../comparison.adoc[See main comparison page.]
 |https://jakarta.ee/specifications/connectors/2.0/[Jakarta Connectors^] 2.0||||{y}|{y}
 |https://jakarta.ee/specifications/enterprise-ws/2.0/[Jakarta Enterprise Web Services^] 2.0||||{y}|{y}
 |https://jakarta.ee/specifications/messaging/3.0/[Jakarta Messaging^] (JMS) 3.0||||{y}|{y}
-|https://jakarta.ee/specifications/soap-attachments/2.0/[Jakarta SOAP with Attachments^] 2.0||||{y}|{y}
-|https://jakarta.ee/specifications/web-services-metadata/3.0/[Jakarta Web Services Metadata^] 3.0||||{y}|{y}
+|https://jakarta.ee/specifications/soap-attachments/2.0/[Jakarta SOAP with Attachments^] (SAAJ) 2.0||||{y}|{y}
+|https://jakarta.ee/specifications/web-services-metadata/3.0/[Jakarta Web Services Metadata^] (JWS) 3.0||||{y}|{y}
 |https://jakarta.ee/specifications/xml-web-services/3.0/[Jakarta XML Web Services^] (JAX-WS) 3.0||||{y}|{y}
 // IMPLEMENTATIONS
 |Jakarta Faces (JSF) implementation||MyFaces|MyFaces|MyFaces|*Mojarra*
 |Jakarta Persistence (JPA) implementation(s)||OpenJPA|OpenJPA|OpenJPA|OpenJPA, *EclipseLink*
 |===
 
-== [[implementations]] Implementations of Jakarta EE and MicroProfile features in TomEE
+== [[implementations]] Implementations of Jakarta EE and MicroProfile features in TomEE 9.x
 
 [options="header",cols="1,1"]
 |===
 |Specifications|Implementations included by TomEE
 |Jakarta Annotations, Servlet, Server Pages (JSP), +
 Jakarta Expression Language (EL), WebSocket, +
-Jakarta Authentication (JASPIC), Security, ...|https://tomcat.apache.org/[Apache Tomcat^]
-|Jakarta{nbsp}Standard{nbsp}Tag{nbsp}Library{nbsp}(JSTL)|https://tomcat.apache.org/taglibs.html[Apache Standard Taglib Implementation^]
-|Jakarta Faces (JSF)|https://myfaces.apache.org/[Apache MyFaces^] *(in all TomEE flavors except Plume)* +
+Jakarta Authentication (JASPIC), Security, ...|
+https://tomcat.apache.org/[Apache Tomcat^] 10.0.x
+|Jakarta{nbsp}Standard{nbsp}Tag{nbsp}Library{nbsp}(JSTL)|https://tomcat.apache.org/taglibs.html[Apache Standard Taglib Implementation^] 2.0.x
+|Jakarta Faces (JSF)|
+https://myfaces.apache.org/[Apache MyFaces^] *(in all TomEE flavors except Plume)* +
 https://projects.eclipse.org/projects/ee4j.mojarra[Eclipse Mojarra^] *(in TomEE Plume only)*
-|Jakarta Bean Validation|https://bval.apache.org/[Apache BVal^] *(in TomEE 8.x and earlier)* +
-https://hibernate.org/validator/[Hibernate Validator^] *(in TomEE 9.x and later)*
+|Jakarta Bean Validation|
+[.line-through]#https://bval.apache.org/[Apache BVal^]# *(in TomEE 8.x and earlier)* +
+https://hibernate.org/validator/[Hibernate Validator^] 7.0.x *(in TomEE 9.x and later)*
 |Jakarta Contexts and Dependency Injection (CDI)|https://openwebbeans.apache.org/[Apache OpenWebBeans^]
 |Jakarta Enterprise Beans (EJB)|https://openejb.apache.org/[Apache OpenEJB^]
-|Jakarta Persistence (JPA)|https://openjpa.apache.org/[Apache OpenJPA^] (in all TomEE flavors) +
-https://www.eclipse.org/eclipselink/[EclipseLink^] *(in TomEE Plume only)*
+|Jakarta Persistence (JPA)|
+https://openjpa.apache.org/[Apache OpenJPA^] 3.2.x with classifier (in all TomEE flavors) +
+https://www.eclipse.org/eclipselink/[EclipseLink^] 3.1.x *(in TomEE Plume only)*
 |Jakarta Transactions (JTA)|Apache{nbsp}Geronimo{nbsp}Transaction{nbsp}Manager
 |Jakarta Mail (JavaMail)|Apache Geronimo JavaMail
-|MicroProfile|Apache Geronimo MicroProfile *(in TomEE 7.1.x and 8.x)* +
+|MicroProfile|
+[.line-through]#Apache Geronimo MicroProfile# *(in TomEE 7.1.x and 8.x)* +
 https://smallrye.io/[SmallRye MicroProfile^] *(in TomEE 9.x and later)*
 |Jakarta JSON Binding (JSON-B), +
-Jakarta JSON Processing (JSON-P)|https://johnzon.apache.org/[Apache Johnzon^]
-|Jakarta XML Binding (JAXB)|https://projects.eclipse.org/projects/ee4j.jaxb-impl[Eclipse Implementation of JAXB^]
+Jakarta JSON Processing (JSON-P)|
+https://johnzon.apache.org/[Apache Johnzon^]
+|Jakarta XML Binding (JAXB)|https://projects.eclipse.org/projects/ee4j.jaxb-impl[Eclipse Implementation of JAXB^] 3.0.x
 |Web Services|https://cxf.apache.org/[Apache CXF^]
 |Jakarta Batch (JBatch)|https://geronimo.apache.org/batchee/[Apache BatchEE^]
 |Jakarta Messaging (JMS)|https://activemq.apache.org/[Apache ActiveMQ^]


### PR DESCRIPTION
Tomcat does not include JSTL nor the javax.security.enterprise.* packages.
The documentation should reflect that, and should have these specs into WebProfile.