### PR TITLE
TOMEE-4023 Comparison pages with wrong specs per profile

### DIFF
--- a/docs/comparison.adoc
+++ b/docs/comparison.adoc
@@ -74,9 +74,8 @@ xref:../../comparison.adoc[See main comparison page.]
 [options="header",cols="1,1"]
 |===
 |Specifications|Implementations included by TomEE
-|Java Annotations, Servlet, Server Pages (JSP), +
-Java Expression Language (EL), WebSocket, +
-Java Authentication (JASPIC), Security, ...|
+|Java Servlet, Server Pages (JSP), Expression Language (EL), +
+Java Annotations, Authentication (JASPIC), WebSocket, ... |
 https://tomcat.apache.org/[Apache Tomcat^]
 |Java{nbsp}Standard{nbsp}Tag{nbsp}Library{nbsp}(JSTL)|https://tomcat.apache.org/taglibs.html[Apache Standard Taglib Implementation^]
 |Java Server Faces (JSF)|

--- a/docs/comparison.adoc
+++ b/docs/comparison.adoc
@@ -95,8 +95,7 @@ https://www.eclipse.org/eclipselink/[EclipseLink^] *(in TomEE Plume only)*
 |MicroProfile|
 Apache Geronimo MicroProfile *(in TomEE 7.1.x and 8.x)* +
 https://smallrye.io/[SmallRye MicroProfile^] *(in TomEE 9.x and later)*
-|Java JSON Binding (JSON-B), +
-Java JSON Processing (JSON-P)|
+|Java JSON Processing (JSON-P)|
 https://johnzon.apache.org/[Apache Johnzon^]
 |Java XML Binding (JAXB)|https://projects.eclipse.org/projects/ee4j.jaxb-impl[Eclipse Implementation of JAXB^]
 |Web Services|https://cxf.apache.org/[Apache CXF^]

--- a/docs/comparison.adoc
+++ b/docs/comparison.adoc
@@ -76,22 +76,28 @@ xref:../../comparison.adoc[See main comparison page.]
 |Specifications|Implementations included by TomEE
 |Java Annotations, Servlet, Server Pages (JSP), +
 Java Expression Language (EL), WebSocket, +
-Java Authentication (JASPIC), Security, ...|https://tomcat.apache.org/[Apache Tomcat^]
+Java Authentication (JASPIC), Security, ...|
+https://tomcat.apache.org/[Apache Tomcat^]
 |Java{nbsp}Standard{nbsp}Tag{nbsp}Library{nbsp}(JSTL)|https://tomcat.apache.org/taglibs.html[Apache Standard Taglib Implementation^]
-|Java Server Faces (JSF)|https://myfaces.apache.org/[Apache MyFaces^] *(in all TomEE flavors except Plume)* +
+|Java Server Faces (JSF)|
+https://myfaces.apache.org/[Apache MyFaces^] *(in all TomEE flavors except Plume)* +
 https://projects.eclipse.org/projects/ee4j.mojarra[Eclipse Mojarra^] *(in TomEE Plume only)*
-|Java Bean Validation|https://bval.apache.org/[Apache BVal^] *(in TomEE 8.x and earlier)* +
+|Java Bean Validation|
+https://bval.apache.org/[Apache BVal^] *(in TomEE 8.x and earlier)* +
 https://hibernate.org/validator/[Hibernate Validator^] *(in TomEE 9.x and later)*
 |Java Contexts and Dependency Injection (CDI)|https://openwebbeans.apache.org/[Apache OpenWebBeans^]
 |Java Enterprise Beans (EJB)|https://openejb.apache.org/[Apache OpenEJB^]
-|Java Persistence (JPA)|https://openjpa.apache.org/[Apache OpenJPA^] (in all TomEE flavors) +
+|Java Persistence (JPA)|
+https://openjpa.apache.org/[Apache OpenJPA^] (in all TomEE flavors) +
 https://www.eclipse.org/eclipselink/[EclipseLink^] *(in TomEE Plume only)*
 |Java Transactions (JTA)|Apache{nbsp}Geronimo{nbsp}Transaction{nbsp}Manager
 |Java Mail (JavaMail)|Apache Geronimo JavaMail
-|MicroProfile|Apache Geronimo MicroProfile *(in TomEE 7.1.x and 8.x)* +
+|MicroProfile|
+Apache Geronimo MicroProfile *(in TomEE 7.1.x and 8.x)* +
 https://smallrye.io/[SmallRye MicroProfile^] *(in TomEE 9.x and later)*
 |Java JSON Binding (JSON-B), +
-Java JSON Processing (JSON-P)|https://johnzon.apache.org/[Apache Johnzon^]
+Java JSON Processing (JSON-P)|
+https://johnzon.apache.org/[Apache Johnzon^]
 |Java XML Binding (JAXB)|https://projects.eclipse.org/projects/ee4j.jaxb-impl[Eclipse Implementation of JAXB^]
 |Web Services|https://cxf.apache.org/[Apache CXF^]
 |Java Batch (JBatch)|https://geronimo.apache.org/batchee/[Apache BatchEE^]

--- a/docs/comparison.adoc
+++ b/docs/comparison.adoc
@@ -19,11 +19,8 @@ xref:../../comparison.adoc[See main comparison page.]
 // TOMCAT
 |https://jcp.org/en/jsr/detail?id=250[Java Annotations^] 1.2|{y}|{y}|{y}|{y}|{y}
 |https://jcp.org/en/jsr/detail?id=196[Java Authentication^] (JASPIC) 1.1|{y}|{y}|{y}|{y}|{y}
-|https://jcp.org/en/jsr/detail?id=45[Java Debugging Support for Other Languages^] 1.0|{y}|{y}|{y}|{y}|{y}
-|Java Security (Java EE Enterprise Security)|{n}|{n}|{n}|{n}|{n}
 |https://jcp.org/en/jsr/detail?id=340[Java Servlet^] 3.1|{y}|{y}|{y}|{y}|{y}
 |https://jcp.org/en/jsr/detail?id=245[Java Server Pages^] (JSP) 2.3|{y}|{y}|{y}|{y}|{y}
-|https://jcp.org/en/jsr/detail?id=52[Java Standard Tag Library^] (JSTL) 1.2|{y}|{y}|{y}|{y}|{y}
 |https://jcp.org/en/jsr/detail?id=341[Java Expression Language^] (EL) 3.0|{y}|{y}|{y}|{y}|{y}
 |https://jcp.org/en/jsr/detail?id=356[Java WebSocket^] 1.1|{y}|{y}|{y}|{y}|{y}
 // WEB PROFILE
@@ -32,6 +29,7 @@ xref:../../comparison.adoc[See main comparison page.]
 |https://jcp.org/en/jsr/detail?id=349[Java Bean Validation^] 1.1||{y}|{y}|{y}|{y}
 |https://jcp.org/en/jsr/detail?id=346[Java Contexts and Dependency Injection^] (CDI) 1.1||{y}|{y}|{y}|{y}
 |https://jcp.org/en/jsr/detail?id=330[Java Dependency Injection^] (@Inject) 1.0||{y}|{y}|{y}|{y}
+|https://jcp.org/en/jsr/detail?id=45[Java Debugging Support for Other Languages^] 1.0||{y}|{y}|{y}|{y}
 |https://jcp.org/en/jsr/detail?id=345[Java Enterprise Beans^] (EJB) 3.2||{y}|{y}|{y}|{y}
 |https://jcp.org/en/jsr/detail?id=344[Java Server Faces^] (JSF) 2.2||{y}|{y}|{y}|{y}
 |https://jcp.org/en/jsr/detail?id=318[Java Interceptors^] 1.2||{y}|{y}|{y}|{y}
@@ -41,6 +39,8 @@ xref:../../comparison.adoc[See main comparison page.]
 |https://jcp.org/en/jsr/detail?id=316[Java Managed Beans^] 1.0||{y}|{y}|{y}|{y}
 |https://jcp.org/en/jsr/detail?id=338[Java Persistence^] (JPA) 2.1||{y}|{y}|{y}|{y}
 |https://jcp.org/en/jsr/detail?id=339[Java RESTful Web Services^] (JAX-RS) 2.0||{y}|{y}|{y}|{y}
+|Java Security (Enterprise Security)||{n}|{n}|{n}|{n}
+|https://jcp.org/en/jsr/detail?id=52[Java Standard Tag Library^] (JSTL) 1.2||{y}|{y}|{y}|{y}
 |https://jcp.org/en/jsr/detail?id=907[Java Transactions^] (JTA) 1.2||{y}|{y}|{y}|{y}
 |https://jcp.org/en/jsr/detail?id=222[Java XML Binding^] (JAXB) 2.2||{y}|{y}|{y}|{y}
 // MICRO PROFILE
@@ -61,8 +61,8 @@ xref:../../comparison.adoc[See main comparison page.]
 |https://jcp.org/en/jsr/detail?id=322[Java Connectors^] 1.7||||{y}|{y}
 |https://jcp.org/en/jsr/detail?id=109[Java Enterprise Web Services^] 1.4||||{y}|{y}
 |https://jcp.org/en/jsr/detail?id=343[Java Messaging^] (JMS) 2.0||||{y}|{y}
-|https://jcp.org/en/jsr/platform?listBy=3&listByType=platform[Java SOAP with Attachments^] 1.3||||{y}|{y}
-|https://jcp.org/en/jsr/detail?id=181[Java Web Services Metadata^] 2.0||||{y}|{y}
+|https://jcp.org/en/jsr/platform?listBy=3&listByType=platform[Java SOAP with Attachments^] (SAAJ) 1.3||||{y}|{y}
+|https://jcp.org/en/jsr/detail?id=181[Java Web Services Metadata^] (JWS) 2.0||||{y}|{y}
 |https://jcp.org/en/jsr/detail?id=224[Java XML Web Services^] (JAX-WS) 2.2||||{y}|{y}
 // IMPLEMENTATIONS
 |Java Server Faces (JSF) implementation||MyFaces|MyFaces|MyFaces|*Mojarra*


### PR DESCRIPTION
Tomcat does not include JSTL nor the javax.security.enterprise.* packages.
The documentation should reflect that, and should have these specs into WebProfile.