### PR TITLE
Improve compatibility matrix to include DeltaSpike as an Apache alternative to Spring Data JPA

### DIFF
--- a/docs/comparison.adoc
+++ b/docs/comparison.adoc
@@ -105,17 +105,19 @@ Apache Geronimo MicroProfile *(ok with TomEE 7.1.x and 8.x)* +
 
 In bold : Implementations that differ between flavors or between versions
 
-== [[Compatibility]] Compatibility with other implementations
+== [[Compatibility]] Implementations compatibility and alternatives
 
 [options="header",cols="1,1"]
 |===
 |Specifications|Implementations alternatives +
-//(see icons for compatibilities with TomEE 8.x)
-|Jakarta Persistence (JPA)|https://hibernate.org/orm/[Hibernate ORM^] {y} 5.6.x +
-|Jakarta MVC|
+|https://jakarta.ee/specifications/mvc/[Jakarta MVC^] (Controllers)|
 https://eclipse-ee4j.github.io/krazo/[Eclipse Krazo^] {y} 1.x +
-|Other containers (CDI, EJB, JTA, etc.) and frameworks|
-https://spring.io/[Spring^] {y} 5.3.x +
+https://spring.io/[Spring Web MVC^] {y} 5.3.x +
+|https://jakarta.ee/specifications/data/[Jakarta Data^] (Repositories)|
+https://deltaspike.apache.org/[Apache DeltaSpike^] {y} 1.9.x +
+https://spring.io/[Spring Data JPA^] {y} 2.7.x +
+|https://jakarta.ee/specifications/persistence/[Jakarta Persistence] (ORM)|
+https://hibernate.org/orm/[Hibernate ORM^] {y} 5.6.x +
 |===
 
-* Please note that TomEE does not ship with the jars for Hibernate, Jersey, Krazo, Spring.
+* Please note that TomEE does not ship with the jars for DeltaSpike, Hibernate, Jersey, Krazo, Spring.


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5782559/193334109-367adf0e-2f33-43fd-a541-82bc71812166.png)
