### PR TITLE
[TOMEE-4053] TomeE 9.x Dependency properties cleanup

### DIFF
--- a/arquillian/arquillian-openejb-embedded/pom.xml
+++ b/arquillian/arquillian-openejb-embedded/pom.xml
@@ -170,7 +170,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>${surefire.version}</version> <!-- 2.21 snapshot has a bug with classloader due to j9 work -->
+        <version>${version.plugin.surefire}</version> <!-- 2.21 snapshot has a bug with classloader due to j9 work -->
       </plugin>
     </plugins>
   </build>

--- a/arquillian/arquillian-tck/pom.xml
+++ b/arquillian/arquillian-tck/pom.xml
@@ -97,7 +97,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>${surefire.version}</version>
+        <version>${version.plugin.surefire}</version>
         <configuration>
           <threadCount>1</threadCount>
           <reuseForks>true</reuseForks>

--- a/arquillian/arquillian-tomee-common/pom.xml
+++ b/arquillian/arquillian-tomee-common/pom.xml
@@ -61,7 +61,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>jakartaee-api</artifactId>
-      <version>${version.jakartaee-api}</version>
+      <version>${version.tomee.jakartaee-api}</version>
       <type>jar</type>
     </dependency>
 
@@ -79,7 +79,7 @@
     <dependency>
       <groupId>org.apache.xbean</groupId>
       <artifactId>xbean-finder-shaded</artifactId>
-      <version>${xbeanVersion}</version>
+      <version>${version.xbean}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/arquillian/arquillian-tomee-embedded/pom.xml
+++ b/arquillian/arquillian-tomee-embedded/pom.xml
@@ -83,7 +83,7 @@
     <dependency>
       <groupId>org.apache.myfaces.core</groupId>
       <artifactId>myfaces-api</artifactId>
-      <version>${myfaces.version}</version>
+      <version>${version.myfaces}</version>
     </dependency>
 
     <dependency>
@@ -95,7 +95,7 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>${commons-io.version}</version>
+      <version>${version.commons-io}</version>
       <scope>test</scope>
     </dependency>
 

--- a/arquillian/arquillian-tomee-moviefun-example/pom.xml
+++ b/arquillian/arquillian-tomee-moviefun-example/pom.xml
@@ -66,7 +66,7 @@
                 <artifactItem>
                   <groupId>commons-logging</groupId>
                   <artifactId>commons-logging</artifactId>
-                  <version>${commons-logging.version}</version>
+                  <version>${version.commons-logging}</version>
                 </artifactItem>
                 <artifactItem>
                   <groupId>jakarta.servlet.jsp.jstl</groupId>
@@ -111,7 +111,7 @@
     <dependency>
       <groupId>org.apache.myfaces.core</groupId>
       <artifactId>myfaces-api</artifactId>
-      <version>${myfaces.version}</version>
+      <version>${version.myfaces}</version>
     </dependency>
     <dependency>
       <groupId>jakarta.servlet.jsp.jstl</groupId>

--- a/arquillian/arquillian-tomee-remote/pom.xml
+++ b/arquillian/arquillian-tomee-remote/pom.xml
@@ -158,7 +158,7 @@
       <groupId>org.apache.openwebbeans</groupId>
       <artifactId>openwebbeans-impl</artifactId>
       <classifier>jakarta</classifier>
-      <version>${openwebbeans.version}</version>
+      <version>${version.openwebbeans}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -232,7 +232,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>${surefire.version}</version>
+        <version>${version.plugin.surefire}</version>
         <configuration>
           <reuseForks>true</reuseForks>
           <forkCount>1</forkCount>

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-config-tests/pom.xml
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-config-tests/pom.xml
@@ -31,7 +31,7 @@
     <dependency>
       <artifactId>commons-lang3</artifactId>
       <groupId>org.apache.commons</groupId>
-      <version>${commons-lang3.version}</version>
+      <version>${version.commons-lang3}</version>
     </dependency>
   </dependencies>
 

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/pom.xml
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/pom.xml
@@ -31,7 +31,7 @@
     <dependency>
       <artifactId>commons-lang3</artifactId>
       <groupId>org.apache.commons</groupId>
-      <version>${commons-lang3.version}</version>
+      <version>${version.commons-lang3}</version>
     </dependency>
     <dependency>
       <groupId>commons-codec</groupId>
@@ -70,7 +70,7 @@
           <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>jakartaee-api</artifactId>
-            <version>${version.jakartaee-api}</version>
+            <version>${version.tomee.jakartaee-api}</version>
           </dependency>
           <dependency>
             <groupId>net.sourceforge.serp</groupId>

--- a/arquillian/arquillian-tomee-tests/pom.xml
+++ b/arquillian/arquillian-tomee-tests/pom.xml
@@ -500,7 +500,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
-            <version>${surefire.version}</version>
+            <version>${version.plugin.surefire}</version>
             <executions>
               <execution>
                 <id>test-tomee-embedded</id>

--- a/arquillian/ziplock/pom.xml
+++ b/arquillian/ziplock/pom.xml
@@ -53,7 +53,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>jakartaee-api</artifactId>
-      <version>${version.jakartaee-api}</version>
+      <version>${version.tomee.jakartaee-api}</version>
     </dependency>
 
     <dependency>

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -37,7 +37,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>${javadoc.version}</version>
+        <version>${version.plugin.javadoc}</version>
         <configuration>
           <skip>true</skip>
         </configuration>

--- a/boms/pom.xml
+++ b/boms/pom.xml
@@ -50,7 +50,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>${javadoc.version}</version>
+        <version>${version.plugin.javadoc}</version>
         <configuration>
           <skip>true</skip>
         </configuration>

--- a/boms/tomee-microprofile/pom.xml
+++ b/boms/tomee-microprofile/pom.xml
@@ -48,7 +48,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>2.13.4</version>
+      <version>2.14.0</version>
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>
@@ -59,7 +59,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.13.4</version>
+      <version>2.14.0</version>
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>
@@ -70,7 +70,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.13.4.2</version>
+      <version>2.14.0</version>
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>
@@ -81,7 +81,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-yaml</artifactId>
-      <version>2.13.4</version>
+      <version>2.14.0</version>
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>

--- a/boms/tomee-plume/pom.xml
+++ b/boms/tomee-plume/pom.xml
@@ -48,7 +48,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>2.13.4</version>
+      <version>2.14.0</version>
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>
@@ -59,7 +59,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.13.4</version>
+      <version>2.14.0</version>
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>
@@ -70,7 +70,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.13.4.2</version>
+      <version>2.14.0</version>
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>
@@ -81,7 +81,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-yaml</artifactId>
-      <version>2.13.4</version>
+      <version>2.14.0</version>
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>

--- a/boms/tomee-plus/pom.xml
+++ b/boms/tomee-plus/pom.xml
@@ -48,7 +48,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>2.13.4</version>
+      <version>2.14.0</version>
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>
@@ -59,7 +59,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.13.4</version>
+      <version>2.14.0</version>
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>
@@ -70,7 +70,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.13.4.2</version>
+      <version>2.14.0</version>
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>
@@ -81,7 +81,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-yaml</artifactId>
-      <version>2.13.4</version>
+      <version>2.14.0</version>
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>

--- a/container/openejb-core/pom.xml
+++ b/container/openejb-core/pom.xml
@@ -398,7 +398,7 @@
             <manifestEntries>
               <Automatic-Module-Name>${tomee.build.name}</Automatic-Module-Name>
               <Class-Path>openejb-loader-${project.version}.jar openejb-client-${project.version}.jar
-                xbean-finder-shaded-${xbeanVersion}.jar xbean-asm9-shaded-${xbeanVersion}.jar
+                xbean-finder-shaded-${version.xbean}.jar xbean-asm9-shaded-${version.xbean}.jar
               </Class-Path>
               <J2EE-DeploymentFactory-Implementation-Class>
                 org.apache.openejb.config.VmDeploymentFactory
@@ -439,7 +439,7 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
-      <version>${log4j2.version}</version>
+      <version>${version.log4j2}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -721,7 +721,7 @@
     <dependency>
       <groupId>org.apache.batchee</groupId>
       <artifactId>batchee-jbatch</artifactId>
-      <version>${batchee.version}</version>
+      <version>${version.batchee}</version>
       <scope>provided</scope>
       <classifier>jakarta</classifier>
       <exclusions>

--- a/deps/activemq-broker-shade/pom.xml
+++ b/deps/activemq-broker-shade/pom.xml
@@ -31,7 +31,7 @@
     <dependency>
       <groupId>org.apache.activemq</groupId>
       <artifactId>activemq-broker</artifactId>
-      <version>${org.apache.activemq.version}</version>
+      <version>${version.activemq}</version>
       <exclusions>
         <exclusion>
           <groupId>org.apache.activemq</groupId>

--- a/deps/activemq-client-shade/pom.xml
+++ b/deps/activemq-client-shade/pom.xml
@@ -31,7 +31,7 @@
     <dependency>
       <groupId>org.apache.activemq</groupId>
       <artifactId>activemq-client</artifactId>
-      <version>${org.apache.activemq.version}</version>
+      <version>${version.activemq}</version>
       <exclusions>
         <exclusion>
           <groupId>org.apache.geronimo.specs</groupId>

--- a/deps/activemq-kahadb-store-shade/pom.xml
+++ b/deps/activemq-kahadb-store-shade/pom.xml
@@ -31,7 +31,7 @@
     <dependency>
       <groupId>org.apache.activemq</groupId>
       <artifactId>activemq-kahadb-store</artifactId>
-      <version>${org.apache.activemq.version}</version>
+      <version>${version.activemq}</version>
       <exclusions>
         <exclusion>
           <groupId>org.apache.activemq</groupId>

--- a/deps/activemq-ra-shade/pom.xml
+++ b/deps/activemq-ra-shade/pom.xml
@@ -31,7 +31,7 @@
     <dependency>
       <groupId>org.apache.activemq</groupId>
       <artifactId>activemq-ra</artifactId>
-      <version>${org.apache.activemq.version}</version>
+      <version>${version.activemq}</version>
       <exclusions>
         <exclusion>
           <groupId>org.apache.activemq</groupId>

--- a/deps/commons-dbcp2-shade/pom.xml
+++ b/deps/commons-dbcp2-shade/pom.xml
@@ -31,7 +31,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-dbcp2</artifactId>
-      <version>${commons-dbcp.version}</version>
+      <version>${version.commons-dbcp2}</version>
     </dependency>
   </dependencies>
 

--- a/deps/commons-fileupload-shade/pom.xml
+++ b/deps/commons-fileupload-shade/pom.xml
@@ -31,7 +31,7 @@
     <dependency>
       <groupId>commons-fileupload</groupId>
       <artifactId>commons-fileupload</artifactId>
-      <version>${commons-fileupload.version}</version>
+      <version>${version.commons-fileupload}</version>
     </dependency>
   </dependencies>
 

--- a/deps/cxf-rt-rs-mp-client-shade/pom.xml
+++ b/deps/cxf-rt-rs-mp-client-shade/pom.xml
@@ -39,7 +39,7 @@
     <dependency>
       <groupId>org.apache.cxf</groupId>
       <artifactId>cxf-rt-rs-mp-client</artifactId>
-      <version>${cxf.version}</version>
+      <version>${version.cxf}</version>
       <exclusions>
         <exclusion>
           <groupId>org.apache.cxf</groupId>
@@ -65,7 +65,7 @@
     <dependency>
       <groupId>org.eclipse.microprofile.rest.client</groupId>
       <artifactId>microprofile-rest-client-api</artifactId>
-      <version>${microprofile.rest-client.version}</version>
+      <version>${version.microprofile.rest-client}</version>
     </dependency>
 
   </dependencies>

--- a/deps/cxf-shade/pom.xml
+++ b/deps/cxf-shade/pom.xml
@@ -39,22 +39,22 @@
     <dependency>
       <groupId>org.apache.cxf</groupId>
       <artifactId>cxf-core</artifactId>
-      <version>${cxf.version}</version>
+      <version>${version.cxf}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.cxf</groupId>
       <artifactId>cxf-rt-databinding-jaxb</artifactId>
-      <version>${cxf.version}</version>
+      <version>${version.cxf}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.cxf</groupId>
       <artifactId>cxf-rt-frontend-jaxrs</artifactId>
-      <version>${cxf.version}</version>
+      <version>${version.cxf}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.cxf</groupId>
       <artifactId>cxf-rt-frontend-jaxws</artifactId>
-      <version>${cxf.version}</version>
+      <version>${version.cxf}</version>
       <exclusions>
         <exclusion>
           <groupId>org.ow2.asm</groupId>
@@ -73,54 +73,54 @@
     <dependency>
       <groupId>org.apache.cxf</groupId>
       <artifactId>cxf-rt-management</artifactId>
-      <version>${cxf.version}</version>
+      <version>${version.cxf}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.cxf</groupId>
       <artifactId>cxf-rt-rs-client</artifactId>
-      <version>${cxf.version}</version>
+      <version>${version.cxf}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.cxf</groupId>
       <artifactId>cxf-rt-rs-extension-providers</artifactId>
-      <version>${cxf.version}</version>
+      <version>${version.cxf}</version>
     </dependency>
     <!--
     <dependency>
       <groupId>org.apache.cxf</groupId>
       <artifactId>cxf-rt-rs-extension-search</artifactId>
-      <version>${cxf.version}</version>
+      <version>${version.cxf}</version>
     </dependency>
     -->
     <dependency>
       <groupId>org.apache.cxf</groupId>
       <artifactId>cxf-rt-rs-security-cors</artifactId>
-      <version>${cxf.version}</version>
+      <version>${version.cxf}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.cxf</groupId>
       <artifactId>cxf-rt-rs-security-oauth2</artifactId>
-      <version>${cxf.version}</version>
+      <version>${version.cxf}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.cxf</groupId>
       <artifactId>cxf-rt-rs-service-description</artifactId>
-      <version>${cxf.version}</version>
+      <version>${version.cxf}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.cxf</groupId>
       <artifactId>cxf-rt-rs-sse</artifactId>
-      <version>${cxf.version}</version>
+      <version>${version.cxf}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.cxf</groupId>
       <artifactId>cxf-rt-transports-http</artifactId>
-      <version>${cxf.version}</version>
+      <version>${version.cxf}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.cxf</groupId>
       <artifactId>cxf-rt-ws-security</artifactId>
-      <version>${cxf.version}</version>
+      <version>${version.cxf}</version>
       <exclusions>
         <!-- Exclude some weird transient dependency to jaxb-runtime from ehcache -->
         <exclusion>
@@ -132,7 +132,7 @@
     <dependency>
       <groupId>org.apache.cxf</groupId>
       <artifactId>cxf-rt-wsdl</artifactId>
-      <version>${cxf.version}</version>
+      <version>${version.cxf}</version>
     </dependency>
 
     <!-- add transitive dependencies so including this is equivalent to including regular deps -->

--- a/deps/pom.xml
+++ b/deps/pom.xml
@@ -44,7 +44,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>${javadoc.version}</version>
+        <version>${version.plugin.javadoc}</version>
         <configuration>
           <skip>true</skip>
         </configuration>

--- a/examples/concurrency-utils/pom.xml
+++ b/examples/concurrency-utils/pom.xml
@@ -25,7 +25,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <jakartaee-api.version>9.1-M2</jakartaee-api.version>
-    <junit.version>4.13.2</junit.version>
+    <version.junit>4.13.2</version.junit>
   </properties>
   <dependencies>
     <dependency>
@@ -38,7 +38,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>${junit.version}</version>
+      <version>${version.junit}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/examples/connector-ear/pom.xml
+++ b/examples/connector-ear/pom.xml
@@ -22,7 +22,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <tomee.version>9.0.0-M9-SNAPSHOT</tomee.version>
     <version.shrinkwrap.resolver>2.1.0</version.shrinkwrap.resolver>
-    <surefire.version>2.21.0</surefire.version>
+    <version.plugin.surefire>2.21.0</version.plugin.surefire>
   </properties>
   <repositories>
     <repository>
@@ -73,7 +73,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>${surefire.version}</version>
+        <version>${version.plugin.surefire}</version>
         <configuration>
           <systemProperties>
             <property>

--- a/examples/jaxrs-json-provider-jettison/pom.xml
+++ b/examples/jaxrs-json-provider-jettison/pom.xml
@@ -24,15 +24,15 @@
   <packaging>war</packaging>
   <name>TomEE :: Examples :: JAXRS JSON Provider with Jettison </name>
   <properties>
-    <version.jakartaee-api>9.1-M2</version.jakartaee-api>
+    <version.tomee.jakartaee-api>9.1-M2</version.tomee.jakartaee-api>
     <version.arquillian.bom>1.7.0.Alpha10</version.arquillian.bom>
-    <junit.version>4.13.2</junit.version>
+    <version.junit>4.13.2</version.junit>
   </properties>
   <dependencies>
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>jakartaee-api</artifactId>
-      <version>${version.jakartaee-api}</version>
+      <version>${version.tomee.jakartaee-api}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -45,7 +45,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>${junit.version}</version>
+      <version>${version.junit}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/examples/jsonb-configuration/pom.xml
+++ b/examples/jsonb-configuration/pom.xml
@@ -23,14 +23,14 @@
   <packaging>war</packaging>
   <name>TomEE :: Examples :: Microprofile JSONB Configuration</name>
   <properties>
-    <version.jakartaee-api>9.1-M2</version.jakartaee-api>
+    <version.tomee.jakartaee-api>9.1-M2</version.tomee.jakartaee-api>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
   <dependencies>
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>jakartaee-api</artifactId>
-      <version>${version.jakartaee-api}</version>
+      <version>${version.tomee.jakartaee-api}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/examples/jsonb-custom-serializer/pom.xml
+++ b/examples/jsonb-custom-serializer/pom.xml
@@ -23,14 +23,14 @@
   <packaging>war</packaging>
   <name>TomEE :: Examples :: Microprofile JSONB Custom Serializer/Deserializer</name>
   <properties>
-    <version.jakartaee-api>9.1-M2</version.jakartaee-api>
+    <version.tomee.jakartaee-api>9.1-M2</version.tomee.jakartaee-api>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
   <dependencies>
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>jakartaee-api</artifactId>
-      <version>${version.jakartaee-api}</version>
+      <version>${version.tomee.jakartaee-api}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/examples/junit5-arquillian-multiple-tomee/pom.xml
+++ b/examples/junit5-arquillian-multiple-tomee/pom.xml
@@ -26,7 +26,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <tomee.version>9.0.0-M9-SNAPSHOT</tomee.version>
-        <junit.jupiter.version>5.8.2</junit.jupiter.version>
+        <version.junit.jupiter>5.8.2</version.junit.jupiter>
 
         <!-- version >= 1.7.0.Alpha5 is required for JUnit5 -->
         <arquillian.version>1.7.0.Alpha10</arquillian.version>
@@ -78,13 +78,13 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>${junit.jupiter.version}</version>
+            <version>${version.junit.jupiter}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>${junit.jupiter.version}</version>
+            <version>${version.junit.jupiter}</version>
             <scope>test</scope>
         </dependency>
         <!--

--- a/examples/junit5-arquillian-simple-websockets/pom.xml
+++ b/examples/junit5-arquillian-simple-websockets/pom.xml
@@ -28,7 +28,7 @@
         <tomee.version>9.0.0-M9-SNAPSHOT</tomee.version>
         <tomcat.version>10.0.16</tomcat.version>
 
-        <junit.jupiter.version>5.8.2</junit.jupiter.version>
+        <version.junit.jupiter>5.8.2</version.junit.jupiter>
         <!-- version >= 1.7.0.Alpha5 is required for JUnit5 -->
         <arquillian.version>1.7.0.Alpha10</arquillian.version>
 
@@ -75,13 +75,13 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>${junit.jupiter.version}</version>
+            <version>${version.junit.jupiter}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>${junit.jupiter.version}</version>
+            <version>${version.junit.jupiter}</version>
             <scope>test</scope>
         </dependency>
         <!--

--- a/examples/mp-config-example/pom.xml
+++ b/examples/mp-config-example/pom.xml
@@ -23,8 +23,8 @@
   <packaging>war</packaging>
   <name>TomEE :: Examples :: MicroProfile Config</name>
   <properties>
-    <version.jakartaee-api>9.1-M2</version.jakartaee-api>
-    <microprofile.config.version>3.0.1</microprofile.config.version>
+    <version.tomee.jakartaee-api>9.1-M2</version.tomee.jakartaee-api>
+    <version.microprofile.config>3.0.1</version.microprofile.config>
     <tomee.version>9.0.0-M9-SNAPSHOT</tomee.version>
     <version.arquillian>1.7.0.Alpha10</version.arquillian>
   </properties>
@@ -32,13 +32,13 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>jakartaee-api</artifactId>
-      <version>${version.jakartaee-api}</version>
+      <version>${version.tomee.jakartaee-api}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.microprofile.config</groupId>
       <artifactId>microprofile-config-api</artifactId>
-      <version>${microprofile.config.version}</version>
+      <version>${version.microprofile.config}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/examples/mp-config-source-database/pom.xml
+++ b/examples/mp-config-source-database/pom.xml
@@ -23,7 +23,7 @@
   <packaging>war</packaging>
   <name>TomEE :: Examples :: MicroProfile Config Source Database</name>
   <properties>
-    <version.jakartaee-api>9.1-M2</version.jakartaee-api>
+    <version.tomee.jakartaee-api>9.1-M2</version.tomee.jakartaee-api>
     <version.microprofile>5.0</version.microprofile>
     <version.arquillian>1.7.0.Alpha10</version.arquillian>
     <tomee.version>9.0.0-M9-SNAPSHOT</tomee.version>
@@ -32,7 +32,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>jakartaee-api</artifactId>
-      <version>${version.jakartaee-api}</version>
+      <version>${version.tomee.jakartaee-api}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/examples/mp-custom-healthcheck/pom.xml
+++ b/examples/mp-custom-healthcheck/pom.xml
@@ -28,7 +28,7 @@
     <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>
     <maven-war-plugin.version>3.1.0</maven-war-plugin.version>
     <jakartaee-api.version>9.1-M2</jakartaee-api.version>
-    <junit.version>4.13.2</junit.version>
+    <version.junit>4.13.2</version.junit>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <tomee.version>9.0.0-M9-SNAPSHOT</tomee.version>
@@ -55,7 +55,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>${junit.version}</version>
+      <version>${version.junit}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/examples/mp-faulttolerance-fallback/pom.xml
+++ b/examples/mp-faulttolerance-fallback/pom.xml
@@ -26,7 +26,7 @@
     <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>
     <maven-war-plugin.version>3.1.0</maven-war-plugin.version>
     <jakartaee-api.version>9.1-M2</jakartaee-api.version>
-    <junit.version>4.13.2</junit.version>
+    <version.junit>4.13.2</version.junit>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <tomee.version>9.0.0-M9-SNAPSHOT</tomee.version>
@@ -47,7 +47,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>${junit.version}</version>
+      <version>${version.junit}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/examples/mp-faulttolerance-retry/pom.xml
+++ b/examples/mp-faulttolerance-retry/pom.xml
@@ -28,7 +28,7 @@
     <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>
     <maven-war-plugin.version>3.1.0</maven-war-plugin.version>
     <jakartaee-api.version>9.1-M2</jakartaee-api.version>
-    <junit.version>4.13.2</junit.version>
+    <version.junit>4.13.2</version.junit>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <tomee.version>9.0.0-M9-SNAPSHOT</tomee.version>
@@ -43,7 +43,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>${junit.version}</version>
+      <version>${version.junit}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/examples/mp-faulttolerance-timeout/pom.xml
+++ b/examples/mp-faulttolerance-timeout/pom.xml
@@ -29,7 +29,7 @@
     <maven-war-plugin.version>3.1.0</maven-war-plugin.version>
     <tomee.version>9.0.0-M9-SNAPSHOT</tomee.version>
     <jakartaee-api.version>9.1-M2</jakartaee-api.version>
-    <junit.version>4.13.2</junit.version>
+    <version.junit>4.13.2</version.junit>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
   </properties>
@@ -49,7 +49,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>${junit.version}</version>
+      <version>${version.junit}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/examples/mp-jsonb-configuration/pom.xml
+++ b/examples/mp-jsonb-configuration/pom.xml
@@ -23,7 +23,7 @@
   <packaging>war</packaging>
   <name>TomEE :: Examples :: Microprofile JSONB Configuration</name>
   <properties>
-    <version.jakartaee-api>9.1-M2</version.jakartaee-api>
+    <version.tomee.jakartaee-api>9.1-M2</version.tomee.jakartaee-api>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <tomee.version>9.0.0-M9-SNAPSHOT</tomee.version>
   </properties>
@@ -31,7 +31,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>jakartaee-api</artifactId>
-      <version>${version.jakartaee-api}</version>
+      <version>${version.tomee.jakartaee-api}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/examples/mp-jwt-bean-validation-strongly-typed/pom.xml
+++ b/examples/mp-jwt-bean-validation-strongly-typed/pom.xml
@@ -25,7 +25,7 @@
   <name>TomEE :: Examples :: MicroProfile JWT Bean Validation, Strongly-typed Annotations</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <version.jakartaee-api>9.1-M2</version.jakartaee-api>
+    <version.tomee.jakartaee-api>9.1-M2</version.tomee.jakartaee-api>
     <tomee.version>9.0.0-M9-SNAPSHOT</tomee.version>
     <version.shrinkwrap.resolver>2.0.0</version.shrinkwrap.resolver>
     <mp-jwt.version>1.1</mp-jwt.version>
@@ -97,7 +97,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>jakartaee-api</artifactId>
-      <version>${version.jakartaee-api}</version>
+      <version>${version.tomee.jakartaee-api}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/examples/mp-jwt-bean-validation/pom.xml
+++ b/examples/mp-jwt-bean-validation/pom.xml
@@ -25,7 +25,7 @@
   <name>TomEE :: Examples :: MicroProfile JWT Bean Validation</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <version.jakartaee-api>9.1-M2</version.jakartaee-api>
+    <version.tomee.jakartaee-api>9.1-M2</version.tomee.jakartaee-api>
     <tomee.version>9.0.0-M9-SNAPSHOT</tomee.version>
     <version.shrinkwrap.resolver>2.0.0</version.shrinkwrap.resolver>
     <mp-jwt.version>1.1</mp-jwt.version>
@@ -97,7 +97,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>jakartaee-api</artifactId>
-      <version>${version.jakartaee-api}</version>
+      <version>${version.tomee.jakartaee-api}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/examples/mp-metrics-counted/pom.xml
+++ b/examples/mp-metrics-counted/pom.xml
@@ -24,10 +24,10 @@
   <packaging>war</packaging>
   <name>TomEE :: Examples :: Microprofile Metrics Counted</name>
   <properties>
-    <version.jakartaee-api>9.1-M2</version.jakartaee-api>
-    <microprofile.metrics.version>3.0.1</microprofile.metrics.version>
+    <version.tomee.jakartaee-api>9.1-M2</version.tomee.jakartaee-api>
+    <version.microprofile.metrics>3.0.1</version.microprofile.metrics>
     <version.arquillian.bom>1.7.0.Alpha10</version.arquillian.bom>
-    <junit.version>4.13.2</junit.version>
+    <version.junit>4.13.2</version.junit>
     <docker.image.name>tomee/${project.artifactId}</docker.image.name>
     <docker.file.name>Dockerfile</docker.file.name>
     <tomee.version>9.0.0-M9-SNAPSHOT</tomee.version>
@@ -36,19 +36,19 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>jakartaee-api</artifactId>
-      <version>${version.jakartaee-api}</version>
+      <version>${version.tomee.jakartaee-api}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.microprofile.metrics</groupId>
       <artifactId>microprofile-metrics-api</artifactId>
-      <version>${microprofile.metrics.version}</version>
+      <version>${version.microprofile.metrics}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>${junit.version}</version>
+      <version>${version.junit}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/examples/mp-metrics-gauge/pom.xml
+++ b/examples/mp-metrics-gauge/pom.xml
@@ -23,23 +23,23 @@
   <packaging>war</packaging>
   <name>TomEE :: Examples :: MicroProfile Metrics Gauge</name>
   <properties>
-    <version.jakartaee-api>9.1-M2</version.jakartaee-api>
-    <microprofile.metrics.version>3.0.1</microprofile.metrics.version>
+    <version.tomee.jakartaee-api>9.1-M2</version.tomee.jakartaee-api>
+    <version.microprofile.metrics>3.0.1</version.microprofile.metrics>
     <version.arquillian.bom>1.7.0.Alpha10</version.arquillian.bom>
-    <junit.version>4.13.2</junit.version>
+    <version.junit>4.13.2</version.junit>
     <tomee.version>9.0.0-M9-SNAPSHOT</tomee.version>
   </properties>
   <dependencies>
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>jakartaee-api</artifactId>
-      <version>${version.jakartaee-api}</version>
+      <version>${version.tomee.jakartaee-api}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.microprofile.metrics</groupId>
       <artifactId>microprofile-metrics-api</artifactId>
-      <version>${microprofile.metrics.version}</version>
+      <version>${version.microprofile.metrics}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -51,7 +51,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>${junit.version}</version>
+      <version>${version.junit}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/examples/mp-metrics-histogram/pom.xml
+++ b/examples/mp-metrics-histogram/pom.xml
@@ -24,29 +24,29 @@
   <packaging>war</packaging>
   <name>TomEE :: Examples :: Microprofile Metrics Histogram</name>
   <properties>
-    <version.jakartaee-api>9.1-M2</version.jakartaee-api>
-    <microprofile.metrics.version>3.0.1</microprofile.metrics.version>
+    <version.tomee.jakartaee-api>9.1-M2</version.tomee.jakartaee-api>
+    <version.microprofile.metrics>3.0.1</version.microprofile.metrics>
     <version.arquillian.bom>1.7.0.Alpha10</version.arquillian.bom>
-    <junit.version>4.13.2</junit.version>
+    <version.junit>4.13.2</version.junit>
     <tomee.version>9.0.0-M9-SNAPSHOT</tomee.version>
   </properties>
   <dependencies>
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>jakartaee-api</artifactId>
-      <version>${version.jakartaee-api}</version>
+      <version>${version.tomee.jakartaee-api}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.microprofile.metrics</groupId>
       <artifactId>microprofile-metrics-api</artifactId>
-      <version>${microprofile.metrics.version}</version>
+      <version>${version.microprofile.metrics}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>${junit.version}</version>
+      <version>${version.junit}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/examples/mp-metrics-metered/pom.xml
+++ b/examples/mp-metrics-metered/pom.xml
@@ -23,23 +23,23 @@
   <name>TomEE :: Examples :: MicroProfile Metrics Metered</name>
   <packaging>war</packaging>
   <properties>
-    <version.jakartaee-api>9.1-M2</version.jakartaee-api>
-    <microprofile.metrics.version>3.0.1</microprofile.metrics.version>
+    <version.tomee.jakartaee-api>9.1-M2</version.tomee.jakartaee-api>
+    <version.microprofile.metrics>3.0.1</version.microprofile.metrics>
     <version.arquillian.bom>1.7.0.Alpha10</version.arquillian.bom>
-    <junit.version>4.13.2</junit.version>
+    <version.junit>4.13.2</version.junit>
     <tomee.version>9.0.0-M9-SNAPSHOT</tomee.version>
   </properties>
   <dependencies>
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>jakartaee-api</artifactId>
-      <version>${version.jakartaee-api}</version>
+      <version>${version.tomee.jakartaee-api}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.microprofile.metrics</groupId>
       <artifactId>microprofile-metrics-api</artifactId>
-      <version>${microprofile.metrics.version}</version>
+      <version>${version.microprofile.metrics}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/examples/mp-metrics-timed/pom.xml
+++ b/examples/mp-metrics-timed/pom.xml
@@ -23,29 +23,29 @@
   <packaging>war</packaging>
   <name>TomEE :: Examples :: Microprofile Metrics Timed</name>
   <properties>
-    <version.jakartaee-api>9.1-M2</version.jakartaee-api>
-    <microprofile.metrics.version>3.0.1</microprofile.metrics.version>
+    <version.tomee.jakartaee-api>9.1-M2</version.tomee.jakartaee-api>
+    <version.microprofile.metrics>3.0.1</version.microprofile.metrics>
     <version.arquillian.bom>1.7.0.Alpha10</version.arquillian.bom>
-    <junit.version>4.13.2</junit.version>
+    <version.junit>4.13.2</version.junit>
     <tomee.version>9.0.0-M9-SNAPSHOT</tomee.version>
   </properties>
   <dependencies>
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>jakartaee-api</artifactId>
-      <version>${version.jakartaee-api}</version>
+      <version>${version.tomee.jakartaee-api}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.microprofile.metrics</groupId>
       <artifactId>microprofile-metrics-api</artifactId>
-      <version>${microprofile.metrics.version}</version>
+      <version>${version.microprofile.metrics}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>${junit.version}</version>
+      <version>${version.junit}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/examples/mp-opentracing-traced/pom.xml
+++ b/examples/mp-opentracing-traced/pom.xml
@@ -24,7 +24,7 @@
   <version>9.0.0-M9-SNAPSHOT</version>
   <packaging>war</packaging>
   <properties>
-    <version.jakartaee-api>9.1-M2</version.jakartaee-api>
+    <version.tomee.jakartaee-api>9.1-M2</version.tomee.jakartaee-api>
     <tomee.version>9.0.0-M9-SNAPSHOT</tomee.version>
     <version.arquillian.bom>1.7.0.Alpha10</version.arquillian.bom>
   </properties>
@@ -32,7 +32,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>jakartaee-api</artifactId>
-      <version>${version.jakartaee-api}</version>
+      <version>${version.tomee.jakartaee-api}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/examples/mp-rest-client/README.adoc
+++ b/examples/mp-rest-client/README.adoc
@@ -23,7 +23,7 @@ To use MicroProfile Rest Client you need 3 changes in your project:
  <dependency>
      <groupId>org.eclipse.microprofile.rest.client</groupId>
      <artifactId>microprofile-rest-client-api</artifactId>
-     <version>${microprofile.rest-client.version}</version>
+     <version>${version.microprofile.rest-client}</version>
      <scope>provided</scope>
  </dependency>
 ----

--- a/examples/mp-rest-client/README_es.adoc
+++ b/examples/mp-rest-client/README_es.adoc
@@ -22,7 +22,7 @@ Para utilizar el Cliente Rest de MicroProfile se requieren 3 cambios en su proye
  <dependency>
      <groupId>org.eclipse.microprofile.rest.client</groupId>
      <artifactId>microprofile-rest-client-api</artifactId>
-     <version>${microprofile.rest-client.version}</version>
+     <version>${version.microprofile.rest-client}</version>
      <scope>provided</scope>
  </dependency>
 ----

--- a/examples/mp-rest-client/README_pt.adoc
+++ b/examples/mp-rest-client/README_pt.adoc
@@ -22,7 +22,7 @@ Para usar o MicroProfile Rest Client, são necessárias 3 alterações no seu pr
  <dependency>
      <groupId>org.eclipse.microprofile.rest.client</groupId>
      <artifactId>microprofile-rest-client-api</artifactId>
-     <version>${microprofile.rest-client.version}</version>
+     <version>${version.microprofile.rest-client}</version>
      <scope>provided</scope>
  </dependency>
 ----

--- a/examples/mp-rest-client/pom.xml
+++ b/examples/mp-rest-client/pom.xml
@@ -24,29 +24,29 @@
   <packaging>war</packaging>
   <name>TomEE :: Examples :: Microprofile REST Client</name>
   <properties>
-    <microprofile.rest-client.version>3.0</microprofile.rest-client.version>
-    <version.jakartaee-api>9.1-M2</version.jakartaee-api>
+    <version.microprofile.rest-client>3.0</version.microprofile.rest-client>
+    <version.tomee.jakartaee-api>9.1-M2</version.tomee.jakartaee-api>
     <version.arquillian.bom>1.7.0.Alpha10</version.arquillian.bom>
-    <junit.version>4.13.2</junit.version>
+    <version.junit>4.13.2</version.junit>
     <tomee.version>9.0.0-M9-SNAPSHOT</tomee.version>
   </properties>
   <dependencies>
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>jakartaee-api</artifactId>
-      <version>${version.jakartaee-api}</version>
+      <version>${version.tomee.jakartaee-api}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.microprofile.rest.client</groupId>
       <artifactId>microprofile-rest-client-api</artifactId>
-      <version>${microprofile.rest-client.version}</version>
+      <version>${version.microprofile.rest-client}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>${junit.version}</version>
+      <version>${version.junit}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/examples/mp-rest-jwt-principal/pom.xml
+++ b/examples/mp-rest-jwt-principal/pom.xml
@@ -26,7 +26,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <tomee.version>9.0.0-M9-SNAPSHOT</tomee.version>
-    <junit.version>4.23</junit.version>
+    <version.junit>4.23</version.junit>
     <arquillian-bom.version>1.7.0.Alpha10</arquillian-bom.version>
   </properties>
   <build>
@@ -93,7 +93,7 @@
     <dependency>
       <groupId>com.nimbusds</groupId>
       <artifactId>nimbus-jose-jwt</artifactId>
-      <version>${junit.version}</version>
+      <version>${version.junit}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/examples/mp-rest-jwt-public-key/pom.xml
+++ b/examples/mp-rest-jwt-public-key/pom.xml
@@ -28,7 +28,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <tomee.version>9.0.0-M9-SNAPSHOT</tomee.version>
-    <version.jakartaee-api>9.1-M2</version.jakartaee-api>
+    <version.tomee.jakartaee-api>9.1-M2</version.tomee.jakartaee-api>
     <version.shrinkwrap.resolver>2.0.0</version.shrinkwrap.resolver>
     <mp-jwt.version>1.1</mp-jwt.version>
   </properties>

--- a/examples/singleton-startup-ordering/pom.xml
+++ b/examples/singleton-startup-ordering/pom.xml
@@ -24,21 +24,21 @@
   <packaging>war</packaging>
   <name>TomEE :: Examples ::  Singleton startup ordering</name>
   <properties>
-    <version.jakartaee-api>9.1-M2</version.jakartaee-api>
+    <version.tomee.jakartaee-api>9.1-M2</version.tomee.jakartaee-api>
     <version.arquillian.bom>1.7.0.Alpha10</version.arquillian.bom>
-    <junit.version>4.13.2</junit.version>
+    <version.junit>4.13.2</version.junit>
   </properties>
   <dependencies>
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>jakartaee-api</artifactId>
-      <version>${version.jakartaee-api}</version>
+      <version>${version.tomee.jakartaee-api}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>${junit.version}</version>
+      <version>${version.junit}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/examples/websocket-tls-basic-auth/pom.xml
+++ b/examples/websocket-tls-basic-auth/pom.xml
@@ -29,7 +29,7 @@
     <jakarta.websocket-api.version>2.0.0</jakarta.websocket-api.version>
     <tomee.classifier>webprofile</tomee.classifier>
     <tomcat.version>10.0.27</tomcat.version>
-    <junit.version>4.13.2</junit.version>
+    <version.junit>4.13.2</version.junit>
   </properties>
   <dependencies>
     <dependency>
@@ -60,7 +60,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>${junit.version}</version>
+      <version>${version.junit}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/itests/failover-ejb/pom.xml
+++ b/itests/failover-ejb/pom.xml
@@ -38,7 +38,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>jakartaee-api</artifactId>
-      <version>${version.jakartaee-api}</version>
+      <version>${version.tomee.jakartaee-api}</version>
       <scope>provided</scope>
       <!-- does not inherit from exclusion and version of parent -->
       <exclusions>

--- a/itests/microprofile-jwt-itests/pom.xml
+++ b/itests/microprofile-jwt-itests/pom.xml
@@ -87,7 +87,7 @@
     <dependency>
       <groupId>org.eclipse.microprofile.jwt</groupId>
       <artifactId>microprofile-jwt-auth-api</artifactId>
-      <version>${microprofile.jwt.version}</version>
+      <version>${version.microprofile.jwt}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/itests/openejb-itests-beans/pom.xml
+++ b/itests/openejb-itests-beans/pom.xml
@@ -67,7 +67,7 @@
           <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>jakartaee-api</artifactId>
-            <version>${version.jakartaee-api}</version>
+            <version>${version.tomee.jakartaee-api}</version>
           </dependency>
           <dependency>
             <groupId>net.sourceforge.serp</groupId>

--- a/itests/pom.xml
+++ b/itests/pom.xml
@@ -56,7 +56,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>${javadoc.version}</version>
+        <version>${version.plugin.javadoc}</version>
         <configuration>
           <skip>true</skip>
         </configuration>

--- a/maven/jarstxt-maven-plugin/pom.xml
+++ b/maven/jarstxt-maven-plugin/pom.xml
@@ -50,7 +50,7 @@ Licensed to the Apache Software Foundation (ASF) under one or more
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>${commons-lang3.version}</version>
+      <version>${version.commons-lang3}</version>
     </dependency>
   </dependencies>
 

--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -30,7 +30,7 @@
   <name>TomEE :: Maven Plugins</name>
 
   <properties>
-    <maven.version>2.2.1</maven.version>
+    <version.maven>2.2.1</version.maven>
   </properties>
 
   <modules>
@@ -58,27 +58,27 @@
       <dependency>
         <groupId>org.apache.maven</groupId>
         <artifactId>maven-plugin-api</artifactId>
-        <version>${maven.version}</version>
+        <version>${version.maven}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.maven</groupId>
         <artifactId>maven-project</artifactId>
-        <version>${maven.version}</version>
+        <version>${version.maven}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.maven</groupId>
         <artifactId>maven-core</artifactId>
-        <version>${maven.version}</version>
+        <version>${version.maven}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.maven</groupId>
         <artifactId>maven-artifact</artifactId>
-        <version>${maven.version}</version>
+        <version>${version.maven}</version>
       </dependency>
       <dependency>
         <groupId>org.sonatype.aether</groupId>
         <artifactId>aether-api</artifactId>
-        <version>${aether.version}</version>
+        <version>${version.aether}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.tomee</groupId>

--- a/maven/tomee-webapp-archetype/pom.xml
+++ b/maven/tomee-webapp-archetype/pom.xml
@@ -43,7 +43,7 @@ Licensed to the Apache Software Foundation (ASF) under one or more
                 <replace file="${project.build.directory}/classes/archetype-resources/pom.xml" token="[TOMEE]" value="${project.version}" />
                 <replace file="${project.build.directory}/classes/archetype-resources/pom.xml" token="[OPENEJB]" value="${project.version}" />
                 <replace file="${project.build.directory}/classes/archetype-resources/pom.xml" token="[OPENJPA]" value="${version.openjpa}" />
-                <replace file="${project.build.directory}/classes/archetype-resources/pom.xml" token="[JAVAEE]" value="${version.jakartaee-api}" />
+                <replace file="${project.build.directory}/classes/archetype-resources/pom.xml" token="[JAVAEE]" value="${version.tomee.jakartaee-api}" />
               </target>
             </configuration>
           </execution>

--- a/mp-jwt/pom.xml
+++ b/mp-jwt/pom.xml
@@ -34,19 +34,19 @@
     <dependency>
       <groupId>org.eclipse.microprofile.jwt</groupId>
       <artifactId>microprofile-jwt-auth-api</artifactId>
-      <version>${microprofile.jwt.version}</version>
+      <version>${version.microprofile.jwt}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.microprofile.config</groupId>
       <artifactId>microprofile-config-api</artifactId>
-      <version>${microprofile.config.version}</version>
+      <version>${version.microprofile.config}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>jakartaee-api</artifactId>
-      <version>${version.jakartaee-api}</version>
+      <version>${version.tomee.jakartaee-api}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -93,37 +93,13 @@
     <!-- allows release plugin to be overridden -->
     <arguments />
     <tomee.version>${project.version}</tomee.version>
-    <surefire.version>3.0.0-M7</surefire.version>
 
     <!-- for the default name of the module. Needs to be overridden -->
     <tomee.build.name>${project.groupId}.${project.artifactId}</tomee.build.name>
 
     <!-- To easily change the javaee api version -->
-    <version.jakartaee-api>9.1-M2</version.jakartaee-api>
+    <version.tomee.jakartaee-api>9.1-M2</version.tomee.jakartaee-api>
     <version.tomee-patch-plugin>0.9</version.tomee-patch-plugin>
-
-    <!--
-      JavaMail is both API and IMPL so we don't have them in the jakartaee-api uber jar.
-      We decided to add them here in the project so we can patch/update the 2 libraries without having
-      to update and release the jakartaee-api.jar. Different lifecycle.
-    -->
-    <geronimo-mail_2.1_spec.version>1.0.0-M1</geronimo-mail_2.1_spec.version>
-    <geronimo-mail_2.1_provider.version>1.0.0</geronimo-mail_2.1_provider.version>
-
-    <!-- Not yet included in EE APIs -->
-    <!-- todo needs to be updated at some point -->
-    <geronimo-jcache_1.0_spec.version>1.0-alpha-1</geronimo-jcache_1.0_spec.version>
-
-    <openwebbeans.version>2.0.27</openwebbeans.version>
-    <jcs.version>2.1</jcs.version>
-    <johnzon.version>1.2.19</johnzon.version>
-    <quartz-openejb-shade.version>2.2.4</quartz-openejb-shade.version>
-
-    <!-- Maven module versions -->
-    <maven-bundle-plugin.version>3.3.0</maven-bundle-plugin.version>
-
-    <!-- This is used by a manifest classpath entry -->
-    <xbeanVersion>4.22</xbeanVersion>
 
     <!-- OSGi bundles properties -->
     <openejb.bundle.activator />
@@ -139,136 +115,124 @@
     <openejb.osgi.dynamic.import>${openejb.osgi.dynamic.import.pkg}</openejb.osgi.dynamic.import>
     <openejb.osgi.symbolic.name>${project.groupId}.${project.artifactId}</openejb.osgi.symbolic.name>
 
-    <batchee.version>1.0.2</batchee.version>
-
+    <!-- arquillian related -->
     <version.arquillian>1.7.0.Alpha10</version.arquillian>
+    <version.arquillian.bom>1.1.13.Final</version.arquillian.bom>
     <version.arquillian-protocol-servlet-jakarta>1.7.0.Alpha10</version.arquillian-protocol-servlet-jakarta>
     <version.shrinkwrap.descriptor>2.0.0</version.shrinkwrap.descriptor>
+    <version.shrinkwrap.resolver.bom>3.1.4</version.shrinkwrap.resolver.bom>
     <version.shrinkwrap.shrinkwrap>1.2.6</version.shrinkwrap.shrinkwrap>
 
-    <tomcat.version>10.0.27</tomcat.version>
+    <version.quartz-openejb-shade>2.2.4</version.quartz-openejb-shade>
+    <version.axiom>1.3.0</version.axiom>
+    <version.xbean>4.22</version.xbean>
+    <version.groovy>2.4.12</version.groovy>
+    <version.ecj>4.6.1</version.ecj>
+    <version.jetty>11.0.8</version.jetty>
+    <version.ehcache>3.10.0</version.ehcache>
+    <version.junit>4.13.2</version.junit>
+    <version.junit.jupiter>5.8.2</version.junit.jupiter>
+    <version.osgi>4.2.0</version.osgi>
+    <version.aether>1.13.1</version.aether>
+    <version.xalan>2.7.2</version.xalan>
 
-    <cxf.version>3.5.0</cxf.version>
-    <ehcache.version>3.10.0</ehcache.version>
-    <wss4j.version>2.4.1</wss4j.version>
-    <!-- used by cxf for security (replay attack) -->
-    <jetty.version>11.0.8</jetty.version>
-    <pax-url.version>1.3.5</pax-url.version>
-    <aether.version>1.13.1</aether.version>
-    <maven.version>3.0.5</maven.version>
-    <wagon.version>2.2</wagon.version>
-    <plexus.version>1.5.5</plexus.version>
-    <plexus-utils.version>3.0.10</plexus-utils.version>
-
-    <!--
-      Old CXF versions were only compatible with 1.3.x. But JDK 9+ requires 1.4.x and higher
-      We used to have some weird exclusions to not run test, but we should try to upgrade to 1.4.x anyway
-    -->
-    <saaj-impl.version>2.0.1</saaj-impl.version>
-
-    <!--
-    - http://docs.codehaus.org/display/MAVENUSER/POM+Element+for+Source+File+Encoding
-    -->
+    <!-- Project encoding -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-    <!-- Apache Commons -->
-    <commons-beanutils.version>1.9.4</commons-beanutils.version>
-    <commons-cli.version>1.5.0</commons-cli.version>
-    <commons-logging.version>1.2</commons-logging.version>
-    <commons-logging-api.version>1.1</commons-logging-api.version>
-    <commons-dbcp.version>2.9.0</commons-dbcp.version>
-    <commons-pool.version>2.11.1</commons-pool.version>
-    <commons-collections.version>3.2.2</commons-collections.version>
-    <commons-codec.version>1.15</commons-codec.version>
-    <commons-fileupload.version>1.4</commons-fileupload.version>
-    <commons-discovery.version>0.5</commons-discovery.version>
-    <commons-lang3.version>3.12.0</commons-lang3.version>
-    <commons-io.version>2.11.0</commons-io.version>
-    <commons-net.version>3.8.0</commons-net.version>
-
-    <bval.version>2.0.6</bval.version>
-    <org.apache.activemq.version>5.16.5</org.apache.activemq.version>
-    <junit.version>4.13.2</junit.version>
-    <junit.jupiter.version>5.8.2</junit.jupiter.version>
-    <org.apache.axis2.version>1.4.1</org.apache.axis2.version>
-    <scannotation.version>1.0.2</scannotation.version>
-    <geronimo.connector.version>3.1.5</geronimo.connector.version>
-    <geronimo-osgi.version>1.1</geronimo-osgi.version>
-    <myfaces.version>3.0.2</myfaces.version>
-    <mojarra.version>3.0.2</mojarra.version>
-    <slf4j.version>1.7.36</slf4j.version>
-    <log4j.version>1.2.17</log4j.version>
-    <log4j2.version>2.19.0</log4j2.version>
-    <osgi.framework.version>4.2.0</osgi.framework.version>
-    <version.axiom>1.3.0</version.axiom>
-    <version.xalan>2.7.2</version.xalan>
-    <version.groovy>2.4.12</version.groovy>
-    <version.ecj>4.6.1</version.ecj>
-
-    <version.deltaspike>1.9.6</version.deltaspike>
-    <version.openjpa>3.2.2</version.openjpa>
-    <version.eclipselink>3.0.3</version.eclipselink>
-    <version.hibernate.orm>6.1.4.Final</version.hibernate.orm>
-    <version.hibernate.validator>7.0.5.Final</version.hibernate.validator>
-    <version.derby>10.14.2.0</version.derby>
-    <version.hsqldb>2.7.1</version.hsqldb>
-
-    <!-- arquillian related -->
-    <version.arquillian.bom>1.1.13.Final</version.arquillian.bom>
-    <version.shrinkwrap.resolver.bom>3.1.4</version.shrinkwrap.resolver.bom>
-
-    <!-- Micro Profile -->
-    <microprofile.version>5.0</microprofile.version>
-
-    <microprofile.config.version>3.0.2</microprofile.config.version>
-    <microprofile.config.tck.version>3.0.2</microprofile.config.tck.version>
-    <microprofile.config.impl.version>3.0.0</microprofile.config.impl.version>
-
-    <microprofile.jwt.version>2.0</microprofile.jwt.version>
-    <microprofile.jwt.tck.version>2.0</microprofile.jwt.tck.version>
-    <microprofile.jwt.impl.version>${project.version}</microprofile.jwt.impl.version>
-
-    <microprofile.fault-tolerance.version>4.0.2</microprofile.fault-tolerance.version>
-    <microprofile.fault-tolerance.tck.version>4.0.2</microprofile.fault-tolerance.tck.version>
-    <microprofile.fault-tolerance.impl.version>6.0.0</microprofile.fault-tolerance.impl.version>
-
-    <microprofile.health.version>4.0.1</microprofile.health.version>
-    <microprofile.health.tck.version>4.0.1</microprofile.health.tck.version>
-    <microprofile.health.impl.version>4.0.0</microprofile.health.impl.version>
-
-    <microprofile.metrics.version>4.0.1</microprofile.metrics.version>
-    <microprofile.metrics.tck.version>4.0.1</microprofile.metrics.tck.version>
-    <microprofile.metrics.impl.version>4.0.0</microprofile.metrics.impl.version>
-
-    <microprofile.rest-client.version>3.0.1</microprofile.rest-client.version>
-    <microprofile.rest-client.tck.version>3.0.1</microprofile.rest-client.tck.version>
-    <microprofile.rest-client.impl.version>${cxf.version}</microprofile.rest-client.impl.version>
-
-    <microprofile.openapi.version>3.0</microprofile.openapi.version>
-    <microprofile.openapi.tck.version>3.0</microprofile.openapi.tck.version>
-    <microprofile.openapi.impl.version>3.0.0</microprofile.openapi.impl.version>
-
-    <microprofile.opentracing.version>3.0</microprofile.opentracing.version>
-    <microprofile.opentracing.tck.version>3.0</microprofile.opentracing.tck.version>
-    <microprofile.opentracing.impl.version>3.0.0</microprofile.opentracing.impl.version>
-
-    <opentracing.api>0.33.0</opentracing.api>
-
-    <!-- Jackson required by OpenAPI Impl -->
-    <version.jackson>2.13.4</version.jackson>
-    <version.jackson.databind>2.13.4.2</version.jackson.databind>
-    <version.jackson.dataformat>2.13.4</version.jackson.dataformat>
-    <!-- required by Jackson dataformat yaml -->
-    <snakeyaml.version>1.33</snakeyaml.version>
-
-    <!-- Javadoc & Asciidoclet -->
-    <javadoc.version>3.3.2</javadoc.version>
-    <asciidoclet.version>1.5.0</asciidoclet.version>
-
+    <!-- Java SE version -->
+    <maven.compiler.release>11</maven.compiler.release>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
-    <maven.compiler.release>11</maven.compiler.release>
+
+    <!-- Plugins and Build -->
+    <version.maven>3.0.5</version.maven>
+    <version.plugin.bundle>3.3.0</version.plugin.bundle>
+    <version.plugin.javadoc>3.3.2</version.plugin.javadoc>
+    <version.asciidoclet>1.5.0</version.asciidoclet>
+    <version.plugin.surefire>3.0.0-M7</version.plugin.surefire>
+
+    <!-- Logging frameworks -->
+    <version.slf4j>1.7.36</version.slf4j>
+    <version.log4j>1.2.17</version.log4j>
+    <version.log4j2>2.19.0</version.log4j2>
+    <version.commons-logging>1.2</version.commons-logging>
+    <version.commons-logging-api>1.1</version.commons-logging-api>
+
+    <!-- Apache Commons -->
+    <version.commons-beanutils>1.9.4</version.commons-beanutils>
+    <version.commons-cli>1.5.0</version.commons-cli>
+    <version.commons-codec>1.15</version.commons-codec>
+    <version.commons-collections>3.2.2</version.commons-collections>
+    <version.commons-dbcp2>2.9.0</version.commons-dbcp2>
+    <version.commons-discovery>0.5</version.commons-discovery>
+    <version.commons-fileupload>1.4</version.commons-fileupload>
+    <version.commons-io>2.11.0</version.commons-io>
+    <version.commons-jcs-cache>2.1</version.commons-jcs-cache>
+    <version.commons-lang3>3.12.0</version.commons-lang3>
+    <version.commons-net>3.8.0</version.commons-net>
+    <version.commons-pool2>2.11.1</version.commons-pool2>
+
+    <!-- Micro Profile API -->
+    <version.microprofile>5.0</version.microprofile>
+    <version.microprofile.config>3.0.2</version.microprofile.config>
+    <version.microprofile.fault-tolerance>4.0.2</version.microprofile.fault-tolerance>
+    <version.microprofile.health>4.0.1</version.microprofile.health>
+    <version.microprofile.jwt>2.0</version.microprofile.jwt>
+    <version.microprofile.metrics>4.0.1</version.microprofile.metrics>
+    <version.microprofile.openapi>3.0</version.microprofile.openapi>
+    <version.microprofile.opentracing>3.0</version.microprofile.opentracing>
+    <version.microprofile.rest-client>3.0.1</version.microprofile.rest-client>
+
+    <version.io.opentracing>0.33.0</version.io.opentracing>
+
+    <!-- Micro Profile Impl -->
+    <version.microprofile.impl.config>3.0.0</version.microprofile.impl.config>
+    <version.microprofile.impl.fault-tolerance>6.0.0</version.microprofile.impl.fault-tolerance>
+    <version.microprofile.impl.health>4.0.0</version.microprofile.impl.health>
+    <version.microprofile.impl.metrics>4.0.0</version.microprofile.impl.metrics>
+    <version.microprofile.impl.openapi>3.0.0</version.microprofile.impl.openapi>
+    <version.microprofile.impl.opentracing>3.0.0</version.microprofile.impl.opentracing>
+
+    <!-- Jackson and snakeyaml required by OpenAPI Impl -->
+    <version.jackson>2.14.0</version.jackson>
+    <version.snakeyaml>1.33</version.snakeyaml>
+
+    <!-- Jakarta EE API -->
+    <version.geronimo-mail_2.1_spec>1.0.0-M1</version.geronimo-mail_2.1_spec>
+    <!-- API not in EE -->
+    <version.geronimo-jcache_1.0_spec>1.0-alpha-1</version.geronimo-jcache_1.0_spec>
+
+    <!-- Jakarta EE Impl -->
+    <tomcat.version>10.0.27</tomcat.version>
+    <!-- com.sun -->
+    <version.impl.saaj>2.0.1</version.impl.saaj>
+    <!-- org.apache -->
+    <version.activemq>5.16.5</version.activemq>
+    <version.batchee>1.0.2</version.batchee>
+    <version.bval>2.0.6</version.bval>
+    <version.cxf>3.5.0</version.cxf>
+    <version.geronimo.components>3.1.5</version.geronimo.components>
+    <version.geronimo-mail_2.1_provider>1.0.0</version.geronimo-mail_2.1_provider>
+    <version.johnzon>1.2.19</version.johnzon>
+    <version.myfaces>3.0.2</version.myfaces>
+    <version.openjpa>3.2.2</version.openjpa>
+    <version.openwebbeans>2.0.27</version.openwebbeans>
+    <!-- org.eclipse -->
+    <version.eclipselink>3.0.3</version.eclipselink>
+    <!-- org.glassfish -->
+    <version.mojarra>3.0.2</version.mojarra>
+    <!-- org.hibernate -->
+    <version.hibernate.orm>6.1.4.Final</version.hibernate.orm>
+    <version.hibernate.validator>7.0.5.Final</version.hibernate.validator>
+    <!-- Impl not in EE -->
+    <version.krazo>2.0.2</version.krazo>
+    <version.deltaspike>1.9.6</version.deltaspike>
+    <version.wss4j>2.4.1</version.wss4j>
+
+    <!-- JDBC Drivers -->
+    <version.derby>10.14.2.0</version.derby>
+    <version.hsqldb>2.7.1</version.hsqldb>
 
   </properties>
 
@@ -290,7 +254,7 @@
         <plugin>
           <groupId>org.apache.felix</groupId>
           <artifactId>maven-bundle-plugin</artifactId>
-          <version>${maven-bundle-plugin.version}</version>
+          <version>${version.plugin.bundle}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -419,7 +383,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>${surefire.version}</version>
+          <version>${version.plugin.surefire}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -492,7 +456,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>${javadoc.version}</version>
+        <version>${version.plugin.javadoc}</version>
         <configuration>
           <source>8</source>
           <release>8</release>
@@ -966,13 +930,13 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
-            <version>${javadoc.version}</version>
+            <version>${version.plugin.javadoc}</version>
             <configuration>
               <doclet>org.asciidoctor.Asciidoclet</doclet>
               <docletArtifact>
                 <groupId>org.asciidoctor</groupId>
                 <artifactId>asciidoclet</artifactId>
-                <version>${asciidoclet.version}</version>
+                <version>${version.asciidoclet}</version>
               </docletArtifact>
               <additionalOptions>
                 <additionalOption>--base-dir ${basedir}</additionalOption>
@@ -1065,7 +1029,7 @@
       <dependency>
         <groupId>${project.groupId}</groupId>
         <artifactId>jakartaee-api</artifactId>
-        <version>${version.jakartaee-api}</version>
+        <version>${version.tomee.jakartaee-api}</version>
         <classifier>tomcat</classifier>
         <exclusions>
           <exclusion>
@@ -1077,7 +1041,7 @@
       <dependency>
         <groupId>${project.groupId}</groupId>
         <artifactId>jakartaee-api</artifactId>
-        <version>${version.jakartaee-api}</version>
+        <version>${version.tomee.jakartaee-api}</version>
         <exclusions>
           <exclusion>
             <groupId>*</groupId>
@@ -1093,73 +1057,73 @@
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-server</artifactId>
-        <version>${jetty.version}</version>
+        <version>${version.jetty}</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-continuation</artifactId>
-        <version>${jetty.version}</version>
+        <version>${version.jetty}</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-jsp-2.1</artifactId>
-        <version>${jetty.version}</version>
+        <version>${version.jetty}</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-plus</artifactId>
-        <version>${jetty.version}</version>
+        <version>${version.jetty}</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-jndi</artifactId>
-        <version>${jetty.version}</version>
+        <version>${version.jetty}</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-webapp</artifactId>
-        <version>${jetty.version}</version>
+        <version>${version.jetty}</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-io</artifactId>
-        <version>${jetty.version}</version>
+        <version>${version.jetty}</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-http</artifactId>
-        <version>${jetty.version}</version>
+        <version>${version.jetty}</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-security</artifactId>
-        <version>${jetty.version}</version>
+        <version>${version.jetty}</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-util</artifactId>
-        <version>${jetty.version}</version>
+        <version>${version.jetty}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.bval</groupId>
         <artifactId>bval-jsr</artifactId>
         <classifier>jakarta</classifier>
-        <version>${bval.version}</version>
+        <version>${version.bval}</version>
       </dependency>
       <dependency>
         <groupId>commons-cli</groupId>
         <artifactId>commons-cli</artifactId>
-        <version>${commons-cli.version}</version>
+        <version>${version.commons-cli}</version>
       </dependency>
       <dependency>
         <groupId>commons-logging</groupId>
         <artifactId>commons-logging-api</artifactId>
-        <version>${commons-logging-api.version}</version>
+        <version>${version.commons-logging-api}</version>
       </dependency>
       <dependency>
         <groupId>commons-logging</groupId>
         <artifactId>commons-logging</artifactId>
-        <version>${commons-logging.version}</version>
+        <version>${version.commons-logging}</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.servlet</groupId>
@@ -1188,25 +1152,25 @@
       <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
-        <version>${junit.version}</version>
+        <version>${version.junit}</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.junit.jupiter</groupId>
         <artifactId>junit-jupiter-api</artifactId>
-        <version>${junit.jupiter.version}</version>
+        <version>${version.junit.jupiter}</version>
         <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>org.junit.jupiter</groupId>
         <artifactId>junit-jupiter-engine</artifactId>
-        <version>${junit.jupiter.version}</version>
+        <version>${version.junit.jupiter}</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.junit.vintage</groupId>
         <artifactId>junit-vintage-engine</artifactId>
-        <version>${junit.jupiter.version}</version>
+        <version>${version.junit.jupiter}</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -1218,7 +1182,7 @@
       <dependency>
         <groupId>org.apache.activemq</groupId>
         <artifactId>activemq-jdbc-store</artifactId>
-        <version>${org.apache.activemq.version}</version>
+        <version>${version.activemq}</version>
         <exclusions>
           <exclusion>
             <groupId>org.apache.derby</groupId>
@@ -1240,7 +1204,7 @@
       <dependency>
         <groupId>commons-net</groupId>
         <artifactId>commons-net</artifactId>
-        <version>${commons-net.version}</version>
+        <version>${version.commons-net}</version>
       </dependency>
       <dependency>
         <groupId>${project.groupId}</groupId>
@@ -1278,7 +1242,7 @@
       <dependency>
         <groupId>org.apache.activemq</groupId>
         <artifactId>activemq-openwire-legacy</artifactId>
-        <version>${org.apache.activemq.version}</version>
+        <version>${version.activemq}</version>
       </dependency>
       <dependency>
         <groupId>xalan</groupId>
@@ -1298,7 +1262,7 @@
       <dependency>
         <groupId>org.apache.geronimo.components</groupId>
         <artifactId>geronimo-connector</artifactId>
-        <version>${geronimo.connector.version}</version>
+        <version>${version.geronimo.components}</version>
         <classifier>jakarta</classifier>
         <exclusions>
           <exclusion>
@@ -1318,7 +1282,7 @@
       <dependency>
         <groupId>org.apache.geronimo.components</groupId>
         <artifactId>geronimo-transaction</artifactId>
-        <version>${geronimo.connector.version}</version>
+        <version>${version.geronimo.components}</version>
         <classifier>jakarta</classifier>
         <exclusions>
           <exclusion>
@@ -1339,12 +1303,12 @@
       <dependency>
         <groupId>org.apache.geronimo.specs</groupId>
         <artifactId>geronimo-mail_2.1_spec</artifactId>
-        <version>${geronimo-mail_2.1_spec.version}</version>
+        <version>${version.geronimo-mail_2.1_spec}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.geronimo.mail</groupId>
         <artifactId>geronimo-mail_2.1_provider</artifactId>
-        <version>${geronimo-mail_2.1_provider.version}</version>
+        <version>${version.geronimo-mail_2.1_provider}</version>
       </dependency>
       <dependency>
         <groupId>stax</groupId>
@@ -1368,12 +1332,12 @@
       <dependency>
         <groupId>org.apache.xbean</groupId>
         <artifactId>xbean-finder-shaded</artifactId>
-        <version>${xbeanVersion}</version>
+        <version>${version.xbean}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.xbean</groupId>
         <artifactId>xbean-asm9-shaded</artifactId>
-        <version>${xbeanVersion}</version>
+        <version>${version.xbean}</version>
         <exclusions>
           <exclusion>
             <groupId>org.ow2.asm</groupId>
@@ -1388,12 +1352,12 @@
       <dependency>
         <groupId>org.apache.xbean</groupId>
         <artifactId>xbean-naming</artifactId>
-        <version>${xbeanVersion}</version>
+        <version>${version.xbean}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.xbean</groupId>
         <artifactId>xbean-bundleutils</artifactId>
-        <version>${xbeanVersion}</version>
+        <version>${version.xbean}</version>
         <exclusions>
           <exclusion>
             <groupId>org.slf4j</groupId>
@@ -1404,12 +1368,12 @@
       <dependency>
         <groupId>org.apache.xbean</groupId>
         <artifactId>xbean-spring</artifactId>
-        <version>${xbeanVersion}</version>
+        <version>${version.xbean}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.xbean</groupId>
         <artifactId>xbean-reflect</artifactId>
-        <version>${xbeanVersion}</version>
+        <version>${version.xbean}</version>
         <exclusions>
           <exclusion>
             <groupId>mx4j</groupId>
@@ -1441,7 +1405,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-pool2</artifactId>
-        <version>${commons-pool.version}</version>
+        <version>${version.commons-pool2}</version>
       </dependency>
       <dependency>
         <artifactId>xmlsec</artifactId>
@@ -1472,7 +1436,7 @@
       <dependency>
         <groupId>org.apache.openejb.shade</groupId>
         <artifactId>quartz-openejb-shade</artifactId>
-        <version>${quartz-openejb-shade.version}</version>
+        <version>${version.quartz-openejb-shade}</version>
         <exclusions>
           <exclusion>
             <groupId>org.quartz-scheduler</groupId>
@@ -1499,12 +1463,12 @@
       <dependency>
         <groupId>org.osgi</groupId>
         <artifactId>org.osgi.core</artifactId>
-        <version>${osgi.framework.version}</version>
+        <version>${version.osgi}</version>
       </dependency>
       <dependency>
         <groupId>org.osgi</groupId>
         <artifactId>org.osgi.compendium</artifactId>
-        <version>${osgi.framework.version}</version>
+        <version>${version.osgi}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.neethi</groupId>
@@ -1558,12 +1522,12 @@
       <dependency>
         <artifactId>slf4j-api</artifactId>
         <groupId>org.slf4j</groupId>
-        <version>${slf4j.version}</version>
+        <version>${version.slf4j}</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-jdk14</artifactId>
-        <version>${slf4j.version}</version>
+        <version>${version.slf4j}</version>
         <exclusions>
           <exclusion>
             <artifactId>slf4j-api</artifactId>
@@ -1574,17 +1538,17 @@
       <dependency>
         <groupId>log4j</groupId>
         <artifactId>log4j</artifactId>
-        <version>${log4j.version}</version>
+        <version>${version.log4j}</version>
       </dependency>
       <dependency>
         <artifactId>commons-collections</artifactId>
         <groupId>commons-collections</groupId>
-        <version>${commons-collections.version}</version>
+        <version>${version.commons-collections}</version>
       </dependency>
       <dependency>
         <groupId>commons-codec</groupId>
         <artifactId>commons-codec</artifactId>
-        <version>${commons-codec.version}</version>
+        <version>${version.commons-codec}</version>
       </dependency>
       <dependency>
         <groupId>${project.groupId}</groupId>
@@ -1599,13 +1563,13 @@
       <dependency>
         <groupId>commons-discovery</groupId>
         <artifactId>commons-discovery</artifactId>
-        <version>${commons-discovery.version}</version>
+        <version>${version.commons-discovery}</version>
       </dependency>
 
       <dependency>
         <groupId>org.apache.openwebbeans</groupId>
         <artifactId>openwebbeans-impl</artifactId>
-        <version>${openwebbeans.version}</version>
+        <version>${version.openwebbeans}</version>
         <classifier>jakarta</classifier>
         <exclusions>
           <exclusion>
@@ -1621,7 +1585,7 @@
       <dependency>
         <groupId>org.apache.openwebbeans</groupId>
         <artifactId>openwebbeans-jsf</artifactId>
-        <version>${openwebbeans.version}</version>
+        <version>${version.openwebbeans}</version>
         <classifier>jakarta</classifier>
         <exclusions>
           <exclusion>
@@ -1633,7 +1597,7 @@
       <dependency>
         <groupId>org.apache.openwebbeans</groupId>
         <artifactId>openwebbeans-spi</artifactId>
-        <version>${openwebbeans.version}</version>
+        <version>${version.openwebbeans}</version>
         <classifier>jakarta</classifier>
         <exclusions>
           <exclusion>
@@ -1650,7 +1614,7 @@
         <groupId>org.apache.openwebbeans</groupId>
         <artifactId>openwebbeans-ejb</artifactId>
         <classifier>jakarta</classifier>
-        <version>${openwebbeans.version}</version>
+        <version>${version.openwebbeans}</version>
         <exclusions>
           <exclusion>
             <!-- impl references a non jakarta classifier version -->
@@ -1667,7 +1631,7 @@
         <groupId>org.apache.openwebbeans</groupId>
         <artifactId>openwebbeans-ee</artifactId>
         <classifier>jakarta</classifier>
-        <version>${openwebbeans.version}</version>
+        <version>${version.openwebbeans}</version>
           <exclusions>
           <exclusion>
             <!-- impl references a non jakarta classifier version -->
@@ -1688,7 +1652,7 @@
         <groupId>org.apache.openwebbeans</groupId>
         <artifactId>openwebbeans-web</artifactId>
         <classifier>jakarta</classifier>
-        <version>${openwebbeans.version}</version>
+        <version>${version.openwebbeans}</version>
         <exclusions>
           <exclusion>
             <!-- impl references a non jakarta classifier version -->
@@ -1705,7 +1669,7 @@
         <groupId>org.apache.openwebbeans</groupId>
         <artifactId>openwebbeans-el22</artifactId>
         <classifier>jakarta</classifier>
-        <version>${openwebbeans.version}</version>
+        <version>${version.openwebbeans}</version>
         <exclusions>
           <exclusion>
             <groupId>org.apache.openwebbeans</groupId>
@@ -1717,7 +1681,7 @@
         <artifactId>openwebbeans-ee-common</artifactId>
         <groupId>org.apache.openwebbeans</groupId>
         <classifier>jakarta</classifier>
-        <version>${openwebbeans.version}</version>
+        <version>${version.openwebbeans}</version>
         <exclusions>
           <exclusion>
             <!-- impl references a non jakarta classifier version -->
@@ -1738,7 +1702,7 @@
       <dependency>
         <groupId>org.apache.johnzon</groupId>
         <artifactId>johnzon-core</artifactId>
-        <version>${johnzon.version}</version>
+        <version>${version.johnzon}</version>
         <classifier>jakarta</classifier>
         <exclusions>
           <exclusion>
@@ -1750,7 +1714,7 @@
       <dependency>
         <groupId>org.apache.johnzon</groupId>
         <artifactId>johnzon-mapper</artifactId>
-        <version>${johnzon.version}</version>
+        <version>${version.johnzon}</version>
         <classifier>jakarta</classifier>
         <exclusions>
           <exclusion>
@@ -1762,7 +1726,7 @@
       <dependency>
         <groupId>org.apache.johnzon</groupId>
         <artifactId>johnzon-jaxrs</artifactId>
-        <version>${johnzon.version}</version>
+        <version>${version.johnzon}</version>
         <classifier>jakarta</classifier>
         <exclusions>
           <exclusion>
@@ -1774,7 +1738,7 @@
       <dependency>
         <groupId>org.apache.johnzon</groupId>
         <artifactId>johnzon-jsonb</artifactId>
-        <version>${johnzon.version}</version>
+        <version>${version.johnzon}</version>
         <classifier>jakarta</classifier>
         <exclusions>
           <exclusion>
@@ -1786,7 +1750,7 @@
       <dependency>
         <groupId>org.apache.johnzon</groupId>
         <artifactId>johnzon-jsonp-strict</artifactId>
-        <version>${johnzon.version}</version>
+        <version>${version.johnzon}</version>
         <classifier>jakarta</classifier>
         <exclusions>
           <exclusion>
@@ -1815,7 +1779,7 @@
       <dependency>
         <artifactId>commons-lang3</artifactId>
         <groupId>org.apache.commons</groupId>
-        <version>${commons-lang3.version}</version>
+        <version>${version.commons-lang3}</version>
       </dependency>
       <dependency>
         <artifactId>commons-lang</artifactId>
@@ -1825,7 +1789,7 @@
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>${commons-io.version}</version>
+        <version>${version.commons-io}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.ws.commons.schema</groupId>
@@ -1835,7 +1799,7 @@
       <dependency>
         <groupId>org.ehcache</groupId>
         <artifactId>ehcache</artifactId>
-        <version>${ehcache.version}</version>
+        <version>${version.ehcache}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.derby</groupId>
@@ -1934,13 +1898,13 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>${version.jackson.databind}</version>
+        <version>${version.jackson}</version>
       </dependency>
       <!-- Jackson required by OpenAPI Impl -->
       <dependency>
         <groupId>com.fasterxml.jackson.dataformat</groupId>
         <artifactId>jackson-dataformat-yaml</artifactId>
-        <version>${version.jackson.dataformat}</version>
+        <version>${version.jackson}</version>
         <exclusions>
           <exclusion>
             <groupId>org.yaml</groupId>
@@ -1952,7 +1916,7 @@
       <dependency>
         <groupId>org.yaml</groupId>
         <artifactId>snakeyaml</artifactId>
-        <version>${snakeyaml.version}</version>
+        <version>${version.snakeyaml}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/server/openejb-bonecp/pom.xml
+++ b/server/openejb-bonecp/pom.xml
@@ -46,7 +46,7 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>${slf4j.version}</version>
+      <version>${version.slf4j}</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/server/openejb-cxf/pom.xml
+++ b/server/openejb-cxf/pom.xml
@@ -33,7 +33,7 @@
 
   <properties>
     <tomee.build.name>${project.groupId}.server.cxf</tomee.build.name>
-    <wss4j.version>2.3.3</wss4j.version>
+    <version.wss4j>2.3.3</version.wss4j>
     <openejb.osgi.import.pkg>
       org.apache.xml.resolver*;resolution:=optional,
       *
@@ -68,7 +68,7 @@
     <dependency>
       <groupId>org.apache.wss4j</groupId>
       <artifactId>wss4j-ws-security-dom</artifactId>
-      <version>${wss4j.version}</version>
+      <version>${version.wss4j}</version>
       <exclusions>
         <exclusion>
           <groupId>org.apache.santuario</groupId>
@@ -117,12 +117,12 @@
     <dependency>
       <groupId>org.apache.wss4j</groupId>
       <artifactId>wss4j-policy</artifactId>
-      <version>${wss4j.version}</version>
+      <version>${version.wss4j}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.wss4j</groupId>
       <artifactId>wss4j-ws-security-stax</artifactId>
-      <version>${wss4j.version}</version>
+      <version>${version.wss4j}</version>
       <exclusions>
         <exclusion>
           <groupId>net.sf.ehcache</groupId>
@@ -137,7 +137,7 @@
     <dependency>
       <groupId>org.apache.wss4j</groupId>
       <artifactId>wss4j-ws-security-policy-stax</artifactId>
-      <version>${wss4j.version}</version>
+      <version>${version.wss4j}</version>
       <exclusions>
         <exclusion>
           <groupId>net.sf.ehcache</groupId>
@@ -189,7 +189,7 @@
     <dependency>
       <groupId>com.sun.xml.messaging.saaj</groupId>
       <artifactId>saaj-impl</artifactId>
-      <version>${saaj-impl.version}</version>
+      <version>${version.impl.saaj}</version>
       <exclusions>
         <exclusion>
           <groupId>jakarta.activation</groupId>

--- a/server/openejb-http/pom.xml
+++ b/server/openejb-http/pom.xml
@@ -137,13 +137,13 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-server</artifactId>
-      <version>${jetty.version}</version>
+      <version>${version.jetty}</version>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-servlet</artifactId>
-      <version>${jetty.version}</version>
+      <version>${version.jetty}</version>
       <optional>true</optional>
     </dependency>
     <dependency>

--- a/server/openejb-webservices/pom.xml
+++ b/server/openejb-webservices/pom.xml
@@ -73,7 +73,7 @@
     <dependency>
       <groupId>com.sun.xml.messaging.saaj</groupId>
       <artifactId>saaj-impl</artifactId>
-      <version>${saaj-impl.version}</version>
+      <version>${version.impl.saaj}</version>
     </dependency>
 
     <!-- spec dependencies -->

--- a/tck/bval-embedded/pom.xml
+++ b/tck/bval-embedded/pom.xml
@@ -40,7 +40,7 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-jdk14</artifactId>
-      <version>${slf4j.version}</version>
+      <version>${version.slf4j}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -144,7 +144,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>${surefire.version}</version>
+        <version>${version.plugin.surefire}</version>
         <configuration>
           <reuseForks>false</reuseForks>
           <suiteXmlFiles>
@@ -160,7 +160,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-report-plugin</artifactId>
-        <version>${surefire.version}</version>
+        <version>${version.plugin.surefire}</version>
         <executions>
           <execution>
             <id>generate-test-report</id>

--- a/tck/cdi-embedded/pom.xml
+++ b/tck/cdi-embedded/pom.xml
@@ -36,13 +36,13 @@
     <dependency>
       <groupId>org.apache.myfaces.core</groupId>
       <artifactId>myfaces-api</artifactId>
-      <version>${myfaces.version}</version>
+      <version>${version.myfaces}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.myfaces.core</groupId>
       <artifactId>myfaces-impl</artifactId>
-      <version>${myfaces.version}</version>
+      <version>${version.myfaces}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -101,7 +101,7 @@
     <dependency>
       <groupId>org.apache.openwebbeans</groupId>
       <artifactId>openwebbeans-porting</artifactId>
-      <version>${openwebbeans.version}</version>
+      <version>${version.openwebbeans}</version>
       <classifier>jakarta</classifier>
       <scope>test</scope>
       <exclusions>
@@ -187,7 +187,7 @@
     <dependency>
       <groupId>org.apache.openwebbeans</groupId>
       <artifactId>openwebbeans-jsf</artifactId>
-      <version>${openwebbeans.version}</version>
+      <version>${version.openwebbeans}</version>
       <classifier>jakarta</classifier>
       <scope>test</scope>
     </dependency>
@@ -239,7 +239,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>${surefire.version}</version>
+        <version>${version.plugin.surefire}</version>
         <configuration>
           <reuseForks>false</reuseForks>
           <forkCount>1</forkCount>

--- a/tck/cdi-signature-test/pom.xml
+++ b/tck/cdi-signature-test/pom.xml
@@ -30,7 +30,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>jakartaee-api</artifactId>
-      <version>${version.jakartaee-api}</version>
+      <version>${version.tomee.jakartaee-api}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/tck/cdi-tomee/pom.xml
+++ b/tck/cdi-tomee/pom.xml
@@ -39,13 +39,13 @@
     <dependency>
       <groupId>org.apache.myfaces.core</groupId>
       <artifactId>myfaces-api</artifactId>
-      <version>${myfaces.version}</version>
+      <version>${version.myfaces}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>jakartaee-api</artifactId>
-      <version>${version.jakartaee-api}</version>
+      <version>${version.tomee.jakartaee-api}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -82,7 +82,7 @@
     <dependency>
       <groupId>org.apache.openwebbeans</groupId>
       <artifactId>openwebbeans-porting</artifactId>
-      <version>${openwebbeans.version}</version>
+      <version>${version.openwebbeans}</version>
       <classifier>jakarta</classifier>
       <scope>test</scope>
       <exclusions>
@@ -164,13 +164,13 @@
     <dependency>
       <groupId>org.apache.geronimo.specs</groupId>
       <artifactId>geronimo-jcache_1.0_spec</artifactId>
-      <version>${geronimo-jcache_1.0_spec.version}</version>
+      <version>${version.geronimo-jcache_1.0_spec}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-jcs-jcache</artifactId>
-      <version>${jcs.version}</version>
+      <version>${version.commons-jcs-cache}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -249,7 +249,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>${surefire.version}</version>
+        <version>${version.plugin.surefire}</version>
         <configuration>
           <reuseForks>false</reuseForks>
           <forkCount>1</forkCount>

--- a/tck/cdi-tomee/src/test/resources/arquillian.xml
+++ b/tck/cdi-tomee/src/test/resources/arquillian.xml
@@ -56,7 +56,7 @@
       <property name="additionalLibs">
         target/test-classes/org
         target/test-classes/META-INF
-        mvn:org.apache.openwebbeans:openwebbeans-porting:${openwebbeans.version}:jar:jakarta
+        mvn:org.apache.openwebbeans:openwebbeans-porting:${version.openwebbeans}:jar:jakarta
         mvn:jakarta.enterprise:cdi-tck-ext-lib:${cdi-tck.version}
       </property>
     </configuration>

--- a/tck/microprofile-tck/config/pom.xml
+++ b/tck/microprofile-tck/config/pom.xml
@@ -116,14 +116,14 @@
     <dependency>
       <groupId>org.eclipse.microprofile.config</groupId>
       <artifactId>microprofile-config-api</artifactId>
-      <version>${microprofile.config.version}</version>
+      <version>${version.microprofile.config}</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.eclipse.microprofile.config</groupId>
       <artifactId>microprofile-config-tck</artifactId>
-      <version>${microprofile.config.tck.version}</version>
+      <version>${version.microprofile.config}</version>
       <scope>test</scope>
     </dependency>
 

--- a/tck/microprofile-tck/fault-tolerance/pom.xml
+++ b/tck/microprofile-tck/fault-tolerance/pom.xml
@@ -97,13 +97,13 @@
     <dependency>
       <groupId>org.eclipse.microprofile.fault-tolerance</groupId>
       <artifactId>microprofile-fault-tolerance-api</artifactId>
-      <version>${microprofile.fault-tolerance.version}</version>
+      <version>${version.microprofile.fault-tolerance}</version>
     </dependency>
 
     <dependency>
       <groupId>org.eclipse.microprofile.fault-tolerance</groupId>
       <artifactId>microprofile-fault-tolerance-tck</artifactId>
-      <version>${microprofile.fault-tolerance.tck.version}</version>
+      <version>${version.microprofile.fault-tolerance}</version>
       <scope>test</scope>
     </dependency>
 

--- a/tck/microprofile-tck/health/pom.xml
+++ b/tck/microprofile-tck/health/pom.xml
@@ -84,7 +84,7 @@
     <dependency>
       <groupId>org.eclipse.microprofile.health</groupId>
       <artifactId>microprofile-health-api</artifactId>
-      <version>${microprofile.health.version}</version>
+      <version>${version.microprofile.health}</version>
       <exclusions>
         <exclusion>
           <groupId>javax.inject</groupId>
@@ -96,7 +96,7 @@
     <dependency>
       <groupId>org.eclipse.microprofile.health</groupId>
       <artifactId>microprofile-health-tck</artifactId>
-      <version>${microprofile.health.tck.version}</version>
+      <version>${version.microprofile.health}</version>
       <scope>test</scope>
     </dependency>
 

--- a/tck/microprofile-tck/jwt/pom.xml
+++ b/tck/microprofile-tck/jwt/pom.xml
@@ -96,7 +96,7 @@
     <dependency>
       <groupId>org.eclipse.microprofile.jwt</groupId>
       <artifactId>microprofile-jwt-auth-tck</artifactId>
-      <version>${microprofile.jwt.tck.version}</version>
+      <version>${version.microprofile.jwt}</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -110,7 +110,7 @@
     <dependency>
       <groupId>org.eclipse.microprofile.jwt</groupId>
       <artifactId>microprofile-jwt-auth-tck</artifactId>
-      <version>${microprofile.jwt.tck.version}</version>
+      <version>${version.microprofile.jwt}</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
@@ -138,7 +138,7 @@
     <dependency>
       <groupId>io.smallrye.config</groupId>
       <artifactId>smallrye-config-core</artifactId>
-      <version>${microprofile.config.impl.version}</version>
+      <version>${version.microprofile.impl.config}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/tck/microprofile-tck/metrics/pom.xml
+++ b/tck/microprofile-tck/metrics/pom.xml
@@ -100,14 +100,14 @@
     <dependency>
       <groupId>org.eclipse.microprofile.metrics</groupId>
       <artifactId>microprofile-metrics-api</artifactId>
-      <version>${microprofile.metrics.version}</version>
+      <version>${version.microprofile.metrics}</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.eclipse.microprofile.metrics</groupId>
       <artifactId>microprofile-metrics-api-tck</artifactId>
-      <version>${microprofile.metrics.version}</version>
+      <version>${version.microprofile.metrics}</version>
       <exclusions>
         <exclusion>
           <groupId>org.jboss.arquillian.container</groupId>
@@ -120,7 +120,7 @@
     <dependency>
       <groupId>org.eclipse.microprofile.metrics</groupId>
       <artifactId>microprofile-metrics-rest-tck</artifactId>
-      <version>${microprofile.metrics.tck.version}</version>
+      <version>${version.microprofile.metrics}</version>
       <scope>test</scope>
     </dependency>
 

--- a/tck/microprofile-tck/openapi/pom.xml
+++ b/tck/microprofile-tck/openapi/pom.xml
@@ -88,14 +88,14 @@
     <dependency>
       <groupId>org.eclipse.microprofile.openapi</groupId>
       <artifactId>microprofile-openapi-api</artifactId>
-      <version>${microprofile.openapi.version}</version>
+      <version>${version.microprofile.openapi}</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.eclipse.microprofile.openapi</groupId>
       <artifactId>microprofile-openapi-tck</artifactId>
-      <version>${microprofile.openapi.tck.version}</version>
+      <version>${version.microprofile.openapi}</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/tck/microprofile-tck/opentracing/pom.xml
+++ b/tck/microprofile-tck/opentracing/pom.xml
@@ -84,27 +84,27 @@
     <dependency>
       <groupId>org.eclipse.microprofile.config</groupId>
       <artifactId>microprofile-config-api</artifactId>
-      <version>${microprofile.config.version}</version>
+      <version>${version.microprofile.config}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.microprofile.opentracing</groupId>
       <artifactId>microprofile-opentracing-api</artifactId>
-      <version>${microprofile.opentracing.version}</version>
+      <version>${version.microprofile.opentracing}</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.eclipse.microprofile.opentracing</groupId>
       <artifactId>microprofile-opentracing-tck</artifactId>
-      <version>${microprofile.opentracing.tck.version}</version>
+      <version>${version.microprofile.opentracing}</version>
       <scope>test</scope>
     </dependency>
     <!--
     <dependency>
       <groupId>org.eclipse.microprofile.opentracing</groupId>
       <artifactId>microprofile-opentracing-tck-rest-client</artifactId>
-      <version>${microprofile.opentracing.tck.version}</version>
+      <version>${version.microprofile.opentracing}</version>
       <scope>test</scope>
     </dependency>
     -->
@@ -112,7 +112,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>jakartaee-api</artifactId>
-      <version>${version.jakartaee-api}</version>
+      <version>${version.tomee.jakartaee-api}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -166,21 +166,21 @@
     <dependency>
       <groupId>io.opentracing</groupId>
       <artifactId>opentracing-mock</artifactId>
-      <version>${opentracing.api}</version>
+      <version>${version.io.opentracing}</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>io.opentracing</groupId>
       <artifactId>opentracing-api</artifactId>
-      <version>${opentracing.api}</version>
+      <version>${version.io.opentracing}</version>
       <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>io.smallrye</groupId>
       <artifactId>smallrye-opentracing</artifactId>
-      <version>${microprofile.opentracing.impl.version}</version>
+      <version>${version.microprofile.impl.opentracing}</version>
       <scope>provided</scope>
     </dependency>
 

--- a/tck/microprofile-tck/rest-client/pom.xml
+++ b/tck/microprofile-tck/rest-client/pom.xml
@@ -29,7 +29,7 @@
   <name>TomEE :: TCK :: MicroProfile Rest Client TCK</name>
 
   <properties>
-    <!--<jetty-tck.version>${jetty.version}</jetty-tck.version>-->
+    <!--<jetty-tck.version>${version.jetty}</jetty-tck.version>-->
     <jetty-tck.version>9.2.28.v20190418</jetty-tck.version>
   </properties>
 
@@ -125,7 +125,7 @@
     <dependency>
       <groupId>org.eclipse.microprofile.rest.client</groupId>
       <artifactId>microprofile-rest-client-api</artifactId>
-      <version>${microprofile.rest-client.version}</version>
+      <version>${version.microprofile.rest-client}</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -138,7 +138,7 @@
     <dependency>
       <groupId>org.eclipse.microprofile.rest.client</groupId>
       <artifactId>microprofile-rest-client-tck</artifactId>
-      <version>${microprofile.rest-client.tck.version}</version>
+      <version>${version.microprofile.rest-client}</version>
       <scope>test</scope>
     </dependency>
 

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -49,7 +49,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>${javadoc.version}</version>
+        <version>${version.plugin.javadoc}</version>
         <configuration>
           <skip>true</skip>
         </configuration>

--- a/tomee/apache-tomee/pom.xml
+++ b/tomee/apache-tomee/pom.xml
@@ -337,7 +337,7 @@
               <dependency>
                 <groupId>org.apache.tomee</groupId>
                 <artifactId>jakartaee-api</artifactId>
-                <version>${version.jakartaee-api}</version>
+                <version>${version.tomee.jakartaee-api}</version>
               </dependency>
               <dependency>
                 <groupId>org.apache.tomee.bom</groupId>
@@ -353,7 +353,7 @@
               <dependency>
                 <groupId>org.apache.xbean</groupId>
                 <artifactId>xbean-asm9-shaded</artifactId>
-                <version>${xbeanVersion}</version>
+                <version>${version.xbean}</version>
               </dependency>
               <dependency>
                 <groupId>org.codehaus.groovy</groupId>
@@ -383,7 +383,7 @@
                   <properties>
                     <tomee.workdir>${webprofile.work-dir}</tomee.workdir>
                     <tomee.webapp>tomee-webapp</tomee.webapp>
-                    <remove.datestamp>${tomee.version}, ${project.version}, ${cxf.version}</remove.datestamp>
+                    <remove.datestamp>${tomee.version}, ${project.version}, ${version.cxf}</remove.datestamp>
                     <jdk.attach.allowAttachSelf>true</jdk.attach.allowAttachSelf>
                   </properties>
                   <source>
@@ -401,7 +401,7 @@
                   <properties>
                     <tomee.workdir>${plus.work-dir}</tomee.workdir>
                     <tomee.webapp>tomee-plus-webapp</tomee.webapp>
-                    <remove.datestamp>${tomee.version}, ${project.version}, ${cxf.version}</remove.datestamp>
+                    <remove.datestamp>${tomee.version}, ${project.version}, ${version.cxf}</remove.datestamp>
                     <jdk.attach.allowAttachSelf>true</jdk.attach.allowAttachSelf>
                   </properties>
                   <source>
@@ -419,7 +419,7 @@
                   <properties>
                     <tomee.workdir>${plume.work-dir}</tomee.workdir>
                     <tomee.webapp>tomee-plume-webapp</tomee.webapp>
-                    <remove.datestamp>${tomee.version}, ${project.version}, ${cxf.version}</remove.datestamp>
+                    <remove.datestamp>${tomee.version}, ${project.version}, ${version.cxf}</remove.datestamp>
                     <jdk.attach.allowAttachSelf>true</jdk.attach.allowAttachSelf>
                   </properties>
                   <source>
@@ -437,7 +437,7 @@
                   <properties>
                     <tomee.workdir>${microprofile.work-dir}</tomee.workdir>
                     <tomee.webapp>tomee-microprofile-webapp</tomee.webapp>
-                    <remove.datestamp>${tomee.version}, ${project.version}, ${cxf.version}</remove.datestamp>
+                    <remove.datestamp>${tomee.version}, ${project.version}, ${version.cxf}</remove.datestamp>
                     <jdk.attach.allowAttachSelf>true</jdk.attach.allowAttachSelf>
                   </properties>
                   <source>
@@ -721,7 +721,7 @@
               <dependency>
                 <groupId>org.apache.tomee</groupId>
                 <artifactId>jakartaee-api</artifactId>
-                <version>${version.jakartaee-api}</version>
+                <version>${version.tomee.jakartaee-api}</version>
               </dependency>
               <dependency>
                 <groupId>org.apache.tomee.bom</groupId>
@@ -737,7 +737,7 @@
               <dependency>
                 <groupId>org.apache.xbean</groupId>
                 <artifactId>xbean-asm9-shaded</artifactId>
-                <version>${xbeanVersion}</version>
+                <version>${version.xbean}</version>
               </dependency>
               <dependency>
                 <groupId>org.codehaus.groovy</groupId>
@@ -767,7 +767,7 @@
                   <properties>
                     <tomee.workdir>${plume.work-dir}</tomee.workdir>
                     <tomee.webapp>tomee-plume-webapp</tomee.webapp>
-                    <remove.datestamp>${tomee.version}, ${project.version}, ${cxf.version}</remove.datestamp>
+                    <remove.datestamp>${tomee.version}, ${project.version}, ${version.cxf}</remove.datestamp>
                   </properties>
                   <source>
                     new commands.SetupCommand(pom: this, log: log, project: project, ant: ant, properties: properties).execute()

--- a/tomee/pom.xml
+++ b/tomee/pom.xml
@@ -150,7 +150,7 @@
       <dependency>
         <artifactId>commons-beanutils</artifactId>
         <groupId>commons-beanutils</groupId>
-        <version>${commons-beanutils.version}</version>
+        <version>${version.commons-beanutils}</version>
       </dependency>
       <dependency>
         <groupId>jakarta.servlet</groupId>
@@ -211,13 +211,13 @@
       <dependency>
         <groupId>org.apache.openwebbeans</groupId>
         <artifactId>openwebbeans-jsf</artifactId>
-        <version>${openwebbeans.version}</version>
+        <version>${version.openwebbeans}</version>
         <classifier>jakarta</classifier>
       </dependency>
       <dependency>
         <groupId>org.apache.myfaces.core</groupId>
         <artifactId>myfaces-api</artifactId>
-        <version>${myfaces.version}</version>
+        <version>${version.myfaces}</version>
         <exclusions>
           <exclusion>
             <groupId>org.apache.geronimo.specs</groupId>
@@ -228,7 +228,7 @@
       <dependency>
         <groupId>org.apache.myfaces.core</groupId>
         <artifactId>myfaces-impl</artifactId>
-        <version>${myfaces.version}</version>
+        <version>${version.myfaces}</version>
         <exclusions>
           <exclusion>
             <groupId>org.apache.geronimo.specs</groupId>
@@ -308,7 +308,7 @@
       <dependency>
         <groupId>org.glassfish</groupId>
         <artifactId>jakarta.faces</artifactId>
-        <version>${mojarra.version}</version>
+        <version>${version.mojarra}</version>
       </dependency>
       <dependency>
         <groupId>${project.groupId}</groupId>

--- a/tomee/tomee-loader/pom.xml
+++ b/tomee/tomee-loader/pom.xml
@@ -90,7 +90,7 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
-      <version>${log4j2.version}</version>
+      <version>${version.log4j2}</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/tomee/tomee-microprofile/mp-common/pom.xml
+++ b/tomee/tomee-microprofile/mp-common/pom.xml
@@ -33,120 +33,120 @@
       <dependency>
         <groupId>org.eclipse.microprofile</groupId>
         <artifactId>microprofile</artifactId>
-        <version>${microprofile.version}</version>
+        <version>${version.microprofile}</version>
         <type>pom</type>
       </dependency>
       <dependency>
         <groupId>org.eclipse.microprofile.config</groupId>
         <artifactId>microprofile-config-api</artifactId>
-        <version>${microprofile.config.version}</version>
+        <version>${version.microprofile.config}</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.microprofile.fault-tolerance</groupId>
         <artifactId>microprofile-fault-tolerance-api</artifactId>
-        <version>${microprofile.fault-tolerance.version}</version>
+        <version>${version.microprofile.fault-tolerance}</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.microprofile.health</groupId>
         <artifactId>microprofile-health-api</artifactId>
-        <version>${microprofile.health.version}</version>
+        <version>${version.microprofile.health}</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.microprofile.jwt</groupId>
         <artifactId>microprofile-jwt-auth-api</artifactId>
-        <version>${microprofile.jwt.version}</version>
+        <version>${version.microprofile.jwt}</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.microprofile.metrics</groupId>
         <artifactId>microprofile-metrics-api</artifactId>
-        <version>${microprofile.metrics.version}</version>
+        <version>${version.microprofile.metrics}</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.microprofile.openapi</groupId>
         <artifactId>microprofile-openapi-api</artifactId>
-        <version>${microprofile.openapi.version}</version>
+        <version>${version.microprofile.openapi}</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.microprofile.opentracing</groupId>
         <artifactId>microprofile-opentracing-api</artifactId>
-        <version>${microprofile.opentracing.version}</version>
+        <version>${version.microprofile.opentracing}</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.microprofile.rest.client</groupId>
         <artifactId>microprofile-rest-client-api</artifactId>
-        <version>${microprofile.rest-client.version}</version>
+        <version>${version.microprofile.rest-client}</version>
       </dependency>
       <!-- SmallRye API & Impl -->
       <dependency>
         <groupId>io.smallrye.config</groupId>
         <artifactId>smallrye-config</artifactId>
-        <version>${microprofile.config.impl.version}</version>
+        <version>${version.microprofile.impl.config}</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-fault-tolerance-api</artifactId>
-        <version>${microprofile.fault-tolerance.impl.version}</version>
+        <version>${version.microprofile.impl.fault-tolerance}</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-fault-tolerance</artifactId>
-        <version>${microprofile.fault-tolerance.impl.version}</version>
+        <version>${version.microprofile.impl.fault-tolerance}</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-fault-tolerance-autoconfig-core</artifactId>
-        <version>${microprofile.fault-tolerance.impl.version}</version>
+        <version>${version.microprofile.impl.fault-tolerance}</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-fault-tolerance-core</artifactId>
-        <version>${microprofile.fault-tolerance.impl.version}</version>
+        <version>${version.microprofile.impl.fault-tolerance}</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-health-api</artifactId>
-        <version>${microprofile.health.impl.version}</version>
+        <version>${version.microprofile.impl.health}</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-health</artifactId>
-        <version>${microprofile.health.impl.version}</version>
+        <version>${version.microprofile.impl.health}</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-metrics-api</artifactId>
-        <version>${microprofile.metrics.impl.version}</version>
+        <version>${version.microprofile.impl.metrics}</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-metrics</artifactId>
-        <version>${microprofile.metrics.impl.version}</version>
+        <version>${version.microprofile.impl.metrics}</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-open-api</artifactId>
-        <version>${microprofile.openapi.impl.version}</version>
+        <version>${version.microprofile.impl.openapi}</version>
         <type>pom</type>
       </dependency>
       <dependency>
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-open-api-core</artifactId>
-        <version>${microprofile.openapi.impl.version}</version>
+        <version>${version.microprofile.impl.openapi}</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-open-api-jaxrs</artifactId>
-        <version>${microprofile.openapi.impl.version}</version>
+        <version>${version.microprofile.impl.openapi}</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-opentracing</artifactId>
-        <version>${microprofile.opentracing.impl.version}</version>
+        <version>${version.microprofile.impl.opentracing}</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-opentracing-contrib</artifactId>
-         <version>${microprofile.opentracing.impl.version}</version>
+         <version>${version.microprofile.impl.opentracing}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -208,7 +208,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>mp-jwt</artifactId>
-      <version>${microprofile.jwt.impl.version}</version>
+      <version>${project.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -346,7 +346,7 @@
     <dependency>
       <groupId>io.opentracing</groupId>
       <artifactId>opentracing-api</artifactId>
-      <version>${opentracing.api}</version>
+      <version>${version.io.opentracing}</version>
     </dependency>
 
   </dependencies>

--- a/tomee/tomee-microprofile/tomee-microprofile-webapp/pom.xml
+++ b/tomee/tomee-microprofile/tomee-microprofile-webapp/pom.xml
@@ -42,7 +42,7 @@
     <dependency><!-- needed by myfaces -->
       <groupId>commons-beanutils</groupId>
       <artifactId>commons-beanutils</artifactId>
-      <version>${commons-beanutils.version}</version>
+      <version>${version.commons-beanutils}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
@@ -301,7 +301,7 @@
     <dependency>
       <groupId>org.apache.myfaces.core</groupId>
       <artifactId>myfaces-api</artifactId>
-      <version>${myfaces.version}</version>
+      <version>${version.myfaces}</version>
       <exclusions>
         <exclusion>
           <groupId>org.apache.geronimo.specs</groupId>
@@ -312,7 +312,7 @@
     <dependency>
       <groupId>org.apache.myfaces.core</groupId>
       <artifactId>myfaces-impl</artifactId>
-      <version>${myfaces.version}</version>
+      <version>${version.myfaces}</version>
       <exclusions>
         <exclusion>
           <groupId>org.apache.myfaces.core</groupId>
@@ -331,7 +331,7 @@
     <dependency>
       <groupId>org.apache.openwebbeans</groupId>
       <artifactId>openwebbeans-spi</artifactId>
-      <version>${openwebbeans.version}</version>
+      <version>${version.openwebbeans}</version>
       <classifier>jakarta</classifier>
       <exclusions>
         <exclusion>
@@ -343,7 +343,7 @@
     <dependency>
       <groupId>org.apache.openwebbeans</groupId>
       <artifactId>openwebbeans-impl</artifactId>
-      <version>${openwebbeans.version}</version>
+      <version>${version.openwebbeans}</version>
       <classifier>jakarta</classifier>
       <exclusions>
         <exclusion>
@@ -355,7 +355,7 @@
     <dependency>
       <groupId>org.apache.openwebbeans</groupId>
       <artifactId>openwebbeans-web</artifactId>
-      <version>${openwebbeans.version}</version>
+      <version>${version.openwebbeans}</version>
       <classifier>jakarta</classifier>
       <exclusions>
         <exclusion>
@@ -367,7 +367,7 @@
     <dependency>
       <groupId>org.apache.openwebbeans</groupId>
       <artifactId>openwebbeans-el22</artifactId>
-      <version>${openwebbeans.version}</version>
+      <version>${version.openwebbeans}</version>
       <classifier>jakarta</classifier>
       <exclusions>
         <exclusion>
@@ -379,7 +379,7 @@
     <dependency>
       <groupId>org.apache.openwebbeans</groupId>
       <artifactId>openwebbeans-jsf</artifactId>
-      <version>${openwebbeans.version}</version>
+      <version>${version.openwebbeans}</version>
       <classifier>jakarta</classifier>
       <exclusions>
         <exclusion>

--- a/tomee/tomee-myfaces/pom.xml
+++ b/tomee/tomee-myfaces/pom.xml
@@ -35,13 +35,13 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>jakartaee-api</artifactId>
-      <version>${version.jakartaee-api}</version>
+      <version>${version.tomee.jakartaee-api}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.myfaces.core</groupId>
       <artifactId>myfaces-impl</artifactId>
-      <version>${myfaces.version}</version>
+      <version>${version.myfaces}</version>
       <scope>provided</scope>
       <exclusions>
         <exclusion>

--- a/tomee/tomee-plume-webapp/pom.xml
+++ b/tomee/tomee-plume-webapp/pom.xml
@@ -56,7 +56,7 @@
     <dependency><!-- needed by myfaces -->
       <groupId>commons-beanutils</groupId>
       <artifactId>commons-beanutils</artifactId>
-      <version>${commons-beanutils.version}</version>
+      <version>${version.commons-beanutils}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
@@ -361,7 +361,7 @@
     <dependency>
       <groupId>org.apache.batchee</groupId>
       <artifactId>batchee-jbatch</artifactId>
-      <version>${batchee.version}</version>
+      <version>${version.batchee}</version>
       <scope>runtime</scope>
       <classifier>jakarta</classifier>
       <exclusions>
@@ -374,13 +374,13 @@
     <dependency>
       <groupId>org.apache.geronimo.specs</groupId>
       <artifactId>geronimo-jcache_1.0_spec</artifactId>
-      <version>${geronimo-jcache_1.0_spec.version}</version>
+      <version>${version.geronimo-jcache_1.0_spec}</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-jcs-jcache</artifactId>
-      <version>${jcs.version}</version>
+      <version>${version.commons-jcs-cache}</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
@@ -556,7 +556,7 @@
     <dependency>
       <groupId>org.apache.openejb.shade</groupId>
       <artifactId>quartz-openejb-shade</artifactId>
-      <version>${quartz-openejb-shade.version}</version>
+      <version>${version.quartz-openejb-shade}</version>
       <exclusions>
         <exclusion>
           <groupId>org.quartz-scheduler</groupId>

--- a/tomee/tomee-plus-webapp/pom.xml
+++ b/tomee/tomee-plus-webapp/pom.xml
@@ -53,7 +53,7 @@
     <dependency><!-- needed by myfaces -->
       <groupId>commons-beanutils</groupId>
       <artifactId>commons-beanutils</artifactId>
-      <version>${commons-beanutils.version}</version>
+      <version>${version.commons-beanutils}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
@@ -361,7 +361,7 @@
     <dependency>
       <groupId>org.apache.batchee</groupId>
       <artifactId>batchee-jbatch</artifactId>
-      <version>${batchee.version}</version>
+      <version>${version.batchee}</version>
       <scope>runtime</scope>
       <classifier>jakarta</classifier>
       <exclusions>
@@ -374,13 +374,13 @@
     <dependency>
       <groupId>org.apache.geronimo.specs</groupId>
       <artifactId>geronimo-jcache_1.0_spec</artifactId>
-      <version>${geronimo-jcache_1.0_spec.version}</version>
+      <version>${version.geronimo-jcache_1.0_spec}</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-jcs-jcache</artifactId>
-      <version>${jcs.version}</version>
+      <version>${version.commons-jcs-cache}</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
@@ -407,7 +407,7 @@
     <dependency>
       <groupId>org.apache.myfaces.core</groupId>
       <artifactId>myfaces-api</artifactId>
-      <version>${myfaces.version}</version>
+      <version>${version.myfaces}</version>
       <exclusions>
         <exclusion>
           <groupId>org.apache.geronimo.specs</groupId>
@@ -418,7 +418,7 @@
     <dependency>
       <groupId>org.apache.myfaces.core</groupId>
       <artifactId>myfaces-impl</artifactId>
-      <version>${myfaces.version}</version>
+      <version>${version.myfaces}</version>
       <exclusions>
         <exclusion>
           <groupId>org.apache.myfaces.core</groupId>
@@ -586,7 +586,7 @@
     <dependency>
       <groupId>org.apache.openejb.shade</groupId>
       <artifactId>quartz-openejb-shade</artifactId>
-      <version>${quartz-openejb-shade.version}</version>
+      <version>${version.quartz-openejb-shade}</version>
       <exclusions>
         <exclusion>
           <groupId>org.quartz-scheduler</groupId>

--- a/tomee/tomee-security/pom.xml
+++ b/tomee/tomee-security/pom.xml
@@ -34,7 +34,7 @@
 
   <properties>
     <!-- Reset Jetty Version to not clash with HtmlUnit -->
-    <jetty.version />
+    <version.jetty />
   </properties>
 
   <dependencies>

--- a/tomee/tomee-webaccess/pom.xml
+++ b/tomee/tomee-webaccess/pom.xml
@@ -71,7 +71,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>${junit.version}</version>
+      <version>${version.junit}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -113,7 +113,7 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>${commons-io.version}</version>
+      <version>${version.commons-io}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -191,7 +191,7 @@
     <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
-      <version>${commons-codec.version}</version>
+      <version>${version.commons-codec}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
@@ -208,7 +208,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>jakartaee-api</artifactId>
-      <version>${version.jakartaee-api}</version>
+      <version>${version.tomee.jakartaee-api}</version>
       <classifier>tomcat</classifier>
       <scope>provided</scope>
     </dependency>
@@ -246,7 +246,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>${surefire.version}</version>
+        <version>${version.plugin.surefire}</version>
         <configuration>
           <systemPropertyVariables>
             <arquillian.tomee.path>${project.basedir}/target/arquillian-tomee</arquillian.tomee.path>

--- a/tomee/tomee-webapp/pom.xml
+++ b/tomee/tomee-webapp/pom.xml
@@ -139,7 +139,7 @@
     <dependency><!-- needed by myfaces -->
       <groupId>commons-beanutils</groupId>
       <artifactId>commons-beanutils</artifactId>
-      <version>${commons-beanutils.version}</version>
+      <version>${version.commons-beanutils}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
@@ -418,7 +418,7 @@
     <dependency>
       <groupId>org.apache.myfaces.core</groupId>
       <artifactId>myfaces-api</artifactId>
-      <version>${myfaces.version}</version>
+      <version>${version.myfaces}</version>
       <exclusions>
         <exclusion>
           <groupId>org.apache.geronimo.specs</groupId>
@@ -429,7 +429,7 @@
     <dependency>
       <groupId>org.apache.myfaces.core</groupId>
       <artifactId>myfaces-impl</artifactId>
-      <version>${myfaces.version}</version>
+      <version>${version.myfaces}</version>
       <exclusions>
         <exclusion>
           <groupId>org.apache.myfaces.core</groupId>
@@ -603,7 +603,7 @@
     <dependency>
       <groupId>org.apache.openejb.shade</groupId>
       <artifactId>quartz-openejb-shade</artifactId>
-      <version>${quartz-openejb-shade.version}</version>
+      <version>${version.quartz-openejb-shade}</version>
       <exclusions>
         <exclusion>
           <groupId>org.quartz-scheduler</groupId>

--- a/utils/log4j2-tomee/pom.xml
+++ b/utils/log4j2-tomee/pom.xml
@@ -30,7 +30,7 @@
 
   <properties>
     <tomee.build.name>${project.groupId}.util.log4j2</tomee.build.name>
-    <log4j2.version>2.3</log4j2.version>
+    <version.log4j2>2.19.0</version.log4j2>
     <log4j.groupId>org.apache.logging.log4j</log4j.groupId>
   </properties>
 
@@ -38,13 +38,13 @@
     <dependency>
       <groupId>${log4j.groupId}</groupId>
       <artifactId>log4j-api</artifactId>
-      <version>${log4j2.version}</version>
+      <version>${version.log4j2}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>${log4j.groupId}</groupId>
       <artifactId>log4j-core</artifactId>
-      <version>${log4j2.version}</version>
+      <version>${version.log4j2}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/utils/openejb-core-hibernate/pom.xml
+++ b/utils/openejb-core-hibernate/pom.xml
@@ -107,7 +107,7 @@
     <dependency>
       <groupId>org.ehcache</groupId>
       <artifactId>ehcache</artifactId>
-      <version>${ehcache.version}</version>
+      <version>${version.ehcache}</version>
       <exclusions>
         <!-- Exclude some weird transient dependency to jaxb-runtime from ehcache -->
         <exclusion>
@@ -119,18 +119,18 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-jdk14</artifactId>
-      <version>${slf4j.version}</version>
+      <version>${version.slf4j}</version>
     </dependency>
     <!--
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-log4j12</artifactId>
-      <version>${slf4j.version}</version>
+      <version>${version.slf4j}</version>
     </dependency>
     <dependency>
       <groupId>log4j</groupId>
       <artifactId>log4j</artifactId>
-      <version>${log4j.version}</version>
+      <version>${version.log4j}</version>
     </dependency>
     -->
   </dependencies>


### PR DESCRIPTION
Versions not to be upgraded:
* cxf = 3.5.0 and not 3.5.4

Changed versions:
* jackson = 2.14.0-rc2

Removed properties:

    <pax-url.version>1.3.5</pax-url.version>
    <wagon.version>2.2</wagon.version>
    <plexus.version>1.5.5</plexus.version>
    <plexus-utils.version>3.0.10</plexus-utils.version>
    <org.apache.axis2.version>1.4.1</org.apache.axis2.version>
    <scannotation.version>1.0.2</scannotation.version>
    <geronimo-osgi.version>1.1</geronimo-osgi.version>


