### PR TITLE
[TOMEE-4035] Upgrade dependencies (SmallRye, Jackson, ...)

### DIFF
--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/resources/hibernate-pom.xml
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/resources/hibernate-pom.xml
@@ -24,8 +24,8 @@
   <artifactId>hibernate-deps</artifactId>
 
   <properties>
-    <version.hibernate.orm>6.1.2.Final</version.hibernate.orm>
-    <version.hibernate.validator>7.0.4.Final</version.hibernate.validator>
+    <version.hibernate.orm>6.1.3.Final</version.hibernate.orm>
+    <version.hibernate.validator>7.0.5.Final</version.hibernate.validator>
   </properties>
   <dependencies>
     <dependency>

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/resources/hibernate-pom.xml
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/resources/hibernate-pom.xml
@@ -23,11 +23,15 @@
   <version>1.0.0</version>
   <artifactId>hibernate-deps</artifactId>
 
+  <properties>
+    <version.hibernate.orm>6.1.2.Final</version.hibernate.orm>
+    <version.hibernate.validator>7.0.4.Final</version.hibernate.validator>
+  </properties>
   <dependencies>
     <dependency>
       <groupId>org.hibernate.orm</groupId>
       <artifactId>hibernate-core</artifactId>
-      <version>6.0.0.Final</version>
+      <version>${version.hibernate.orm}</version>
       <exclusions>
         <exclusion>
           <groupId>jakarta.persistence</groupId>
@@ -54,7 +58,7 @@
     <dependency>
       <groupId>org.hibernate.validator</groupId>
       <artifactId>hibernate-validator</artifactId>
-      <version>7.0.4.Final</version>
+      <version>${version.hibernate.validator}</version>
     </dependency>
   </dependencies>
 </project>

--- a/arquillian/arquillian-tomee-tests/pom.xml
+++ b/arquillian/arquillian-tomee-tests/pom.xml
@@ -145,13 +145,13 @@
     <dependency>
       <groupId>org.hibernate.orm</groupId>
       <artifactId>hibernate-core</artifactId>
-      <version>6.0.0.Final</version>
+      <version>${version.hibernate.orm}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.hibernate.common</groupId>
       <artifactId>hibernate-commons-annotations</artifactId>
-      <version>5.1.2.Final</version>
+      <version>6.0.4.Final</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/boms/tomee-microprofile/pom.xml
+++ b/boms/tomee-microprofile/pom.xml
@@ -268,7 +268,7 @@
     <dependency>
       <groupId>io.smallrye.common</groupId>
       <artifactId>smallrye-common-annotation</artifactId>
-      <version>2.0.0-RC2</version>
+      <version>2.0.0</version>
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>
@@ -279,7 +279,7 @@
     <dependency>
       <groupId>io.smallrye.common</groupId>
       <artifactId>smallrye-common-classloader</artifactId>
-      <version>2.0.0-RC2</version>
+      <version>2.0.0</version>
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>
@@ -290,7 +290,7 @@
     <dependency>
       <groupId>io.smallrye.common</groupId>
       <artifactId>smallrye-common-constraint</artifactId>
-      <version>2.0.0-RC2</version>
+      <version>2.0.0</version>
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>
@@ -301,7 +301,7 @@
     <dependency>
       <groupId>io.smallrye.common</groupId>
       <artifactId>smallrye-common-expression</artifactId>
-      <version>2.0.0-RC2</version>
+      <version>2.0.0</version>
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>
@@ -312,7 +312,7 @@
     <dependency>
       <groupId>io.smallrye.common</groupId>
       <artifactId>smallrye-common-function</artifactId>
-      <version>2.0.0-RC2</version>
+      <version>2.0.0</version>
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>
@@ -323,7 +323,7 @@
     <dependency>
       <groupId>io.smallrye.config</groupId>
       <artifactId>smallrye-config-common</artifactId>
-      <version>3.0.0-RC2</version>
+      <version>3.0.0</version>
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>
@@ -334,7 +334,7 @@
     <dependency>
       <groupId>io.smallrye.config</groupId>
       <artifactId>smallrye-config-core</artifactId>
-      <version>3.0.0-RC2</version>
+      <version>3.0.0</version>
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>
@@ -345,7 +345,7 @@
     <dependency>
       <groupId>io.smallrye.config</groupId>
       <artifactId>smallrye-config</artifactId>
-      <version>3.0.0-RC2</version>
+      <version>3.0.0</version>
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>
@@ -367,7 +367,7 @@
     <dependency>
       <groupId>io.smallrye</groupId>
       <artifactId>smallrye-fault-tolerance-core</artifactId>
-      <version>6.0.0-RC1</version>
+      <version>6.0.0</version>
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>
@@ -378,7 +378,7 @@
     <dependency>
       <groupId>io.smallrye</groupId>
       <artifactId>smallrye-health-api</artifactId>
-      <version>4.0.0-RC1</version>
+      <version>4.0.0</version>
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>
@@ -389,7 +389,7 @@
     <dependency>
       <groupId>io.smallrye</groupId>
       <artifactId>smallrye-health</artifactId>
-      <version>4.0.0-RC1</version>
+      <version>4.0.0</version>
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>
@@ -400,7 +400,7 @@
     <dependency>
       <groupId>io.smallrye</groupId>
       <artifactId>smallrye-metrics</artifactId>
-      <version>4.0.0-RC1</version>
+      <version>4.0.0</version>
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>
@@ -411,7 +411,7 @@
     <dependency>
       <groupId>io.smallrye</groupId>
       <artifactId>smallrye-open-api-core</artifactId>
-      <version>3.0.0-RC1</version>
+      <version>3.0.0</version>
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>
@@ -422,7 +422,7 @@
     <dependency>
       <groupId>io.smallrye</groupId>
       <artifactId>smallrye-open-api-jaxrs</artifactId>
-      <version>3.0.0-RC1</version>
+      <version>3.0.0</version>
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>
@@ -433,7 +433,7 @@
     <dependency>
       <groupId>io.smallrye</groupId>
       <artifactId>smallrye-opentracing-contrib</artifactId>
-      <version>3.0.0-RC1</version>
+      <version>3.0.0</version>
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>
@@ -444,7 +444,7 @@
     <dependency>
       <groupId>io.smallrye</groupId>
       <artifactId>smallrye-opentracing</artifactId>
-      <version>3.0.0-RC1</version>
+      <version>3.0.0</version>
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>

--- a/boms/tomee-plume/pom.xml
+++ b/boms/tomee-plume/pom.xml
@@ -279,7 +279,7 @@
     <dependency>
       <groupId>io.smallrye.common</groupId>
       <artifactId>smallrye-common-annotation</artifactId>
-      <version>2.0.0-RC2</version>
+      <version>2.0.0</version>
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>
@@ -290,7 +290,7 @@
     <dependency>
       <groupId>io.smallrye.common</groupId>
       <artifactId>smallrye-common-classloader</artifactId>
-      <version>2.0.0-RC2</version>
+      <version>2.0.0</version>
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>
@@ -301,7 +301,7 @@
     <dependency>
       <groupId>io.smallrye.common</groupId>
       <artifactId>smallrye-common-constraint</artifactId>
-      <version>2.0.0-RC2</version>
+      <version>2.0.0</version>
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>
@@ -312,7 +312,7 @@
     <dependency>
       <groupId>io.smallrye.common</groupId>
       <artifactId>smallrye-common-expression</artifactId>
-      <version>2.0.0-RC2</version>
+      <version>2.0.0</version>
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>
@@ -323,7 +323,7 @@
     <dependency>
       <groupId>io.smallrye.common</groupId>
       <artifactId>smallrye-common-function</artifactId>
-      <version>2.0.0-RC2</version>
+      <version>2.0.0</version>
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>
@@ -334,7 +334,7 @@
     <dependency>
       <groupId>io.smallrye.config</groupId>
       <artifactId>smallrye-config-common</artifactId>
-      <version>3.0.0-RC2</version>
+      <version>3.0.0</version>
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>
@@ -345,7 +345,7 @@
     <dependency>
       <groupId>io.smallrye.config</groupId>
       <artifactId>smallrye-config-core</artifactId>
-      <version>3.0.0-RC2</version>
+      <version>3.0.0</version>
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>
@@ -356,7 +356,7 @@
     <dependency>
       <groupId>io.smallrye.config</groupId>
       <artifactId>smallrye-config</artifactId>
-      <version>3.0.0-RC2</version>
+      <version>3.0.0</version>
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>
@@ -378,7 +378,7 @@
     <dependency>
       <groupId>io.smallrye</groupId>
       <artifactId>smallrye-fault-tolerance-core</artifactId>
-      <version>6.0.0-RC1</version>
+      <version>6.0.0</version>
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>
@@ -389,7 +389,7 @@
     <dependency>
       <groupId>io.smallrye</groupId>
       <artifactId>smallrye-health-api</artifactId>
-      <version>4.0.0-RC1</version>
+      <version>4.0.0</version>
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>
@@ -400,7 +400,7 @@
     <dependency>
       <groupId>io.smallrye</groupId>
       <artifactId>smallrye-health</artifactId>
-      <version>4.0.0-RC1</version>
+      <version>4.0.0</version>
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>
@@ -1881,7 +1881,7 @@
     <dependency>
       <groupId>org.eclipse.persistence</groupId>
       <artifactId>eclipselink</artifactId>
-      <version>3.0.2</version>
+      <version>3.0.3</version>
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>

--- a/boms/tomee-plus/pom.xml
+++ b/boms/tomee-plus/pom.xml
@@ -290,7 +290,7 @@
     <dependency>
       <groupId>io.smallrye.common</groupId>
       <artifactId>smallrye-common-annotation</artifactId>
-      <version>2.0.0-RC2</version>
+      <version>2.0.0</version>
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>
@@ -301,7 +301,7 @@
     <dependency>
       <groupId>io.smallrye.common</groupId>
       <artifactId>smallrye-common-classloader</artifactId>
-      <version>2.0.0-RC2</version>
+      <version>2.0.0</version>
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>
@@ -312,7 +312,7 @@
     <dependency>
       <groupId>io.smallrye.common</groupId>
       <artifactId>smallrye-common-constraint</artifactId>
-      <version>2.0.0-RC2</version>
+      <version>2.0.0</version>
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>
@@ -323,7 +323,7 @@
     <dependency>
       <groupId>io.smallrye.common</groupId>
       <artifactId>smallrye-common-expression</artifactId>
-      <version>2.0.0-RC2</version>
+      <version>2.0.0</version>
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>
@@ -334,7 +334,7 @@
     <dependency>
       <groupId>io.smallrye.common</groupId>
       <artifactId>smallrye-common-function</artifactId>
-      <version>2.0.0-RC2</version>
+      <version>2.0.0</version>
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>
@@ -345,7 +345,7 @@
     <dependency>
       <groupId>io.smallrye.config</groupId>
       <artifactId>smallrye-config-common</artifactId>
-      <version>3.0.0-RC2</version>
+      <version>3.0.0</version>
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>
@@ -356,7 +356,7 @@
     <dependency>
       <groupId>io.smallrye.config</groupId>
       <artifactId>smallrye-config-core</artifactId>
-      <version>3.0.0-RC2</version>
+      <version>3.0.0</version>
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>
@@ -367,7 +367,7 @@
     <dependency>
       <groupId>io.smallrye.config</groupId>
       <artifactId>smallrye-config</artifactId>
-      <version>3.0.0-RC2</version>
+      <version>3.0.0</version>
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>
@@ -389,7 +389,7 @@
     <dependency>
       <groupId>io.smallrye</groupId>
       <artifactId>smallrye-fault-tolerance-core</artifactId>
-      <version>6.0.0-RC1</version>
+      <version>6.0.0</version>
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>

--- a/examples/jpa-eclipselink/pom.xml
+++ b/examples/jpa-eclipselink/pom.xml
@@ -27,6 +27,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <surefire.argline />
+    <version.eclipselink>3.0.3</version.eclipselink>
   </properties>
   <build>
     <defaultGoal>install</defaultGoal>
@@ -88,7 +89,7 @@
     <dependency>
       <groupId>org.eclipse.persistence</groupId>
       <artifactId>eclipselink</artifactId>
-      <version>3.0.2</version>
+      <version>${version.eclipselink}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/examples/multi-jpa-provider-testing/src/test/resources/hibernate-pom.xml
+++ b/examples/multi-jpa-provider-testing/src/test/resources/hibernate-pom.xml
@@ -24,8 +24,8 @@
   <artifactId>hibernate-deps</artifactId>
 
   <properties>
-    <version.hibernate.orm>6.1.2.Final</version.hibernate.orm>
-    <version.hibernate.validator>7.0.4.Final</version.hibernate.validator>
+    <version.hibernate.orm>6.1.3.Final</version.hibernate.orm>
+    <version.hibernate.validator>7.0.5.Final</version.hibernate.validator>
   </properties>
   <dependencies>
     <dependency>

--- a/examples/multi-jpa-provider-testing/src/test/resources/hibernate-pom.xml
+++ b/examples/multi-jpa-provider-testing/src/test/resources/hibernate-pom.xml
@@ -23,11 +23,15 @@
   <version>1.0.0</version>
   <artifactId>hibernate-deps</artifactId>
 
+  <properties>
+    <version.hibernate.orm>6.1.2.Final</version.hibernate.orm>
+    <version.hibernate.validator>7.0.4.Final</version.hibernate.validator>
+  </properties>
   <dependencies>
     <dependency>
       <groupId>org.hibernate.orm</groupId>
       <artifactId>hibernate-core</artifactId>
-      <version>6.0.0.Final</version>
+      <version>${version.hibernate.orm}</version>
       <exclusions>
         <exclusion>
           <groupId>jakarta.persistence</groupId>

--- a/examples/mvc-cxf-hibernate/pom.xml
+++ b/examples/mvc-cxf-hibernate/pom.xml
@@ -29,9 +29,11 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <tomee.version>9.0.0-M9-SNAPSHOT</tomee.version>
     <version.deltaspike>1.9.3</version.deltaspike>
-    <version.krazo>1.1.0-M1</version.krazo>
+    <version.krazo>2.0.2</version.krazo>
     <version.arquillian>1.7.0.Alpha10</version.arquillian>
     <version.graphene.webdriver>2.3.1</version.graphene.webdriver>
+    <version.hibernate.orm>6.1.2.Final</version.hibernate.orm>
+    <version.hibernate.validator>7.0.4.Final</version.hibernate.validator>
   </properties>
   <build>
     <finalName>mvc-cxf</finalName>
@@ -61,7 +63,7 @@
           <args>-Xmx512m -XX:PermSize=256m</args>
           <libs>
             <!-- add hibernate -->
-            <lib>org.hibernate.orm:hibernate-core:6.0.0.Final</lib>
+            <lib>org.hibernate.orm:hibernate-core:${version.hibernate.orm}</lib>
             <lib>remove:openjpa</lib>
           </libs>
         </configuration>
@@ -113,7 +115,7 @@
       <version>${version.deltaspike}</version>
       <scope>runtime</scope>
     </dependency>
-    <!-- MVC 1.0(JSR 371) -->
+    <!-- MVC -->
     <dependency>
       <groupId>org.eclipse.krazo</groupId>
       <artifactId>krazo-core</artifactId>
@@ -132,7 +134,7 @@
     <dependency>
       <groupId>org.eclipse.persistence</groupId>
       <artifactId>eclipselink</artifactId>
-      <version>2.7.7</version>
+      <version>${version.eclipselink}</version>
     </dependency>
     <!--  tests  -->
     <dependency>

--- a/examples/mvc-cxf-hibernate/pom.xml
+++ b/examples/mvc-cxf-hibernate/pom.xml
@@ -32,8 +32,8 @@
     <version.krazo>2.0.2</version.krazo>
     <version.arquillian>1.7.0.Alpha10</version.arquillian>
     <version.graphene.webdriver>2.3.1</version.graphene.webdriver>
-    <version.hibernate.orm>6.1.2.Final</version.hibernate.orm>
-    <version.hibernate.validator>7.0.4.Final</version.hibernate.validator>
+    <version.hibernate.orm>6.1.3.Final</version.hibernate.orm>
+    <version.hibernate.validator>7.0.5.Final</version.hibernate.validator>
   </properties>
   <build>
     <finalName>mvc-cxf</finalName>

--- a/examples/mvc-cxf/pom.xml
+++ b/examples/mvc-cxf/pom.xml
@@ -115,7 +115,7 @@
     <dependency>
       <groupId>org.eclipse.persistence</groupId>
       <artifactId>eclipselink</artifactId>
-      <version>2.7.7</version>
+      <version>${version.eclipselink}</version>
     </dependency>
     <!--  tests  -->
     <dependency>

--- a/examples/tomee-jersey-eclipselink/pom.xml
+++ b/examples/tomee-jersey-eclipselink/pom.xml
@@ -25,7 +25,7 @@
   <name>TomEE :: Examples :: TomEE, Jersey, Eclipselink</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <version.eclipselink>2.7.7</version.eclipselink>
+    <version.eclipselink>3.0.3</version.eclipselink>
     <tomee.version>9.0.0-M9-SNAPSHOT</tomee.version>
     <arquillian_universe.version>1.2.0.1</arquillian_universe.version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -206,8 +206,8 @@
     <version.hsqldb>2.7.0</version.hsqldb>
     <version.axiom>1.3.0</version.axiom>
     <version.xalan>2.7.2</version.xalan>
-    <version.hibernate.orm>6.1.2.Final</version.hibernate.orm>
-    <version.hibernate.validator>7.0.4.Final</version.hibernate.validator>
+    <version.hibernate.orm>6.1.3.Final</version.hibernate.orm>
+    <version.hibernate.validator>7.0.5.Final</version.hibernate.validator>
     <version.eclipselink>3.0.3</version.eclipselink>
     <version.groovy>2.4.12</version.groovy>
     <version.ecj>4.6.1</version.ecj>

--- a/pom.xml
+++ b/pom.xml
@@ -197,7 +197,7 @@
     <geronimo.connector.version>3.1.5</geronimo.connector.version>
     <geronimo-osgi.version>1.1</geronimo-osgi.version>
     <myfaces.version>3.0.2</myfaces.version>
-    <mojarra.version>3.0.0</mojarra.version>
+    <mojarra.version>3.0.2</mojarra.version>
     <slf4j.version>1.7.36</slf4j.version>
     <log4j.version>1.2.17</log4j.version>
     <log4j2.version>2.18.0</log4j2.version>
@@ -206,8 +206,9 @@
     <version.hsqldb>2.7.0</version.hsqldb>
     <version.axiom>1.3.0</version.axiom>
     <version.xalan>2.7.2</version.xalan>
-    <version.hibernate>6.0.2.Final</version.hibernate>
-    <version.eclipselink>3.0.2</version.eclipselink>
+    <version.hibernate.orm>6.1.2.Final</version.hibernate.orm>
+    <version.hibernate.validator>7.0.4.Final</version.hibernate.validator>
+    <version.eclipselink>3.0.3</version.eclipselink>
     <version.groovy>2.4.12</version.groovy>
     <version.ecj>4.6.1</version.ecj>
 
@@ -220,7 +221,7 @@
 
     <microprofile.config.version>3.0.1</microprofile.config.version>
     <microprofile.config.tck.version>3.0.1</microprofile.config.tck.version>
-    <microprofile.config.impl.version>3.0.0-RC2</microprofile.config.impl.version>
+    <microprofile.config.impl.version>3.0.0</microprofile.config.impl.version>
 
     <microprofile.jwt.version>2.0</microprofile.jwt.version>
     <microprofile.jwt.tck.version>2.0</microprofile.jwt.tck.version>
@@ -228,15 +229,15 @@
 
     <microprofile.fault-tolerance.version>4.0</microprofile.fault-tolerance.version>
     <microprofile.fault-tolerance.tck.version>4.0</microprofile.fault-tolerance.tck.version>
-    <microprofile.fault-tolerance.impl.version>6.0.0-RC1</microprofile.fault-tolerance.impl.version>
+    <microprofile.fault-tolerance.impl.version>6.0.0</microprofile.fault-tolerance.impl.version>
 
     <microprofile.health.version>4.0</microprofile.health.version>
     <microprofile.health.tck.version>4.0</microprofile.health.tck.version>
-    <microprofile.health.impl.version>4.0.0-RC1</microprofile.health.impl.version>
+    <microprofile.health.impl.version>4.0.0</microprofile.health.impl.version>
 
     <microprofile.metrics.version>4.0.1</microprofile.metrics.version>
     <microprofile.metrics.tck.version>4.0.1</microprofile.metrics.tck.version>
-    <microprofile.metrics.impl.version>4.0.0-RC1</microprofile.metrics.impl.version>
+    <microprofile.metrics.impl.version>4.0.0</microprofile.metrics.impl.version>
 
     <microprofile.rest-client.version>3.0</microprofile.rest-client.version>
     <microprofile.rest-client.tck.version>3.0</microprofile.rest-client.tck.version>
@@ -244,16 +245,16 @@
 
     <microprofile.openapi.version>3.0</microprofile.openapi.version>
     <microprofile.openapi.tck.version>3.0</microprofile.openapi.tck.version>
-    <microprofile.openapi.impl.version>3.0.0-RC1</microprofile.openapi.impl.version>
+    <microprofile.openapi.impl.version>3.0.0</microprofile.openapi.impl.version>
 
     <microprofile.opentracing.version>3.0</microprofile.opentracing.version>
     <microprofile.opentracing.tck.version>3.0</microprofile.opentracing.tck.version>
-    <microprofile.opentracing.impl.version>3.0.0-RC1</microprofile.opentracing.impl.version>
+    <microprofile.opentracing.impl.version>3.0.0</microprofile.opentracing.impl.version>
     <opentracing.api>0.33.0</opentracing.api>
 
     <!-- Jackson required by OpenAPI Impl -->
-    <jackson.version>2.13.2.2</jackson.version>
-    <jackson.dataformat.version>2.13.2</jackson.dataformat.version>
+    <jackson.version>2.13.4</jackson.version>
+    <jackson.dataformat.version>2.13.4</jackson.dataformat.version>
 
     <!-- Javadoc & Asciidoclet -->
     <javadoc.version>3.3.2</javadoc.version>
@@ -1858,7 +1859,7 @@
       <dependency>
         <groupId>org.hibernate.orm</groupId>
         <artifactId>hibernate-core</artifactId>
-        <version>${version.hibernate}</version>
+        <version>${version.hibernate.orm}</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.persistence</groupId>
@@ -1885,7 +1886,7 @@
       <dependency>
         <groupId>org.hibernate.validator</groupId>
         <artifactId>hibernate-validator</artifactId>
-        <version>7.0.4.Final</version>
+        <version>${version.hibernate.validator}</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.validation</groupId>

--- a/utils/openejb-core-hibernate/pom.xml
+++ b/utils/openejb-core-hibernate/pom.xml
@@ -88,7 +88,7 @@
     <dependency>
       <groupId>org.hibernate.orm</groupId>
       <artifactId>hibernate-jcache</artifactId>
-      <version>${version.hibernate}</version>
+      <version>${version.hibernate.orm}</version>
       <exclusions>
         <exclusion>
           <groupId>org.hibernate.orm</groupId>


### PR DESCRIPTION
versions of SmallRye that were RC are now stable releases.
hibernate 6.0 is EOL, use 6.1 instead (compatible jakarta 9.1).
updated mojarra (faces) to 3.0.2 eclipselink to 3.0.3 krazo (mvc) to 2.0.2