### PR TITLE
[TOMEE-4053] TomEE 8.x Dependency properties cleanup

### DIFF
--- a/arquillian/arquillian-openejb-embedded/pom.xml
+++ b/arquillian/arquillian-openejb-embedded/pom.xml
@@ -170,7 +170,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>${surefire.version}</version> <!-- 2.21 snapshot has a bug with classloader due to j9 work -->
+        <version>${version.plugin.surefire}</version> <!-- 2.21 snapshot has a bug with classloader due to j9 work -->
       </plugin>
     </plugins>
   </build>

--- a/arquillian/arquillian-tck/pom.xml
+++ b/arquillian/arquillian-tck/pom.xml
@@ -97,7 +97,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>${surefire.version}</version>
+        <version>${version.plugin.surefire}</version>
         <configuration>
           <threadCount>1</threadCount>
           <reuseForks>true</reuseForks>

--- a/arquillian/arquillian-tomee-common/pom.xml
+++ b/arquillian/arquillian-tomee-common/pom.xml
@@ -66,7 +66,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>javaee-api</artifactId>
-      <version>${version.javaee-api}</version>
+      <version>${version.tomee.javaee-api}</version>
       <type>jar</type>
     </dependency>
 
@@ -84,7 +84,7 @@
     <dependency>
       <groupId>org.apache.xbean</groupId>
       <artifactId>xbean-finder-shaded</artifactId>
-      <version>${xbeanVersion}</version>
+      <version>${version.xbean}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/arquillian/arquillian-tomee-embedded/pom.xml
+++ b/arquillian/arquillian-tomee-embedded/pom.xml
@@ -83,7 +83,7 @@
     <dependency>
       <groupId>org.apache.myfaces.core</groupId>
       <artifactId>myfaces-api</artifactId>
-      <version>${myfaces.version}</version>
+      <version>${version.myfaces}</version>
     </dependency>
 
     <dependency>
@@ -95,7 +95,7 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>${commons-io.version}</version>
+      <version>${version.commons-io}</version>
       <scope>test</scope>
     </dependency>
 

--- a/arquillian/arquillian-tomee-moviefun-example/pom.xml
+++ b/arquillian/arquillian-tomee-moviefun-example/pom.xml
@@ -66,7 +66,7 @@
                 <artifactItem>
                   <groupId>commons-logging</groupId>
                   <artifactId>commons-logging</artifactId>
-                  <version>${commons-logging.version}</version>
+                  <version>${version.commons-logging}</version>
                 </artifactItem>
                 <artifactItem>
                   <groupId>javax.servlet</groupId>
@@ -111,7 +111,7 @@
     <dependency>
       <groupId>org.apache.myfaces.core</groupId>
       <artifactId>myfaces-api</artifactId>
-      <version>${myfaces.version}</version>
+      <version>${version.myfaces}</version>
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>

--- a/arquillian/arquillian-tomee-remote/pom.xml
+++ b/arquillian/arquillian-tomee-remote/pom.xml
@@ -157,7 +157,7 @@
     <dependency>
       <groupId>org.apache.openwebbeans</groupId>
       <artifactId>openwebbeans-impl</artifactId>
-      <version>${openwebbeans.version}</version>
+      <version>${version.openwebbeans}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -231,7 +231,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>${surefire.version}</version>
+        <version>${version.plugin.surefire}</version>
         <configuration>
           <reuseForks>true</reuseForks>
           <forkCount>1</forkCount>

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-config-tests/pom.xml
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-config-tests/pom.xml
@@ -31,7 +31,7 @@
     <dependency>
       <artifactId>commons-lang3</artifactId>
       <groupId>org.apache.commons</groupId>
-      <version>${commons-lang3.version}</version>
+      <version>${version.commons-lang3}</version>
     </dependency>
   </dependencies>
 

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-jms-tests/pom.xml
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-jms-tests/pom.xml
@@ -43,7 +43,7 @@
     <dependency>
       <groupId>org.apache.cxf</groupId>
       <artifactId>cxf-rt-frontend-jaxrs</artifactId>
-      <version>${cxf.version}</version>
+      <version>${version.cxf}</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/pom.xml
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/pom.xml
@@ -31,7 +31,7 @@
     <dependency>
       <artifactId>commons-lang3</artifactId>
       <groupId>org.apache.commons</groupId>
-      <version>${commons-lang3.version}</version>
+      <version>${version.commons-lang3}</version>
     </dependency>
     <dependency>
       <groupId>commons-codec</groupId>

--- a/arquillian/arquillian-tomee-tests/pom.xml
+++ b/arquillian/arquillian-tomee-tests/pom.xml
@@ -502,7 +502,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
-            <version>${surefire.version}</version>
+            <version>${version.plugin.surefire}</version>
             <executions>
               <execution>
                 <id>test-tomee-embedded</id>

--- a/arquillian/ziplock/pom.xml
+++ b/arquillian/ziplock/pom.xml
@@ -53,7 +53,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>javaee-api</artifactId>
-      <version>${version.javaee-api}</version>
+      <version>${version.tomee.javaee-api}</version>
     </dependency>
 
     <dependency>

--- a/container/openejb-core/pom.xml
+++ b/container/openejb-core/pom.xml
@@ -400,7 +400,7 @@
             <manifestEntries>
               <Automatic-Module-Name>${tomee.build.name}</Automatic-Module-Name>
               <Class-Path>openejb-loader-${project.version}.jar openejb-client-${project.version}.jar
-                xbean-finder-shaded-${xbeanVersion}.jar xbean-asm9-shaded-${xbeanVersion}.jar
+                xbean-finder-shaded-${version.xbean}.jar xbean-asm9-shaded-${version.xbean}.jar
               </Class-Path>
               <J2EE-DeploymentFactory-Implementation-Class>
                 org.apache.openejb.config.VmDeploymentFactory
@@ -436,7 +436,7 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
-      <version>${log4j2.version}</version>
+      <version>${version.log4j2}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -550,7 +550,7 @@
     <dependency>
       <groupId>org.apache.geronimo.specs</groupId>
       <artifactId>geronimo-activation_1.1_spec</artifactId>
-      <version>${geronimo-activation_1.1_spec.version}</version>
+      <version>${version.geronimo-activation_1.1_spec}</version>
       <scope>provided</scope>
     </dependency>
     <!-- JavaMail -->
@@ -702,7 +702,7 @@
     <dependency>
       <groupId>org.apache.batchee</groupId>
       <artifactId>batchee-jbatch</artifactId>
-      <version>${batchee.version}</version>
+      <version>${version.batchee}</version>
       <scope>provided</scope>
     </dependency>
 

--- a/deps/cxf-shade/pom.xml
+++ b/deps/cxf-shade/pom.xml
@@ -39,27 +39,27 @@
     <dependency>
       <groupId>org.apache.cxf</groupId>
       <artifactId>cxf-rt-transports-http</artifactId>
-      <version>${cxf.version}</version>
+      <version>${version.cxf}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.cxf</groupId>
       <artifactId>cxf-core</artifactId>
-      <version>${cxf.version}</version>
+      <version>${version.cxf}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.cxf</groupId>
       <artifactId>cxf-rt-rs-client</artifactId>
-      <version>${cxf.version}</version>
+      <version>${version.cxf}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.cxf</groupId>
       <artifactId>cxf-rt-frontend-jaxrs</artifactId>
-      <version>${cxf.version}</version>
+      <version>${version.cxf}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.cxf</groupId>
       <artifactId>cxf-rt-databinding-jaxb</artifactId>
-      <version>${cxf.version}</version>
+      <version>${version.cxf}</version>
     </dependency>
 
     <!-- add transitive dependencies so including this is equivalent to including regular deps -->
@@ -101,7 +101,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>javaee-api</artifactId>
-      <version>${version.javaee-api}</version>
+      <version>${version.tomee.javaee-api}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -229,7 +229,7 @@
           <source>1.8</source>
           <target>1.8</target>
           <dependencies>
-            <dependency>${project.groupId}:javaee-api:jar:${version.javaee-api}</dependency>
+            <dependency>${project.groupId}:javaee-api:jar:${version.tomee.javaee-api}</dependency>
 
             <dependency>org.apache.aries.blueprint:blueprint-parser:jar:1.6.0</dependency>
             <dependency>org.apache.aries.blueprint:org.apache.aries.blueprint.api:jar:1.0.1</dependency>

--- a/examples/concurrency-utils/pom.xml
+++ b/examples/concurrency-utils/pom.xml
@@ -29,7 +29,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <javaee-api.version>8.0</javaee-api.version>
-    <junit.version>4.13.2</junit.version>
+    <version.junit>4.13.2</version.junit>
   </properties>
 
   <dependencies>
@@ -43,7 +43,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>${junit.version}</version>
+      <version>${version.junit}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/examples/connector-ear/pom.xml
+++ b/examples/connector-ear/pom.xml
@@ -26,7 +26,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <version.shrinkwrap.resolver>2.1.0</version.shrinkwrap.resolver>
-    <surefire.version>2.21.0</surefire.version>
+    <version.plugin.surefire>2.21.0</version.plugin.surefire>
   </properties>
 
   <repositories>
@@ -82,7 +82,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>${surefire.version}</version>
+        <version>${version.plugin.surefire}</version>
         <configuration>
           <systemProperties>
             <property>

--- a/examples/jaxrs-json-provider-jettison/pom.xml
+++ b/examples/jaxrs-json-provider-jettison/pom.xml
@@ -29,9 +29,9 @@
 
 
   <properties>
-    <version.javaee-api>8.0</version.javaee-api>
+    <version.tomee.javaee-api>8.0</version.tomee.javaee-api>
     <version.arquillian.bom>1.1.13.Final</version.arquillian.bom>
-    <junit.version>4.13.2</junit.version>
+    <version.junit>4.13.2</version.junit>
   </properties>
 
 
@@ -39,7 +39,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>javaee-api</artifactId>
-      <version>${version.javaee-api}</version>
+      <version>${version.tomee.javaee-api}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -52,7 +52,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>${junit.version}</version>
+      <version>${version.junit}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/examples/jsonb-configuration/pom.xml
+++ b/examples/jsonb-configuration/pom.xml
@@ -26,7 +26,7 @@
   <name>TomEE :: Examples :: Microprofile JSONB Configuration</name>
 
   <properties>
-    <version.javaee-api>8.0</version.javaee-api>
+    <version.tomee.javaee-api>8.0</version.tomee.javaee-api>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
@@ -34,7 +34,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>javaee-api</artifactId>
-      <version>${version.javaee-api}</version>
+      <version>${version.tomee.javaee-api}</version>
       <scope>provided</scope>
     </dependency>
 

--- a/examples/jsonb-custom-serializer/pom.xml
+++ b/examples/jsonb-custom-serializer/pom.xml
@@ -26,7 +26,7 @@
   <name>TomEE :: Examples :: Microprofile JSONB Custom Serializer/Deserializer</name>
 
   <properties>
-    <version.javaee-api>8.0</version.javaee-api>
+    <version.tomee.javaee-api>8.0</version.tomee.javaee-api>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
@@ -34,7 +34,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>javaee-api</artifactId>
-      <version>${version.javaee-api}</version>
+      <version>${version.tomee.javaee-api}</version>
       <scope>provided</scope>
     </dependency>
 

--- a/examples/junit5-arquillian-multiple-tomee/pom.xml
+++ b/examples/junit5-arquillian-multiple-tomee/pom.xml
@@ -26,7 +26,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <tomee.version>8.0.14-SNAPSHOT</tomee.version>
-        <junit.jupiter.version>5.8.0-M1</junit.jupiter.version>
+        <version.junit.jupiter>5.8.0-M1</version.junit.jupiter>
 
         <!-- version >= 1.7.0.Alpha5 is required for JUnit5 -->
         <arquillian.version>1.7.0.Alpha9</arquillian.version>
@@ -94,13 +94,13 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>${junit.jupiter.version}</version>
+            <version>${version.junit.jupiter}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>${junit.jupiter.version}</version>
+            <version>${version.junit.jupiter}</version>
             <scope>test</scope>
         </dependency>
         <!--

--- a/examples/junit5-arquillian-simple-websockets/pom.xml
+++ b/examples/junit5-arquillian-simple-websockets/pom.xml
@@ -26,9 +26,9 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <tomee.version>8.0.14-SNAPSHOT</tomee.version>
-        <tomcat.version>9.0.43</tomcat.version>
+        <tomcat.version>9.0.68</tomcat.version>
 
-        <junit.jupiter.version>5.8.0-M1</junit.jupiter.version>
+        <version.junit.jupiter>5.8.0-M1</version.junit.jupiter>
         <!-- version >= 1.7.0.Alpha5 is required for JUnit5 -->
         <arquillian.version>1.7.0.Alpha9</arquillian.version>
 
@@ -91,13 +91,13 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>${junit.jupiter.version}</version>
+            <version>${version.junit.jupiter}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>${junit.jupiter.version}</version>
+            <version>${version.junit.jupiter}</version>
             <scope>test</scope>
         </dependency>
         <!--

--- a/examples/mp-config-example/pom.xml
+++ b/examples/mp-config-example/pom.xml
@@ -26,8 +26,8 @@
   <name>MicroProfile :: Examples :: Config</name>
 
   <properties>
-    <version.javaee-api>8.0</version.javaee-api>
-    <microprofile.config.version>1.3</microprofile.config.version>
+    <version.tomee.javaee-api>8.0</version.tomee.javaee-api>
+    <version.microprofile.config>1.3</version.microprofile.config>
     <tomee.version>8.0.14-SNAPSHOT</tomee.version>
     <version.arquillian>1.1.13.Final</version.arquillian>
   </properties>
@@ -36,14 +36,14 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>javaee-api</artifactId>
-      <version>${version.javaee-api}</version>
+      <version>${version.tomee.javaee-api}</version>
       <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>org.eclipse.microprofile.config</groupId>
       <artifactId>microprofile-config-api</artifactId>
-      <version>${microprofile.config.version}</version>
+      <version>${version.microprofile.config}</version>
       <scope>provided</scope>
     </dependency>
 

--- a/examples/mp-config-source-database/pom.xml
+++ b/examples/mp-config-source-database/pom.xml
@@ -26,7 +26,7 @@
   <name>MicroProfile :: Examples :: Config Source Database</name>
 
   <properties>
-    <version.javaee-api>8.0-2</version.javaee-api>
+    <version.tomee.javaee-api>8.0-2</version.tomee.javaee-api>
     <version.microprofile>2.0.1</version.microprofile>
     <version.arquillian>1.1.13.Final</version.arquillian>
     <tomee.version>8.0.14-SNAPSHOT</tomee.version>
@@ -36,7 +36,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>javaee-api</artifactId>
-      <version>${version.javaee-api}</version>
+      <version>${version.tomee.javaee-api}</version>
       <scope>provided</scope>
     </dependency>
 

--- a/examples/mp-custom-healthcheck/pom.xml
+++ b/examples/mp-custom-healthcheck/pom.xml
@@ -26,11 +26,11 @@
 
   <properties>
     <arquillian-junit-container.version>1.4.0.Final</arquillian-junit-container.version>
-    <microprofile-health-api.version>1.0</microprofile-health-api.version>
+    <version.microprofile.health-api>1.0</version.microprofile.health-api>
     <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>
     <maven-war-plugin.version>3.1.0</maven-war-plugin.version>
     <javaee-api.version>8.0</javaee-api.version>
-    <junit.version>4.13.2</junit.version>
+    <version.junit>4.13.2</version.junit>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <tomee.version>8.0.14-SNAPSHOT</tomee.version>
@@ -47,7 +47,7 @@
     <dependency>
       <groupId>org.eclipse.microprofile.health</groupId>
       <artifactId>microprofile-health-api</artifactId>
-      <version>${microprofile-health-api.version}</version>
+      <version>${version.microprofile.health-api}</version>
       <scope>provided</scope>
       <exclusions>
         <exclusion>
@@ -60,7 +60,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>${junit.version}</version>
+      <version>${version.junit}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/examples/mp-faulttolerance-fallback/pom.xml
+++ b/examples/mp-faulttolerance-fallback/pom.xml
@@ -23,12 +23,12 @@
   <name>TomEE :: Examples :: Microprofile Fault Tolerance :: Fallback</name>
 
   <properties>
-    <microprofile-fault-tolerance-api.version>1.0</microprofile-fault-tolerance-api.version>
+    <version.microprofile.fault-tolerance-api>1.0</version.microprofile.fault-tolerance-api>
     <arquillian-junit-container.version>1.4.0.Final</arquillian-junit-container.version>
     <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>
     <maven-war-plugin.version>3.1.0</maven-war-plugin.version>
     <javaee-api.version>8.0-2</javaee-api.version>
-    <junit.version>4.13.2</junit.version>
+    <version.junit>4.13.2</version.junit>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <tomee.version>8.0.14-SNAPSHOT</tomee.version>
@@ -44,13 +44,13 @@
     <dependency>
       <groupId>org.eclipse.microprofile.fault-tolerance</groupId>
       <artifactId>microprofile-fault-tolerance-api</artifactId>
-      <version>${microprofile-fault-tolerance-api.version}</version>
+      <version>${version.microprofile.fault-tolerance-api}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>${junit.version}</version>
+      <version>${version.junit}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/examples/mp-faulttolerance-retry/pom.xml
+++ b/examples/mp-faulttolerance-retry/pom.xml
@@ -26,12 +26,12 @@
   <name>TomEE :: Examples :: Microprofile Fault Tolerance :: Retry</name>
 
   <properties>
-    <microprofile-fault-tolerance-api.version>1.0</microprofile-fault-tolerance-api.version>
+    <version.microprofile.fault-tolerance-api>1.0</version.microprofile.fault-tolerance-api>
     <arquillian-junit-container.version>1.4.0.Final</arquillian-junit-container.version>
     <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>
     <maven-war-plugin.version>3.1.0</maven-war-plugin.version>
     <javaee-api.version>8.0</javaee-api.version>
-    <junit.version>4.13.2</junit.version>
+    <version.junit>4.13.2</version.junit>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <tomee.version>8.0.14-SNAPSHOT</tomee.version>
@@ -47,7 +47,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>${junit.version}</version>
+      <version>${version.junit}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/examples/mp-faulttolerance-timeout/pom.xml
+++ b/examples/mp-faulttolerance-timeout/pom.xml
@@ -26,13 +26,13 @@
   <name>TomEE :: Examples :: Microprofile Fault Tolerance :: Timeout</name>
 
   <properties>
-    <microprofile-fault-tolerance-api.version>1.0</microprofile-fault-tolerance-api.version>
+    <version.microprofile.fault-tolerance-api>1.0</version.microprofile.fault-tolerance-api>
     <arquillian-junit-container.version>1.4.0.Final</arquillian-junit-container.version>
     <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>
     <maven-war-plugin.version>3.1.0</maven-war-plugin.version>
     <tomee.version>8.0.14-SNAPSHOT</tomee.version>
     <javaee-api.version>8.0</javaee-api.version>
-    <junit.version>4.13.2</junit.version>
+    <version.junit>4.13.2</version.junit>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
   </properties>
@@ -47,13 +47,13 @@
     <dependency>
       <groupId>org.eclipse.microprofile.fault-tolerance</groupId>
       <artifactId>microprofile-fault-tolerance-api</artifactId>
-      <version>${microprofile-fault-tolerance-api.version}</version>
+      <version>${version.microprofile.fault-tolerance-api}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>${junit.version}</version>
+      <version>${version.junit}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/examples/mp-jsonb-configuration/pom.xml
+++ b/examples/mp-jsonb-configuration/pom.xml
@@ -26,7 +26,7 @@
   <name>TomEE :: Examples :: Microprofile JSONB Configuration</name>
 
   <properties>
-    <version.javaee-api>8.0</version.javaee-api>
+    <version.tomee.javaee-api>8.0</version.tomee.javaee-api>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <tomee.version>8.0.14-SNAPSHOT</tomee.version>
   </properties>
@@ -35,7 +35,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>javaee-api</artifactId>
-      <version>${version.javaee-api}</version>
+      <version>${version.tomee.javaee-api}</version>
       <scope>provided</scope>
     </dependency>
 

--- a/examples/mp-jwt-bean-validation-strongly-typed/pom.xml
+++ b/examples/mp-jwt-bean-validation-strongly-typed/pom.xml
@@ -27,7 +27,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <version.javaee-api>8.0</version.javaee-api>
+    <version.tomee.javaee-api>8.0</version.tomee.javaee-api>
     <tomee.version>8.0.14-SNAPSHOT</tomee.version>
     <version.shrinkwrap.resolver>2.0.0</version.shrinkwrap.resolver>
     <mp-jwt.version>1.1</mp-jwt.version>
@@ -100,7 +100,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>javaee-api</artifactId>
-      <version>${version.javaee-api}</version>
+      <version>${version.tomee.javaee-api}</version>
       <scope>provided</scope>
     </dependency>
 

--- a/examples/mp-jwt-bean-validation/pom.xml
+++ b/examples/mp-jwt-bean-validation/pom.xml
@@ -27,7 +27,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <version.javaee-api>8.0</version.javaee-api>
+    <version.tomee.javaee-api>8.0</version.tomee.javaee-api>
     <tomee.version>8.0.14-SNAPSHOT</tomee.version>
     <version.shrinkwrap.resolver>2.0.0</version.shrinkwrap.resolver>
     <mp-jwt.version>1.1</mp-jwt.version>
@@ -100,7 +100,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>javaee-api</artifactId>
-      <version>${version.javaee-api}</version>
+      <version>${version.tomee.javaee-api}</version>
       <scope>provided</scope>
     </dependency>
 

--- a/examples/mp-metrics-counted/pom.xml
+++ b/examples/mp-metrics-counted/pom.xml
@@ -28,10 +28,10 @@
   <name>TomEE :: Examples :: Microprofile Metrics Counted</name>
 
   <properties>
-    <version.javaee-api>8.0</version.javaee-api>
-    <microprofile.metrics.version>1.1</microprofile.metrics.version>
+    <version.tomee.javaee-api>8.0</version.tomee.javaee-api>
+    <version.microprofile.metrics>1.1</version.microprofile.metrics>
     <version.arquillian.bom>1.1.13.Final</version.arquillian.bom>
-    <junit.version>4.13.2</junit.version>
+    <version.junit>4.13.2</version.junit>
     <docker.image.name>tomee/${project.artifactId}</docker.image.name>
     <docker.file.name>Dockerfile</docker.file.name>
     <tomee.version>8.0.14-SNAPSHOT</tomee.version>
@@ -41,19 +41,19 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>javaee-api</artifactId>
-      <version>${version.javaee-api}</version>
+      <version>${version.tomee.javaee-api}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.microprofile.metrics</groupId>
       <artifactId>microprofile-metrics-api</artifactId>
-      <version>${microprofile.metrics.version}</version>
+      <version>${version.microprofile.metrics}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>${junit.version}</version>
+      <version>${version.junit}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/examples/mp-metrics-gauge/pom.xml
+++ b/examples/mp-metrics-gauge/pom.xml
@@ -25,9 +25,9 @@
   <packaging>war</packaging>
 
   <properties>
-    <junit.version>4.13.2</junit.version>
-    <version.javaee-api>8.0-1</version.javaee-api>
-    <microprofile.metrics.version>1.1.1</microprofile.metrics.version>
+    <version.junit>4.13.2</version.junit>
+    <version.tomee.javaee-api>8.0-1</version.tomee.javaee-api>
+    <version.microprofile.metrics>1.1.1</version.microprofile.metrics>
     <tomee.version>8.0.14-SNAPSHOT</tomee.version>
     <version.arquillian.bom>1.1.13.Final</version.arquillian.bom>
   </properties>
@@ -36,13 +36,13 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>javaee-api</artifactId>
-      <version>${version.javaee-api}</version>
+      <version>${version.tomee.javaee-api}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.microprofile.metrics</groupId>
       <artifactId>microprofile-metrics-api</artifactId>
-      <version>${microprofile.metrics.version}</version>
+      <version>${version.microprofile.metrics}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -54,7 +54,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>${junit.version}</version>
+      <version>${version.junit}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/examples/mp-metrics-histogram/pom.xml
+++ b/examples/mp-metrics-histogram/pom.xml
@@ -28,10 +28,10 @@
   <name>TomEE :: Examples :: Microprofile Metrics Histogram</name>
 
   <properties>
-    <version.javaee-api>8.0</version.javaee-api>
-    <microprofile.metrics.version>1.1</microprofile.metrics.version>
+    <version.tomee.javaee-api>8.0</version.tomee.javaee-api>
+    <version.microprofile.metrics>1.1</version.microprofile.metrics>
     <version.arquillian.bom>1.1.13.Final</version.arquillian.bom>
-    <junit.version>4.13.2</junit.version>
+    <version.junit>4.13.2</version.junit>
     <tomee.version>8.0.14-SNAPSHOT</tomee.version>
   </properties>
 
@@ -39,19 +39,19 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>javaee-api</artifactId>
-      <version>${version.javaee-api}</version>
+      <version>${version.tomee.javaee-api}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.microprofile.metrics</groupId>
       <artifactId>microprofile-metrics-api</artifactId>
-      <version>${microprofile.metrics.version}</version>
+      <version>${version.microprofile.metrics}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>${junit.version}</version>
+      <version>${version.junit}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/examples/mp-metrics-metered/pom.xml
+++ b/examples/mp-metrics-metered/pom.xml
@@ -25,10 +25,10 @@
   <packaging>war</packaging>
 
   <properties>
-    <version.javaee-api>8.0</version.javaee-api>
-    <microprofile.metrics.version>1.1</microprofile.metrics.version>
+    <version.tomee.javaee-api>8.0</version.tomee.javaee-api>
+    <version.microprofile.metrics>1.1</version.microprofile.metrics>
     <version.arquillian.bom>1.1.13.Final</version.arquillian.bom>
-    <junit.version>4.13.2</junit.version>
+    <version.junit>4.13.2</version.junit>
     <tomee.version>8.0.14-SNAPSHOT</tomee.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
@@ -38,7 +38,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>javaee-api</artifactId>
-      <version>${version.javaee-api}</version>
+      <version>${version.tomee.javaee-api}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/examples/mp-metrics-timed/pom.xml
+++ b/examples/mp-metrics-timed/pom.xml
@@ -27,9 +27,9 @@
   <name>TomEE :: Examples :: Microprofile Metrics Timed</name>
 
   <properties>
-    <version.javaee-api>8.0</version.javaee-api>
-    <microprofile.metrics.version>1.1</microprofile.metrics.version>
-    <junit.version>4.13.2</junit.version>
+    <version.tomee.javaee-api>8.0</version.tomee.javaee-api>
+    <version.microprofile.metrics>1.1</version.microprofile.metrics>
+    <version.junit>4.13.2</version.junit>
     <tomee.version>8.0.14-SNAPSHOT</tomee.version>
   </properties>
 
@@ -37,19 +37,19 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>javaee-api</artifactId>
-      <version>${version.javaee-api}</version>
+      <version>${version.tomee.javaee-api}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.microprofile.metrics</groupId>
       <artifactId>microprofile-metrics-api</artifactId>
-      <version>${microprofile.metrics.version}</version>
+      <version>${version.microprofile.metrics}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>${junit.version}</version>
+      <version>${version.junit}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/examples/mp-opentracing-traced/pom.xml
+++ b/examples/mp-opentracing-traced/pom.xml
@@ -27,7 +27,7 @@
   <packaging>war</packaging>
 
   <properties>
-    <version.javaee-api>8.0</version.javaee-api>
+    <version.tomee.javaee-api>8.0</version.tomee.javaee-api>
     <tomee.version>8.0.14-SNAPSHOT</tomee.version>
     <version.arquillian.bom>1.1.13.Final</version.arquillian.bom>
   </properties>
@@ -35,7 +35,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>javaee-api</artifactId>
-      <version>${version.javaee-api}</version>
+      <version>${version.tomee.javaee-api}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/examples/mp-rest-client/README.adoc
+++ b/examples/mp-rest-client/README.adoc
@@ -23,7 +23,7 @@ To use MicroProfile Rest Client you need 3 changes in your project:
  <dependency>
      <groupId>org.eclipse.microprofile.rest.client</groupId>
      <artifactId>microprofile-rest-client-api</artifactId>
-     <version>${microprofile.rest-client.version}</version>
+     <version>${version.microprofile.rest-client}</version>
      <scope>provided</scope>
  </dependency>
 ----

--- a/examples/mp-rest-client/README_es.adoc
+++ b/examples/mp-rest-client/README_es.adoc
@@ -22,7 +22,7 @@ Para utilizar el Cliente Rest de MicroProfile se requieren 3 cambios en su proye
  <dependency>
      <groupId>org.eclipse.microprofile.rest.client</groupId>
      <artifactId>microprofile-rest-client-api</artifactId>
-     <version>${microprofile.rest-client.version}</version>
+     <version>${version.microprofile.rest-client}</version>
      <scope>provided</scope>
  </dependency>
 ----

--- a/examples/mp-rest-client/README_pt.adoc
+++ b/examples/mp-rest-client/README_pt.adoc
@@ -22,7 +22,7 @@ Para usar o MicroProfile Rest Client, são necessárias 3 alterações no seu pr
  <dependency>
      <groupId>org.eclipse.microprofile.rest.client</groupId>
      <artifactId>microprofile-rest-client-api</artifactId>
-     <version>${microprofile.rest-client.version}</version>
+     <version>${version.microprofile.rest-client}</version>
      <scope>provided</scope>
  </dependency>
 ----

--- a/examples/mp-rest-client/pom.xml
+++ b/examples/mp-rest-client/pom.xml
@@ -29,10 +29,10 @@
 
 
   <properties>
-    <microprofile.rest-client.version>1.1</microprofile.rest-client.version>
-    <version.javaee-api>8.0</version.javaee-api>
+    <version.microprofile.rest-client>1.1</version.microprofile.rest-client>
+    <version.tomee.javaee-api>8.0</version.tomee.javaee-api>
     <version.arquillian.bom>1.1.13.Final</version.arquillian.bom>
-    <junit.version>4.13.2</junit.version>
+    <version.junit>4.13.2</version.junit>
     <tomee.version>8.0.14-SNAPSHOT</tomee.version>
   </properties>
 
@@ -41,7 +41,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>javaee-api</artifactId>
-      <version>${version.javaee-api}</version>
+      <version>${version.tomee.javaee-api}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -54,7 +54,7 @@
     <dependency>
       <groupId>org.eclipse.microprofile.rest.client</groupId>
       <artifactId>microprofile-rest-client-api</artifactId>
-      <version>${microprofile.rest-client.version}</version>
+      <version>${version.microprofile.rest-client}</version>
       <scope>provided</scope>
     </dependency>
 
@@ -62,7 +62,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>${junit.version}</version>
+      <version>${version.junit}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/examples/mp-rest-jwt-jwk/pom.xml
+++ b/examples/mp-rest-jwt-jwk/pom.xml
@@ -27,7 +27,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <version.javaee-api>8.0</version.javaee-api>
+    <version.tomee.javaee-api>8.0</version.tomee.javaee-api>
     <tomee.version>8.0.14-SNAPSHOT</tomee.version>
     <version.shrinkwrap.resolver>2.0.0</version.shrinkwrap.resolver>
     <mp-jwt.version>1.1</mp-jwt.version>
@@ -101,7 +101,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>javaee-api</artifactId>
-      <version>${version.javaee-api}</version>
+      <version>${version.tomee.javaee-api}</version>
       <scope>provided</scope>
     </dependency>
 

--- a/examples/mp-rest-jwt-principal/pom.xml
+++ b/examples/mp-rest-jwt-principal/pom.xml
@@ -28,8 +28,8 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <tomee.version>8.0.14-SNAPSHOT</tomee.version>
-    <version.javaee-api>8.0</version.javaee-api>
-    <junit.version>4.23</junit.version>
+    <version.tomee.javaee-api>8.0</version.tomee.javaee-api>
+    <version.junit>4.23</version.junit>
     <arquillian-bom.version>1.4.1.Final</arquillian-bom.version>
     <mp-jwt.version>1.1.1</mp-jwt.version>
     <mp-config.version>1.0</mp-config.version>
@@ -94,7 +94,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>javaee-api</artifactId>
-      <version>${version.javaee-api}</version>
+      <version>${version.tomee.javaee-api}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -118,7 +118,7 @@
     <dependency>
       <groupId>com.nimbusds</groupId>
       <artifactId>nimbus-jose-jwt</artifactId>
-      <version>${junit.version}</version>
+      <version>${version.junit}</version>
       <scope>test</scope>
     </dependency>
 

--- a/examples/mp-rest-jwt-public-key/pom.xml
+++ b/examples/mp-rest-jwt-public-key/pom.xml
@@ -28,7 +28,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <tomee.version>8.0.14-SNAPSHOT</tomee.version>
-    <version.javaee-api>8.0</version.javaee-api>
+    <version.tomee.javaee-api>8.0</version.tomee.javaee-api>
     <version.shrinkwrap.resolver>2.0.0</version.shrinkwrap.resolver>
     <mp-jwt.version>1.1</mp-jwt.version>
   </properties>
@@ -100,7 +100,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>javaee-api</artifactId>
-      <version>${version.javaee-api}</version>
+      <version>${version.tomee.javaee-api}</version>
       <scope>provided</scope>
     </dependency>
 

--- a/examples/mp-rest-jwt/pom.xml
+++ b/examples/mp-rest-jwt/pom.xml
@@ -27,7 +27,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <version.javaee-api>8.0</version.javaee-api>
+    <version.tomee.javaee-api>8.0</version.tomee.javaee-api>
     <tomee.version>8.0.14-SNAPSHOT</tomee.version>
     <version.shrinkwrap.resolver>2.0.0</version.shrinkwrap.resolver>
     <mp-jwt.version>1.0</mp-jwt.version>
@@ -103,7 +103,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>javaee-api</artifactId>
-      <version>${version.javaee-api}</version>
+      <version>${version.tomee.javaee-api}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/examples/singleton-startup-ordering/pom.xml
+++ b/examples/singleton-startup-ordering/pom.xml
@@ -29,9 +29,9 @@
 
 
   <properties>
-    <version.javaee-api>8.0</version.javaee-api>
+    <version.tomee.javaee-api>8.0</version.tomee.javaee-api>
     <version.arquillian.bom>1.1.13.Final</version.arquillian.bom>
-    <junit.version>4.13.2</junit.version>
+    <version.junit>4.13.2</version.junit>
   </properties>
 
 
@@ -39,13 +39,13 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>javaee-api</artifactId>
-      <version>${version.javaee-api}</version>
+      <version>${version.tomee.javaee-api}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>${junit.version}</version>
+      <version>${version.junit}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/examples/websocket-tls-basic-auth/pom.xml
+++ b/examples/websocket-tls-basic-auth/pom.xml
@@ -31,8 +31,8 @@
     <javaee-api.version>8.0</javaee-api.version>
     <javax.websocket-api.version>1.1</javax.websocket-api.version>
     <tomee.classifier>webprofile</tomee.classifier>
-    <tomcat.version>9.0.12</tomcat.version>
-    <junit.version>4.13.2</junit.version>
+    <tomcat.version>9.0.68</tomcat.version>
+    <version.junit>4.13.2</version.junit>
   </properties>
 
   <dependencies>
@@ -64,7 +64,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>${junit.version}</version>
+      <version>${version.junit}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/itests/ejb/pom.xml
+++ b/itests/ejb/pom.xml
@@ -79,7 +79,7 @@
     <dependency>
       <groupId>org.apache.activemq</groupId>
       <artifactId>activemq-broker</artifactId>
-      <version>${org.apache.activemq.version}</version>
+      <version>${version.activemq}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/itests/failover-ejb/pom.xml
+++ b/itests/failover-ejb/pom.xml
@@ -38,7 +38,7 @@
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>javaee-api</artifactId>
-      <version>${version.javaee-api}</version>
+      <version>${version.tomee.javaee-api}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/maven/jarstxt-maven-plugin/pom.xml
+++ b/maven/jarstxt-maven-plugin/pom.xml
@@ -50,7 +50,7 @@ Licensed to the Apache Software Foundation (ASF) under one or more
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>${commons-lang3.version}</version>
+      <version>${version.commons-lang3}</version>
     </dependency>
   </dependencies>
 

--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -30,7 +30,7 @@
   <name>TomEE :: Maven Plugins</name>
 
   <properties>
-    <maven.version>2.2.1</maven.version>
+    <version.maven>2.2.1</version.maven>
   </properties>
 
   <modules>
@@ -58,27 +58,27 @@
       <dependency>
         <groupId>org.apache.maven</groupId>
         <artifactId>maven-plugin-api</artifactId>
-        <version>${maven.version}</version>
+        <version>${version.maven}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.maven</groupId>
         <artifactId>maven-project</artifactId>
-        <version>${maven.version}</version>
+        <version>${version.maven}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.maven</groupId>
         <artifactId>maven-core</artifactId>
-        <version>${maven.version}</version>
+        <version>${version.maven}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.maven</groupId>
         <artifactId>maven-artifact</artifactId>
-        <version>${maven.version}</version>
+        <version>${version.maven}</version>
       </dependency>
       <dependency>
         <groupId>org.sonatype.aether</groupId>
         <artifactId>aether-api</artifactId>
-        <version>${aether.version}</version>
+        <version>${version.aether}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.tomee</groupId>

--- a/maven/tomee-webapp-archetype/pom.xml
+++ b/maven/tomee-webapp-archetype/pom.xml
@@ -43,7 +43,7 @@ Licensed to the Apache Software Foundation (ASF) under one or more
                 <replace file="${project.build.directory}/classes/archetype-resources/pom.xml" token="[TOMEE]" value="${project.version}" />
                 <replace file="${project.build.directory}/classes/archetype-resources/pom.xml" token="[OPENEJB]" value="${project.version}" />
                 <replace file="${project.build.directory}/classes/archetype-resources/pom.xml" token="[OPENJPA]" value="${version.openjpa}" />
-                <replace file="${project.build.directory}/classes/archetype-resources/pom.xml" token="[JAVAEE]" value="${version.javaee-api}" />
+                <replace file="${project.build.directory}/classes/archetype-resources/pom.xml" token="[JAVAEE]" value="${version.tomee.javaee-api}" />
               </target>
             </configuration>
           </execution>

--- a/mp-jwt/pom.xml
+++ b/mp-jwt/pom.xml
@@ -34,19 +34,19 @@
     <dependency>
       <groupId>org.eclipse.microprofile.jwt</groupId>
       <artifactId>microprofile-jwt-auth-api</artifactId>
-      <version>${microprofile.jwt.version}</version>
+      <version>${version.microprofile.jwt}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.microprofile.config</groupId>
       <artifactId>microprofile-config-api</artifactId>
-      <version>${microprofile.config.version}</version>
+      <version>${version.microprofile.config}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.tomee</groupId>
       <artifactId>javaee-api</artifactId>
-      <version>${version.javaee-api}</version>
+      <version>${version.tomee.javaee-api}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -93,39 +93,13 @@
     <!-- allows release plugin to be overridden -->
     <arguments />
     <tomee.version>${project.version}</tomee.version>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
-    <surefire.version>3.0.0-M5</surefire.version>
 
     <!-- for the default name of the module. Needs to be overridden -->
     <tomee.build.name>${project.groupId}.${project.artifactId}</tomee.build.name>
 
     <!-- To easily change the javaee api version -->
-    <version.javaee-api>8.0-6</version.javaee-api>
+    <version.tomee.javaee-api>8.0-6</version.tomee.javaee-api>
     <version.tomee-patch-plugin>0.9</version.tomee-patch-plugin>
-    
-    <!--
-      Activation and JavaMail are both API and IMPL so we don't have them in the javaee-api uber jar.
-      We decided to add them here in the project so we can patch/update the 2 libraries without having
-      to update and release the javaee-api.jar. Different lifecycle.
-    -->
-    <geronimo-activation_1.1_spec.version>1.1</geronimo-activation_1.1_spec.version>
-    <geronimo-javamail_1.6_spec.version>1.0.1</geronimo-javamail_1.6_spec.version>
-    <geronimo-javamail_1.6_mail.version>1.0.1</geronimo-javamail_1.6_mail.version>
-
-    <!-- not part of EE APIs so we have to add it manually -->
-    <geronimo-jcache_1.0_spec.version>1.0-alpha-1</geronimo-jcache_1.0_spec.version>
-
-    <openwebbeans.version>2.0.27</openwebbeans.version>
-    <jcs.version>2.1</jcs.version>
-    <johnzon.version>1.2.19</johnzon.version>
-    <quartz-openejb-shade.version>2.2.4</quartz-openejb-shade.version>
-
-    <!-- Maven module versions -->
-    <maven-bundle-plugin.version>3.3.0</maven-bundle-plugin.version>
-
-    <!-- This is used by a manifest classpath entry -->
-    <xbeanVersion>4.22</xbeanVersion>
 
     <!-- OSGi bundles properties -->
     <openejb.bundle.activator />
@@ -141,117 +115,131 @@
     <openejb.osgi.dynamic.import>${openejb.osgi.dynamic.import.pkg}</openejb.osgi.dynamic.import>
     <openejb.osgi.symbolic.name>${project.groupId}.${project.artifactId}</openejb.osgi.symbolic.name>
 
-    <batchee.version>1.0.2</batchee.version>
-
+    <!-- arquillian related -->
     <version.arquillian>1.1.13.Final</version.arquillian>
+    <version.arquillian.bom>1.1.13.Final</version.arquillian.bom>
     <version.shrinkwrap.descriptor>2.0.0</version.shrinkwrap.descriptor>
+    <version.shrinkwrap.resolver.bom>3.1.4</version.shrinkwrap.resolver.bom>
     <version.shrinkwrap.shrinkwrap>1.2.6</version.shrinkwrap.shrinkwrap>
 
-    <tomcat.version>9.0.68</tomcat.version>
+    <version.quartz-openejb-shade>2.2.4</version.quartz-openejb-shade>
+    <version.axiom>1.3.0</version.axiom>
+    <version.xbean>4.22</version.xbean>
+    <version.groovy>2.4.12</version.groovy>
+    <version.ecj>4.6.1</version.ecj>
+    <version.jetty>9.4.49.v20220914</version.jetty>
+    <version.ehcache>2.10.6</version.ehcache>
+    <version.junit>4.13.2</version.junit>
+    <version.junit.jupiter>5.8.2</version.junit.jupiter>
+    <version.osgi>4.2.0</version.osgi>
+    <version.aether>1.13.1</version.aether>
+    <version.xalan>2.7.2</version.xalan>
 
-    <cxf.version>3.4.8</cxf.version>
-    <ehcache.version>2.10.6</ehcache.version>
-    <!-- used by cxf for security (replay attack) -->
-    <jetty.version>9.4.49.v20220914</jetty.version>
-    <pax-url.version>1.3.5</pax-url.version>
-    <aether.version>1.13.1</aether.version>
-    <maven.version>3.0.5</maven.version>
-    <wagon.version>2.2</wagon.version>
-    <plexus.version>1.5.5</plexus.version>
-    <plexus-utils.version>3.0.10</plexus-utils.version>
-
-    <!--
-      Old CXF versions were only compatible with 1.3.x. But JDK 9+ requires 1.4.x and higher
-      We used to have some weird exclusions to not run test, but we should try to upgrade to 1.4.x anyway
-    -->
-    <saaj-impl.version>1.5.1</saaj-impl.version>
-
-    <!--
-    - http://docs.codehaus.org/display/MAVENUSER/POM+Element+for+Source+File+Encoding
-    -->
+    <!-- Project encoding -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
+    <!-- Java SE version -->
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+
+    <!-- Plugins and Build -->
+    <version.maven>3.0.5</version.maven>
+    <version.plugin.bundle>3.3.0</version.plugin.bundle>
+    <version.plugin.javadoc>3.0.1</version.plugin.javadoc>
+    <version.asciidoclet>1.5.0</version.asciidoclet>
+    <version.plugin.surefire>3.0.0-M5</version.plugin.surefire>
+
+    <!-- Logging frameworks -->
+    <version.slf4j>1.7.36</version.slf4j>
+    <version.log4j>1.2.17</version.log4j>
+    <version.log4j2>2.19.0</version.log4j2>
+    <version.commons-logging>1.2</version.commons-logging>
+    <version.commons-logging-api>1.1</version.commons-logging-api>
+
     <!-- Apache Commons -->
-    <commons-beanutils.version>1.9.4</commons-beanutils.version>
-    <commons-cli.version>1.5.0</commons-cli.version>
-    <commons-logging.version>1.2</commons-logging.version>
-    <commons-logging-api.version>1.1</commons-logging-api.version>
-    <!--
-      'QuartzPersistenceForEJBTimersTest' is unable to obtain DB connection with
-      commons-dbcp.version > 2.3.0
-    -->
-    <commons-dbcp.version>2.9.0</commons-dbcp.version>
-    <commons-pool.version>2.11.1</commons-pool.version>
-    <commons-collections.version>3.2.2</commons-collections.version>
-    <commons-codec.version>1.15</commons-codec.version>
-    <commons-fileupload.version>1.4</commons-fileupload.version>
-    <commons-discovery.version>0.5</commons-discovery.version>
-    <commons-lang3.version>3.12.0</commons-lang3.version>
-    <commons-io.version>2.11.0</commons-io.version>
-    <commons-net.version>3.8.0</commons-net.version>
+    <version.commons-beanutils>1.9.4</version.commons-beanutils>
+    <version.commons-cli>1.5.0</version.commons-cli>
+    <version.commons-codec>1.15</version.commons-codec>
+    <version.commons-collections>3.2.2</version.commons-collections>
+    <version.commons-dbcp2>2.9.0</version.commons-dbcp2>
+    <version.commons-discovery>0.5</version.commons-discovery>
+    <version.commons-fileupload>1.4</version.commons-fileupload>
+    <version.commons-io>2.11.0</version.commons-io>
+    <version.commons-jcs-cache>2.1</version.commons-jcs-cache>
+    <version.commons-lang3>3.12.0</version.commons-lang3>
+    <version.commons-net>3.8.0</version.commons-net>
+    <version.commons-pool2>2.11.1</version.commons-pool2>
 
-    <bval.version>2.0.5</bval.version>
-    <org.apache.activemq.version>5.16.5</org.apache.activemq.version>
-    <junit.version>4.13.2</junit.version>
-    <junit.jupiter.version>5.8.2</junit.jupiter.version>
-    <org.apache.axis2.version>1.4.1</org.apache.axis2.version>
-    <scannotation.version>1.0.2</scannotation.version>
-    <geronimo.connector.version>3.1.5</geronimo.connector.version>
-    <geronimo-osgi.version>1.1</geronimo-osgi.version>
-    <myfaces.version>2.3.10</myfaces.version>
-    <mojarra.version>2.3.18</mojarra.version>
-    <slf4j.version>1.7.36</slf4j.version>
-    <log4j.version>1.2.17</log4j.version>
-    <log4j2.version>2.19.0</log4j2.version>
-    <osgi.framework.version>4.2.0</osgi.framework.version>
-    <version.axiom>1.3.0</version.axiom>
-    <version.xalan>2.7.2</version.xalan>
-    <version.groovy>2.4.12</version.groovy>
-    <version.ecj>4.6.1</version.ecj>
+    <!-- Micro Profile API -->
+    <version.microprofile>2.0</version.microprofile>
+    <version.microprofile.config>1.3</version.microprofile.config>
+    <version.microprofile.fault-tolerance>1.1.4</version.microprofile.fault-tolerance>
+    <version.microprofile.health>1.0</version.microprofile.health>
+    <version.microprofile.jwt>1.1.1</version.microprofile.jwt>
+    <version.microprofile.metrics>1.1.1</version.microprofile.metrics>
+    <version.microprofile.openapi>1.1.2</version.microprofile.openapi>
+    <version.microprofile.opentracing>1.1.2</version.microprofile.opentracing>
+    <version.microprofile.rest-client>1.3.3</version.microprofile.rest-client>
 
-    <version.krazo>1.1.1</version.krazo>
-    <version.deltaspike>1.9.6</version.deltaspike>
-    <version.openjpa>3.2.2</version.openjpa>
-    <version.eclipselink>2.7.11</version.eclipselink>
-    <version.hibernate>5.6.12.Final</version.hibernate>
-    <version.derby>10.14.2.0</version.derby>
-    <version.hsqldb>2.7.1</version.hsqldb>
+    <version.io.opentracing>0.33.0</version.io.opentracing>
 
-    <!-- arquillian related -->
-    <version.arquillian.bom>1.1.13.Final</version.arquillian.bom>
-    <version.shrinkwrap.resolver.bom>3.1.4</version.shrinkwrap.resolver.bom>
-
-    <!-- Micro Profile -->
-    <microprofile.version>2.0</microprofile.version>
-    <microprofile.config.version>1.3</microprofile.config.version>
-    <microprofile.config.impl.version>1.2.1</microprofile.config.impl.version>
-    <microprofile.jwt.version>1.1.1</microprofile.jwt.version>
-    <microprofile.jwt.impl.version>${project.version}</microprofile.jwt.impl.version>
-    <!-- 1.1 Implementation not started yet -->
-    <microprofile.fault-tolerance.version>1.1.4</microprofile.fault-tolerance.version>
-    <microprofile.fault-tolerance.impl.version>1.2.1</microprofile.fault-tolerance.impl.version>
-    <microprofile.health.version>1.0</microprofile.health.version>
-    <microprofile.health.impl.version>1.0.1</microprofile.health.impl.version>
-    <microprofile.metrics.version>1.1.1</microprofile.metrics.version>
-    <microprofile.metrics.impl.version>1.0.2</microprofile.metrics.impl.version>
-    <microprofile.rest-client.version>1.3.3</microprofile.rest-client.version>
-    <microprofile.rest-client.impl.version>${cxf.version}</microprofile.rest-client.impl.version>
-    <microprofile.openapi.version>1.1.2</microprofile.openapi.version>
-    <microprofile.openapi.impl.version>1.0.12</microprofile.openapi.impl.version>
-    <microprofile.opentracing.version>1.1.2</microprofile.opentracing.version>
-    <microprofile.opentracing.impl.version>1.0.0</microprofile.opentracing.impl.version>
-    <opentracing.api>0.31.0</opentracing.api>
+    <!-- Micro Profile Impl -->
+    <version.microprofile.impl.config>1.2.1</version.microprofile.impl.config>
+    <version.microprofile.impl.fault-tolerance>1.2.1</version.microprofile.impl.fault-tolerance>
+    <version.microprofile.impl.health>1.0.1</version.microprofile.impl.health>
+    <version.microprofile.impl.metrics>1.0.2</version.microprofile.impl.metrics>
+    <version.microprofile.impl.openapi>1.0.12</version.microprofile.impl.openapi>
+    <version.microprofile.impl.opentracing>1.0.0</version.microprofile.impl.opentracing>
 
     <!-- Jackson required by OpenAPI Impl -->
     <version.jackson>2.14.0-rc2</version.jackson>
-    <version.jackson.dataformat>2.14.0-rc2</version.jackson.dataformat>
-    <!-- required by Jackson dataformat yaml -->
-    <snakeyaml.version>1.33</snakeyaml.version>
+    <version.snakeyaml>1.33</version.snakeyaml>
 
-    <!-- Javadoc & Asciidoclet -->
-    <javadoc.version>3.0.1</javadoc.version>
-    <asciidoclet.version>1.5.0</asciidoclet.version>
+    <!-- Jakarta EE API -->
+    <version.javax.activation>1.2.0</version.javax.activation>
+    <version.javax.mail>1.6.2</version.javax.mail>
+    <version.jakarta.activation>1.2.2</version.jakarta.activation>
+    <version.jakarta.mail>1.6.7</version.jakarta.mail>
+    <version.geronimo-activation_1.1_spec>1.1</version.geronimo-activation_1.1_spec>
+    <version.geronimo-javamail_1.6_spec>1.0.1</version.geronimo-javamail_1.6_spec>
+    <!-- API not in EE -->
+    <version.javax.mvc>1.0.0</version.javax.mvc>
+    <version.jakarta.mvc>1.1.0</version.jakarta.mvc>
+    <version.javax.jcache>1.1.1</version.javax.jcache>
+    <version.geronimo-jcache_1.0_spec>1.0-alpha-1</version.geronimo-jcache_1.0_spec>
+
+    <!-- Jakarta EE Impl -->
+    <tomcat.version>9.0.68</tomcat.version>
+    <!-- com.sun -->
+    <version.impl.activation>1.2.2</version.impl.activation>
+    <version.impl.saaj>1.5.1</version.impl.saaj>
+    <!-- org.apache -->
+    <version.activemq>5.16.5</version.activemq>
+    <version.batchee>1.0.2</version.batchee>
+    <version.bval>2.0.5</version.bval>
+    <version.cxf>3.4.8</version.cxf>
+    <version.geronimo.components>3.1.5</version.geronimo.components>
+    <version.geronimo-javamail_1.6_mail>1.0.1</version.geronimo-javamail_1.6_mail>
+    <version.johnzon>1.2.19</version.johnzon>
+    <version.myfaces>2.3.10</version.myfaces>
+    <version.openjpa>3.2.2</version.openjpa>
+    <version.openwebbeans>2.0.27</version.openwebbeans>
+    <!-- org.eclipse -->
+    <version.eclipselink>2.7.11</version.eclipselink>
+    <!-- org.glassfish -->
+    <version.mojarra>2.3.18</version.mojarra>
+    <!-- org.hibernate -->
+    <version.hibernate.orm>5.6.12.Final</version.hibernate.orm>
+    <version.hibernate.validator>6.2.5.Final</version.hibernate.validator>
+    <!-- Impl not in EE -->
+    <version.krazo>1.1.1</version.krazo>
+    <version.deltaspike>1.9.6</version.deltaspike>
+
+    <!-- JDBC Drivers -->
+    <version.derby>10.14.2.0</version.derby>
+    <version.hsqldb>2.7.1</version.hsqldb>
+
   </properties>
 
   <build>
@@ -267,7 +255,7 @@
         <plugin>
           <groupId>org.apache.felix</groupId>
           <artifactId>maven-bundle-plugin</artifactId>
-          <version>${maven-bundle-plugin.version}</version>
+          <version>${version.plugin.bundle}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -396,7 +384,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>${surefire.version}</version>
+          <version>${version.plugin.surefire}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -920,13 +908,13 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
-            <version>${javadoc.version}</version>
+            <version>${version.plugin.javadoc}</version>
             <configuration>
               <doclet>org.asciidoctor.Asciidoclet</doclet>
               <docletArtifact>
                 <groupId>org.asciidoctor</groupId>
                 <artifactId>asciidoclet</artifactId>
-                <version>${asciidoclet.version}</version>
+                <version>${version.asciidoclet}</version>
               </docletArtifact>
               <additionalOptions>
                 <additionalOption>--base-dir ${basedir}</additionalOption>
@@ -1004,7 +992,7 @@
       <dependency>
         <groupId>${project.groupId}</groupId>
         <artifactId>javaee-api</artifactId>
-        <version>${version.javaee-api}</version>
+        <version>${version.tomee.javaee-api}</version>
         <classifier>tomcat</classifier>
         <exclusions>
           <exclusion>
@@ -1016,7 +1004,7 @@
       <dependency>
         <groupId>${project.groupId}</groupId>
         <artifactId>javaee-api</artifactId>
-        <version>${version.javaee-api}</version>
+        <version>${version.tomee.javaee-api}</version>
         <exclusions>
           <exclusion>
             <groupId>org.apache.geronimo.specs</groupId>
@@ -1032,82 +1020,82 @@
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-server</artifactId>
-        <version>${jetty.version}</version>
+        <version>${version.jetty}</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-continuation</artifactId>
-        <version>${jetty.version}</version>
+        <version>${version.jetty}</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-jsp-2.1</artifactId>
-        <version>${jetty.version}</version>
+        <version>${version.jetty}</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-plus</artifactId>
-        <version>${jetty.version}</version>
+        <version>${version.jetty}</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-jndi</artifactId>
-        <version>${jetty.version}</version>
+        <version>${version.jetty}</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-webapp</artifactId>
-        <version>${jetty.version}</version>
+        <version>${version.jetty}</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-io</artifactId>
-        <version>${jetty.version}</version>
+        <version>${version.jetty}</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-http</artifactId>
-        <version>${jetty.version}</version>
+        <version>${version.jetty}</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-security</artifactId>
-        <version>${jetty.version}</version>
+        <version>${version.jetty}</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-servlet</artifactId>
-        <version>${jetty.version}</version>
+        <version>${version.jetty}</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-servlets</artifactId>
-        <version>${jetty.version}</version>
+        <version>${version.jetty}</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-util</artifactId>
-        <version>${jetty.version}</version>
+        <version>${version.jetty}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.bval</groupId>
         <artifactId>bval-jsr</artifactId>
-        <version>${bval.version}</version>
+        <version>${version.bval}</version>
       </dependency>
       <dependency>
         <groupId>commons-cli</groupId>
         <artifactId>commons-cli</artifactId>
-        <version>${commons-cli.version}</version>
+        <version>${version.commons-cli}</version>
       </dependency>
       <dependency>
         <groupId>commons-logging</groupId>
         <artifactId>commons-logging-api</artifactId>
-        <version>${commons-logging-api.version}</version>
+        <version>${version.commons-logging-api}</version>
       </dependency>
       <dependency>
         <groupId>commons-logging</groupId>
         <artifactId>commons-logging</artifactId>
-        <version>${commons-logging.version}</version>
+        <version>${version.commons-logging}</version>
         <exclusions>
           <exclusion>
             <groupId>javax.servlet</groupId>
@@ -1137,25 +1125,25 @@
       <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
-        <version>${junit.version}</version>
+        <version>${version.junit}</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.junit.jupiter</groupId>
         <artifactId>junit-jupiter-api</artifactId>
-        <version>${junit.jupiter.version}</version>
+        <version>${version.junit.jupiter}</version>
         <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>org.junit.jupiter</groupId>
         <artifactId>junit-jupiter-engine</artifactId>
-        <version>${junit.jupiter.version}</version>
+        <version>${version.junit.jupiter}</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.junit.vintage</groupId>
         <artifactId>junit-vintage-engine</artifactId>
-        <version>${junit.jupiter.version}</version>
+        <version>${version.junit.jupiter}</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -1167,7 +1155,7 @@
       <dependency>
         <groupId>org.apache.activemq</groupId>
         <artifactId>activemq-jdbc-store</artifactId>
-        <version>${org.apache.activemq.version}</version>
+        <version>${version.activemq}</version>
         <exclusions>
           <exclusion>
             <groupId>org.apache.derby</groupId>
@@ -1178,7 +1166,7 @@
       <dependency>
         <groupId>org.apache.activemq</groupId>
         <artifactId>activemq-ra</artifactId>
-        <version>${org.apache.activemq.version}</version>
+        <version>${version.activemq}</version>
         <exclusions>
           <exclusion>
             <groupId>org.springframework</groupId>
@@ -1229,12 +1217,12 @@
       <dependency>
         <groupId>commons-net</groupId>
         <artifactId>commons-net</artifactId>
-        <version>${commons-net.version}</version>
+        <version>${version.commons-net}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.activemq</groupId>
         <artifactId>activemq-broker</artifactId>
-        <version>${org.apache.activemq.version}</version>
+        <version>${version.activemq}</version>
         <exclusions>
           <exclusion>
             <groupId>org.fusesource.mqtt-client</groupId>
@@ -1392,7 +1380,7 @@
       <dependency>
         <groupId>org.apache.geronimo.components</groupId>
         <artifactId>geronimo-connector</artifactId>
-        <version>${geronimo.connector.version}</version>
+        <version>${version.geronimo.components}</version>
         <exclusions>
           <exclusion>
             <groupId>org.apache.geronimo.specs</groupId>
@@ -1415,7 +1403,7 @@
       <dependency>
         <groupId>org.apache.geronimo.components</groupId>
         <artifactId>geronimo-transaction</artifactId>
-        <version>${geronimo.connector.version}</version>
+        <version>${version.geronimo.components}</version>
         <exclusions>
           <exclusion>
             <groupId>org.apache.geronimo.specs</groupId>
@@ -1439,12 +1427,12 @@
       <dependency>
         <groupId>org.apache.geronimo.specs</groupId>
         <artifactId>geronimo-javamail_1.6_spec</artifactId>
-        <version>${geronimo-javamail_1.6_spec.version}</version>
+        <version>${version.geronimo-javamail_1.6_spec}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.geronimo.javamail</groupId>
         <artifactId>geronimo-javamail_1.6_mail</artifactId>
-        <version>${geronimo-javamail_1.6_mail.version}</version>
+        <version>${version.geronimo-javamail_1.6_mail}</version>
         <exclusions>
           <exclusion>
             <groupId>org.apache.geronimo.javamail</groupId>
@@ -1520,12 +1508,12 @@
       <dependency>
         <groupId>org.apache.xbean</groupId>
         <artifactId>xbean-finder-shaded</artifactId>
-        <version>${xbeanVersion}</version>
+        <version>${version.xbean}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.xbean</groupId>
         <artifactId>xbean-asm9-shaded</artifactId>
-        <version>${xbeanVersion}</version>
+        <version>${version.xbean}</version>
         <exclusions>
           <exclusion>
             <groupId>org.ow2.asm</groupId>
@@ -1540,12 +1528,12 @@
       <dependency>
         <groupId>org.apache.xbean</groupId>
         <artifactId>xbean-naming</artifactId>
-        <version>${xbeanVersion}</version>
+        <version>${version.xbean}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.xbean</groupId>
         <artifactId>xbean-bundleutils</artifactId>
-        <version>${xbeanVersion}</version>
+        <version>${version.xbean}</version>
         <exclusions>
           <exclusion>
             <groupId>org.slf4j</groupId>
@@ -1556,12 +1544,12 @@
       <dependency>
         <groupId>org.apache.xbean</groupId>
         <artifactId>xbean-spring</artifactId>
-        <version>${xbeanVersion}</version>
+        <version>${version.xbean}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.xbean</groupId>
         <artifactId>xbean-reflect</artifactId>
-        <version>${xbeanVersion}</version>
+        <version>${version.xbean}</version>
         <exclusions>
           <exclusion>
             <groupId>mx4j</groupId>
@@ -1582,12 +1570,12 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-dbcp2</artifactId>
-        <version>${commons-dbcp.version}</version>
+        <version>${version.commons-dbcp2}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-pool2</artifactId>
-        <version>${commons-pool.version}</version>
+        <version>${version.commons-pool2}</version>
       </dependency>
       <dependency>
         <artifactId>xmlsec</artifactId>
@@ -1613,7 +1601,7 @@
       <dependency>
         <groupId>org.apache.openejb.shade</groupId>
         <artifactId>quartz-openejb-shade</artifactId>
-        <version>${quartz-openejb-shade.version}</version>
+        <version>${version.quartz-openejb-shade}</version>
         <exclusions>
           <exclusion>
             <groupId>org.quartz-scheduler</groupId>
@@ -1640,12 +1628,12 @@
       <dependency>
         <groupId>org.osgi</groupId>
         <artifactId>org.osgi.core</artifactId>
-        <version>${osgi.framework.version}</version>
+        <version>${version.osgi}</version>
       </dependency>
       <dependency>
         <groupId>org.osgi</groupId>
         <artifactId>org.osgi.compendium</artifactId>
-        <version>${osgi.framework.version}</version>
+        <version>${version.osgi}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.neethi</groupId>
@@ -1704,12 +1692,12 @@
       <dependency>
         <artifactId>slf4j-api</artifactId>
         <groupId>org.slf4j</groupId>
-        <version>${slf4j.version}</version>
+        <version>${version.slf4j}</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-jdk14</artifactId>
-        <version>${slf4j.version}</version>
+        <version>${version.slf4j}</version>
         <exclusions>
           <exclusion>
             <artifactId>slf4j-api</artifactId>
@@ -1720,22 +1708,22 @@
       <dependency>
         <groupId>log4j</groupId>
         <artifactId>log4j</artifactId>
-        <version>${log4j.version}</version>
+        <version>${version.log4j}</version>
       </dependency>
       <dependency>
         <artifactId>commons-collections</artifactId>
         <groupId>commons-collections</groupId>
-        <version>${commons-collections.version}</version>
+        <version>${version.commons-collections}</version>
       </dependency>
       <dependency>
         <groupId>commons-codec</groupId>
         <artifactId>commons-codec</artifactId>
-        <version>${commons-codec.version}</version>
+        <version>${version.commons-codec}</version>
       </dependency>
       <dependency>
         <groupId>commons-fileupload</groupId>
         <artifactId>commons-fileupload</artifactId>
-        <version>${commons-fileupload.version}</version>
+        <version>${version.commons-fileupload}</version>
       </dependency>
       <dependency>
         <groupId>regexp</groupId>
@@ -1745,12 +1733,12 @@
       <dependency>
         <groupId>commons-discovery</groupId>
         <artifactId>commons-discovery</artifactId>
-        <version>${commons-discovery.version}</version>
+        <version>${version.commons-discovery}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.openwebbeans</groupId>
         <artifactId>openwebbeans-impl</artifactId>
-        <version>${openwebbeans.version}</version>
+        <version>${version.openwebbeans}</version>
         <exclusions>
           <exclusion>
             <groupId>org.apache.xbean</groupId>
@@ -1761,12 +1749,12 @@
       <dependency>
         <groupId>org.apache.openwebbeans</groupId>
         <artifactId>openwebbeans-jsf</artifactId>
-        <version>${openwebbeans.version}</version>
+        <version>${version.openwebbeans}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.openwebbeans</groupId>
         <artifactId>openwebbeans-spi</artifactId>
-        <version>${openwebbeans.version}</version>
+        <version>${version.openwebbeans}</version>
         <exclusions>
           <exclusion>
             <groupId>org.apache.geronimo.specs</groupId>
@@ -1789,7 +1777,7 @@
       <dependency>
         <groupId>org.apache.openwebbeans</groupId>
         <artifactId>openwebbeans-ejb</artifactId>
-        <version>${openwebbeans.version}</version>
+        <version>${version.openwebbeans}</version>
         <exclusions>
           <exclusion>
             <groupId>org.apache.geronimo.specs</groupId>
@@ -1808,7 +1796,7 @@
       <dependency>
         <groupId>org.apache.openwebbeans</groupId>
         <artifactId>openwebbeans-ee</artifactId>
-        <version>${openwebbeans.version}</version>
+        <version>${version.openwebbeans}</version>
         <exclusions>
           <exclusion>
             <groupId>org.apache.geronimo.specs</groupId>
@@ -1839,7 +1827,7 @@
       <dependency>
         <groupId>org.apache.openwebbeans</groupId>
         <artifactId>openwebbeans-web</artifactId>
-        <version>${openwebbeans.version}</version>
+        <version>${version.openwebbeans}</version>
         <exclusions>
           <exclusion>
             <groupId>org.apache.xbean</groupId>
@@ -1850,7 +1838,7 @@
       <dependency>
         <artifactId>openwebbeans-ee-common</artifactId>
         <groupId>org.apache.openwebbeans</groupId>
-        <version>${openwebbeans.version}</version>
+        <version>${version.openwebbeans}</version>
         <exclusions>
           <exclusion>
             <groupId>org.apache.geronimo.specs</groupId>
@@ -1866,27 +1854,27 @@
       <dependency>
         <groupId>org.apache.johnzon</groupId>
         <artifactId>johnzon-core</artifactId>
-        <version>${johnzon.version}</version>
+        <version>${version.johnzon}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.johnzon</groupId>
         <artifactId>johnzon-mapper</artifactId>
-        <version>${johnzon.version}</version>
+        <version>${version.johnzon}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.johnzon</groupId>
         <artifactId>johnzon-jaxrs</artifactId>
-        <version>${johnzon.version}</version>
+        <version>${version.johnzon}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.johnzon</groupId>
         <artifactId>johnzon-jsonb</artifactId>
-        <version>${johnzon.version}</version>
+        <version>${version.johnzon}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.johnzon</groupId>
         <artifactId>johnzon-jsonp-strict</artifactId>
-        <version>${johnzon.version}</version>
+        <version>${version.johnzon}</version>
       </dependency>
 
       <dependency>
@@ -1908,7 +1896,7 @@
       <dependency>
         <artifactId>commons-lang3</artifactId>
         <groupId>org.apache.commons</groupId>
-        <version>${commons-lang3.version}</version>
+        <version>${version.commons-lang3}</version>
       </dependency>
       <dependency>
         <artifactId>commons-lang</artifactId>
@@ -1918,7 +1906,7 @@
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>${commons-io.version}</version>
+        <version>${version.commons-io}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.ws.commons.schema</groupId>
@@ -1928,7 +1916,7 @@
       <dependency>
         <groupId>net.sf.ehcache</groupId>
         <artifactId>ehcache-core</artifactId>
-        <version>${ehcache.version}</version>
+        <version>${version.ehcache}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.derby</groupId>
@@ -1958,7 +1946,7 @@
       <dependency>
         <groupId>org.hibernate</groupId>
         <artifactId>hibernate-core</artifactId>
-        <version>${version.hibernate}</version>
+        <version>${version.hibernate.orm}</version>
         <exclusions>
           <exclusion>
             <artifactId>jboss-logging</artifactId>
@@ -2023,7 +2011,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.dataformat</groupId>
         <artifactId>jackson-dataformat-yaml</artifactId>
-        <version>${version.jackson.dataformat}</version>
+        <version>${version.jackson}</version>
         <exclusions>
           <exclusion>
             <groupId>org.yaml</groupId>
@@ -2035,7 +2023,7 @@
       <dependency>
         <groupId>org.yaml</groupId>
         <artifactId>snakeyaml</artifactId>
-        <version>${snakeyaml.version}</version>
+        <version>${version.snakeyaml}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/server/openejb-bonecp/pom.xml
+++ b/server/openejb-bonecp/pom.xml
@@ -46,7 +46,7 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>${slf4j.version}</version>
+      <version>${version.slf4j}</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/server/openejb-cxf-rs/pom.xml
+++ b/server/openejb-cxf-rs/pom.xml
@@ -120,7 +120,7 @@
     <dependency>
       <groupId>org.apache.cxf</groupId>
       <artifactId>cxf-rt-rs-service-description</artifactId>
-      <version>${cxf.version}</version>
+      <version>${version.cxf}</version>
       <exclusions>
         <exclusion>
           <groupId>org.glassfish.jaxb</groupId>
@@ -151,7 +151,7 @@
     <dependency>
       <groupId>org.apache.cxf</groupId>
       <artifactId>cxf-rt-rs-extension-search</artifactId>
-      <version>${cxf.version}</version>
+      <version>${version.cxf}</version>
       <exclusions>
         <exclusion>
           <groupId>org.glassfish.jaxb</groupId>
@@ -182,7 +182,7 @@
     <dependency>
       <groupId>org.apache.cxf</groupId>
       <artifactId>cxf-rt-rs-security-cors</artifactId>
-      <version>${cxf.version}</version>
+      <version>${version.cxf}</version>
       <exclusions>
         <exclusion>
           <groupId>org.glassfish.jaxb</groupId>
@@ -213,7 +213,7 @@
     <dependency>
       <groupId>org.apache.cxf</groupId>
       <artifactId>cxf-rt-rs-security-oauth2</artifactId>
-      <version>${cxf.version}</version>
+      <version>${version.cxf}</version>
       <exclusions>
         <exclusion>
           <groupId>org.glassfish.jaxb</groupId>
@@ -248,7 +248,7 @@
     <dependency> <!-- JAXBElementProvider -->
       <groupId>org.apache.cxf</groupId>
       <artifactId>cxf-rt-rs-extension-providers</artifactId>
-      <version>${cxf.version}</version>
+      <version>${version.cxf}</version>
       <exclusions>
         <exclusion>
           <groupId>org.glassfish.jaxb</groupId>
@@ -279,7 +279,7 @@
     <dependency>
       <groupId>org.apache.cxf</groupId>
       <artifactId>cxf-rt-rs-sse</artifactId>
-      <version>${cxf.version}</version>
+      <version>${version.cxf}</version>
       <exclusions>
         <exclusion>
           <groupId>org.apache.cxf</groupId>

--- a/server/openejb-cxf-transport/pom.xml
+++ b/server/openejb-cxf-transport/pom.xml
@@ -74,7 +74,7 @@
     <dependency>
       <groupId>org.apache.cxf</groupId>
       <artifactId>cxf-rt-management</artifactId>
-      <version>${cxf.version}</version>
+      <version>${version.cxf}</version>
       <exclusions>
         <exclusion>
           <groupId>org.apache.cxf</groupId>

--- a/server/openejb-cxf/pom.xml
+++ b/server/openejb-cxf/pom.xml
@@ -194,7 +194,7 @@
     <dependency>
       <groupId>org.apache.cxf</groupId>
       <artifactId>cxf-rt-frontend-jaxws</artifactId>
-      <version>${cxf.version}</version>
+      <version>${version.cxf}</version>
       <exclusions>
         <exclusion>
           <groupId>org.glassfish.jaxb</groupId>
@@ -237,7 +237,7 @@
     <dependency>
       <groupId>org.apache.cxf</groupId>
       <artifactId>cxf-rt-ws-security</artifactId>
-      <version>${cxf.version}</version>
+      <version>${version.cxf}</version>
       <exclusions>
         <exclusion>
           <groupId>org.glassfish.jaxb</groupId>
@@ -264,7 +264,7 @@
     <dependency>
       <groupId>com.sun.xml.messaging.saaj</groupId>
       <artifactId>saaj-impl</artifactId>
-      <version>${saaj-impl.version}</version>
+      <version>${version.impl.saaj}</version>
       <exclusions>
         <exclusion>
           <groupId>jakarta.activation</groupId>

--- a/server/openejb-webservices/pom.xml
+++ b/server/openejb-webservices/pom.xml
@@ -73,7 +73,7 @@
     <dependency>
       <groupId>com.sun.xml.messaging.saaj</groupId>
       <artifactId>saaj-impl</artifactId>
-      <version>${saaj-impl.version}</version>
+      <version>${version.impl.saaj}</version>
     </dependency>
 
     <!-- spec dependencies -->

--- a/tck/bval-embedded/pom.xml
+++ b/tck/bval-embedded/pom.xml
@@ -40,7 +40,7 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-jdk14</artifactId>
-      <version>${slf4j.version}</version>
+      <version>${version.slf4j}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -124,7 +124,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>${surefire.version}</version>
+        <version>${version.plugin.surefire}</version>
         <configuration>
           <reuseForks>true</reuseForks>
           <suiteXmlFiles>
@@ -143,7 +143,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-report-plugin</artifactId>
-        <version>${surefire.version}</version>
+        <version>${version.plugin.surefire}</version>
         <executions>
           <execution>
             <id>generate-test-report</id>

--- a/tck/cdi-embedded/pom.xml
+++ b/tck/cdi-embedded/pom.xml
@@ -40,13 +40,13 @@
     <dependency>
       <groupId>org.apache.myfaces.core</groupId>
       <artifactId>myfaces-api</artifactId>
-      <version>${myfaces.version}</version>
+      <version>${version.myfaces}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.myfaces.core</groupId>
       <artifactId>myfaces-impl</artifactId>
-      <version>${myfaces.version}</version>
+      <version>${version.myfaces}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -101,7 +101,7 @@
     <dependency>
       <groupId>org.apache.openwebbeans</groupId>
       <artifactId>openwebbeans-porting</artifactId>
-      <version>${openwebbeans.version}</version>
+      <version>${version.openwebbeans}</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -170,7 +170,7 @@
     <dependency>
       <groupId>org.apache.openwebbeans</groupId>
       <artifactId>openwebbeans-jsf</artifactId>
-      <version>${openwebbeans.version}</version>
+      <version>${version.openwebbeans}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -219,7 +219,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>${surefire.version}</version>
+        <version>${version.plugin.surefire}</version>
         <configuration>
           <reuseForks>true</reuseForks>
           <forkCount>1</forkCount>

--- a/tck/cdi-signature-test/pom.xml
+++ b/tck/cdi-signature-test/pom.xml
@@ -30,7 +30,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>javaee-api</artifactId>
-      <version>${version.javaee-api}</version>
+      <version>${version.tomee.javaee-api}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/tck/cdi-tomee/pom.xml
+++ b/tck/cdi-tomee/pom.xml
@@ -39,13 +39,13 @@
     <dependency>
       <groupId>org.apache.myfaces.core</groupId>
       <artifactId>myfaces-api</artifactId>
-      <version>${myfaces.version}</version>
+      <version>${version.myfaces}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>javaee-api</artifactId>
-      <version>${version.javaee-api}</version>
+      <version>${version.tomee.javaee-api}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -82,7 +82,7 @@
     <dependency>
       <groupId>org.apache.openwebbeans</groupId>
       <artifactId>openwebbeans-porting</artifactId>
-      <version>${openwebbeans.version}</version>
+      <version>${version.openwebbeans}</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -147,13 +147,13 @@
     <dependency>
       <groupId>org.apache.geronimo.specs</groupId>
       <artifactId>geronimo-jcache_1.0_spec</artifactId>
-      <version>${geronimo-jcache_1.0_spec.version}</version>
+      <version>${version.geronimo-jcache_1.0_spec}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-jcs-jcache</artifactId>
-      <version>${jcs.version}</version>
+      <version>${version.commons-jcs-cache}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -226,7 +226,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>${surefire.version}</version>
+        <version>${version.plugin.surefire}</version>
         <configuration>
           <reuseForks>true</reuseForks>
           <forkCount>1</forkCount>

--- a/tck/cdi-tomee/src/test/resources/arquillian.xml
+++ b/tck/cdi-tomee/src/test/resources/arquillian.xml
@@ -56,7 +56,7 @@
       <property name="additionalLibs">
         target/test-classes/org
         target/test-classes/META-INF
-          mvn:org.apache.openwebbeans:openwebbeans-porting:${openwebbeans.version}
+          mvn:org.apache.openwebbeans:openwebbeans-porting:${version.openwebbeans}
         mvn:org.jboss.cdi.tck:cdi-tck-ext-lib:${cdi-tck.version}
       </property>
     </configuration>

--- a/tck/microprofile-tck/config/pom.xml
+++ b/tck/microprofile-tck/config/pom.xml
@@ -99,14 +99,14 @@
     <dependency>
       <groupId>org.eclipse.microprofile.config</groupId>
       <artifactId>microprofile-config-api</artifactId>
-      <version>${microprofile.config.version}</version>
+      <version>${version.microprofile.config}</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.eclipse.microprofile.config</groupId>
       <artifactId>microprofile-config-tck</artifactId>
-      <version>${microprofile.config.version}</version>
+      <version>${version.microprofile.config}</version>
       <scope>test</scope>
     </dependency>
 

--- a/tck/microprofile-tck/fault-tolerance/pom.xml
+++ b/tck/microprofile-tck/fault-tolerance/pom.xml
@@ -86,14 +86,14 @@
     <dependency>
       <groupId>org.eclipse.microprofile.fault-tolerance</groupId>
       <artifactId>microprofile-fault-tolerance-api</artifactId>
-      <version>${microprofile.fault-tolerance.version}</version>
+      <version>${version.microprofile.fault-tolerance}</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.eclipse.microprofile.fault-tolerance</groupId>
       <artifactId>microprofile-fault-tolerance-tck</artifactId>
-      <version>${microprofile.fault-tolerance.version}</version>
+      <version>${version.microprofile.fault-tolerance}</version>
       <scope>test</scope>
     </dependency>
 

--- a/tck/microprofile-tck/health/pom.xml
+++ b/tck/microprofile-tck/health/pom.xml
@@ -85,7 +85,7 @@
     <dependency>
       <groupId>org.eclipse.microprofile.health</groupId>
       <artifactId>microprofile-health-api</artifactId>
-      <version>${microprofile.health.version}</version>
+      <version>${version.microprofile.health}</version>
       <exclusions>
         <exclusion>
           <groupId>javax.inject</groupId>
@@ -97,7 +97,7 @@
     <dependency>
       <groupId>org.eclipse.microprofile.health</groupId>
       <artifactId>microprofile-health-tck</artifactId>
-      <version>${microprofile.health.version}</version>
+      <version>${version.microprofile.health}</version>
       <scope>test</scope>
     </dependency>
 

--- a/tck/microprofile-tck/jwt/pom.xml
+++ b/tck/microprofile-tck/jwt/pom.xml
@@ -49,7 +49,7 @@
     <dependency>
       <groupId>org.apache.cxf</groupId>
       <artifactId>cxf-rt-rs-client</artifactId>
-      <version>${cxf.version}</version>
+      <version>${version.cxf}</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -95,7 +95,7 @@
     <dependency>
       <groupId>org.eclipse.microprofile.jwt</groupId>
       <artifactId>microprofile-jwt-auth-tck</artifactId>
-      <version>${microprofile.jwt.version}</version>
+      <version>${version.microprofile.jwt}</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -109,7 +109,7 @@
     <dependency>
       <groupId>org.eclipse.microprofile.jwt</groupId>
       <artifactId>microprofile-jwt-auth-tck</artifactId>
-      <version>${microprofile.jwt.version}</version>
+      <version>${version.microprofile.jwt}</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>

--- a/tck/microprofile-tck/metrics/pom.xml
+++ b/tck/microprofile-tck/metrics/pom.xml
@@ -93,14 +93,14 @@
     <dependency>
       <groupId>org.eclipse.microprofile.metrics</groupId>
       <artifactId>microprofile-metrics-api</artifactId>
-      <version>${microprofile.metrics.version}</version>
+      <version>${version.microprofile.metrics}</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.eclipse.microprofile.metrics</groupId>
       <artifactId>microprofile-metrics-api-tck</artifactId>
-      <version>${microprofile.metrics.version}</version>
+      <version>${version.microprofile.metrics}</version>
       <exclusions>
         <exclusion>
           <groupId>org.jboss.arquillian.container</groupId>
@@ -113,7 +113,7 @@
     <dependency>
       <groupId>org.eclipse.microprofile.metrics</groupId>
       <artifactId>microprofile-metrics-rest-tck</artifactId>
-      <version>${microprofile.metrics.version}</version>
+      <version>${version.microprofile.metrics}</version>
       <scope>test</scope>
     </dependency>
 

--- a/tck/microprofile-tck/openapi/pom.xml
+++ b/tck/microprofile-tck/openapi/pom.xml
@@ -97,14 +97,14 @@
     <dependency>
       <groupId>org.eclipse.microprofile.openapi</groupId>
       <artifactId>microprofile-openapi-api</artifactId>
-      <version>${microprofile.openapi.version}</version>
+      <version>${version.microprofile.openapi}</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.eclipse.microprofile.openapi</groupId>
       <artifactId>microprofile-openapi-tck</artifactId>
-      <version>${microprofile.openapi.version}</version>
+      <version>${version.microprofile.openapi}</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -133,7 +133,7 @@
       <!-- required by the MP TCK -->
       <groupId>org.yaml</groupId>
       <artifactId>snakeyaml</artifactId>
-      <version>${snakeyaml.version}</version>
+      <version>${version.snakeyaml}</version>
       <scope>test</scope>
     </dependency>
 

--- a/tck/microprofile-tck/opentracing/pom.xml
+++ b/tck/microprofile-tck/opentracing/pom.xml
@@ -85,14 +85,14 @@
     <dependency>
       <groupId>org.eclipse.microprofile.opentracing</groupId>
       <artifactId>microprofile-opentracing-api</artifactId>
-      <version>${microprofile.opentracing.version}</version>
+      <version>${version.microprofile.opentracing}</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.eclipse.microprofile.opentracing</groupId>
       <artifactId>microprofile-opentracing-tck</artifactId>
-      <version>${microprofile.opentracing.version}</version>
+      <version>${version.microprofile.opentracing}</version>
       <scope>test</scope>
     </dependency>
 
@@ -121,14 +121,14 @@
     <dependency>
       <groupId>io.opentracing</groupId>
       <artifactId>opentracing-mock</artifactId>
-      <version>${opentracing.api}</version>
+      <version>${version.io.opentracing}</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>io.opentracing</groupId>
       <artifactId>opentracing-api</artifactId>
-      <version>${opentracing.api}</version>
+      <version>${version.io.opentracing}</version>
       <scope>provided</scope>
     </dependency>
 

--- a/tck/microprofile-tck/rest-client/pom.xml
+++ b/tck/microprofile-tck/rest-client/pom.xml
@@ -115,7 +115,7 @@
     <dependency>
       <groupId>org.eclipse.microprofile.rest.client</groupId>
       <artifactId>microprofile-rest-client-api</artifactId>
-      <version>${microprofile.rest-client.version}</version>
+      <version>${version.microprofile.rest-client}</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -128,7 +128,7 @@
     <dependency>
       <groupId>org.eclipse.microprofile.rest.client</groupId>
       <artifactId>microprofile-rest-client-tck</artifactId>
-      <version>${microprofile.rest-client.version}</version>
+      <version>${version.microprofile.rest-client}</version>
       <scope>test</scope>
     </dependency>
 
@@ -205,7 +205,7 @@
     <dependency>
       <groupId>org.apache.cxf</groupId>
       <artifactId>cxf-rt-rs-mp-client</artifactId>
-      <version>${microprofile.rest-client.impl.version}</version>
+      <version>${version.cxf}</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/tomee/apache-tomee/pom.xml
+++ b/tomee/apache-tomee/pom.xml
@@ -324,7 +324,7 @@
               <dependency>
                 <groupId>org.apache.tomee</groupId>
                 <artifactId>javaee-api</artifactId>
-                <version>${version.javaee-api}</version>
+                <version>${version.tomee.javaee-api}</version>
               </dependency>
               <dependency>
                 <groupId>org.apache.tomee.bom</groupId>
@@ -340,7 +340,7 @@
               <dependency>
                 <groupId>org.apache.xbean</groupId>
                 <artifactId>xbean-asm9-shaded</artifactId>
-                <version>${xbeanVersion}</version>
+                <version>${version.xbean}</version>
               </dependency>
               <dependency>
                 <groupId>org.codehaus.groovy</groupId>
@@ -370,7 +370,7 @@
                   <properties>
                     <tomee.workdir>${webprofile.work-dir}</tomee.workdir>
                     <tomee.webapp>tomee-webapp</tomee.webapp>
-                    <remove.datestamp>${tomee.version}, ${project.version}, ${cxf.version}</remove.datestamp>
+                    <remove.datestamp>${tomee.version}, ${project.version}, ${version.cxf}</remove.datestamp>
                   </properties>
                   <source>
                     new commands.SetupCommand(pom: this, log: log, project: project, ant: ant, properties: properties).execute()
@@ -387,7 +387,7 @@
                   <properties>
                     <tomee.workdir>${plus.work-dir}</tomee.workdir>
                     <tomee.webapp>tomee-plus-webapp</tomee.webapp>
-                    <remove.datestamp>${tomee.version}, ${project.version}, ${cxf.version}</remove.datestamp>
+                    <remove.datestamp>${tomee.version}, ${project.version}, ${version.cxf}</remove.datestamp>
                   </properties>
                   <source>
                     new commands.SetupCommand(pom: this, log: log, project: project, ant: ant, properties: properties).execute()
@@ -404,7 +404,7 @@
                   <properties>
                     <tomee.workdir>${plume.work-dir}</tomee.workdir>
                     <tomee.webapp>tomee-plume-webapp</tomee.webapp>
-                    <remove.datestamp>${tomee.version}, ${project.version}, ${cxf.version}</remove.datestamp>
+                    <remove.datestamp>${tomee.version}, ${project.version}, ${version.cxf}</remove.datestamp>
                   </properties>
                   <source>
                     new commands.SetupCommand(pom: this, log: log, project: project, ant: ant, properties: properties).execute()
@@ -421,7 +421,7 @@
                   <properties>
                     <tomee.workdir>${microprofile.work-dir}</tomee.workdir>
                     <tomee.webapp>tomee-microprofile-webapp</tomee.webapp>
-                    <remove.datestamp>${tomee.version}, ${project.version}, ${cxf.version}</remove.datestamp>
+                    <remove.datestamp>${tomee.version}, ${project.version}, ${version.cxf}</remove.datestamp>
                   </properties>
                   <source>
                     new commands.SetupCommand(pom: this, log: log, project: project, ant: ant, properties: properties).execute()
@@ -704,7 +704,7 @@
               <dependency>
                 <groupId>org.apache.tomee</groupId>
                 <artifactId>javaee-api</artifactId>
-                <version>${version.javaee-api}</version>
+                <version>${version.tomee.javaee-api}</version>
               </dependency>
               <dependency>
                 <groupId>org.apache.tomee.bom</groupId>
@@ -720,7 +720,7 @@
               <dependency>
                 <groupId>org.apache.xbean</groupId>
                 <artifactId>xbean-asm9-shaded</artifactId>
-                <version>${xbeanVersion}</version>
+                <version>${version.xbean}</version>
               </dependency>
               <dependency>
                 <groupId>org.codehaus.groovy</groupId>
@@ -750,7 +750,7 @@
                   <properties>
                     <tomee.workdir>${plume.work-dir}</tomee.workdir>
                     <tomee.webapp>tomee-plume-webapp</tomee.webapp>
-                    <remove.datestamp>${tomee.version}, ${project.version}, ${cxf.version}</remove.datestamp>
+                    <remove.datestamp>${tomee.version}, ${project.version}, ${version.cxf}</remove.datestamp>
                   </properties>
                   <source>
                     new commands.SetupCommand(pom: this, log: log, project: project, ant: ant, properties: properties).execute()

--- a/tomee/pom.xml
+++ b/tomee/pom.xml
@@ -224,7 +224,7 @@
       <dependency>
         <artifactId>commons-beanutils</artifactId>
         <groupId>commons-beanutils</groupId>
-        <version>${commons-beanutils.version}</version>
+        <version>${version.commons-beanutils}</version>
       </dependency>
       <dependency>
         <groupId>javax.servlet</groupId>
@@ -285,12 +285,12 @@
       <dependency>
         <groupId>org.apache.openwebbeans</groupId>
         <artifactId>openwebbeans-jsf</artifactId>
-        <version>${openwebbeans.version}</version>
+        <version>${version.openwebbeans}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.myfaces.core</groupId>
         <artifactId>myfaces-api</artifactId>
-        <version>${myfaces.version}</version>
+        <version>${version.myfaces}</version>
         <exclusions>
           <exclusion>
             <groupId>org.apache.geronimo.specs</groupId>
@@ -305,7 +305,7 @@
       <dependency>
         <groupId>org.apache.myfaces.core</groupId>
         <artifactId>myfaces-impl</artifactId>
-        <version>${myfaces.version}</version>
+        <version>${version.myfaces}</version>
         <exclusions>
           <exclusion>
             <groupId>org.apache.geronimo.specs</groupId>
@@ -385,7 +385,7 @@
       <dependency>
         <groupId>org.glassfish</groupId>
         <artifactId>jakarta.faces</artifactId>
-        <version>${mojarra.version}</version>
+        <version>${version.mojarra}</version>
       </dependency>
       <dependency>
         <groupId>${project.groupId}</groupId>

--- a/tomee/tomee-loader/pom.xml
+++ b/tomee/tomee-loader/pom.xml
@@ -78,7 +78,7 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
-      <version>${log4j2.version}</version>
+      <version>${version.log4j2}</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/tomee/tomee-microprofile/mp-common/pom.xml
+++ b/tomee/tomee-microprofile/mp-common/pom.xml
@@ -52,37 +52,37 @@
     <dependency>
       <groupId>org.eclipse.microprofile.config</groupId>
       <artifactId>microprofile-config-api</artifactId>
-      <version>${microprofile.config.version}</version>
+      <version>${version.microprofile.config}</version>
     </dependency>
 
     <dependency>
       <groupId>org.apache.geronimo.config</groupId>
       <artifactId>geronimo-config-impl</artifactId>
-      <version>${microprofile.config.impl.version}</version>
+      <version>${version.microprofile.impl.config}</version>
     </dependency>
 
     <dependency>
       <groupId>org.eclipse.microprofile.jwt</groupId>
       <artifactId>microprofile-jwt-auth-api</artifactId>
-      <version>${microprofile.jwt.version}</version>
+      <version>${version.microprofile.jwt}</version>
     </dependency>
 
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>mp-jwt</artifactId>
-      <version>${microprofile.jwt.impl.version}</version>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.eclipse.microprofile.fault-tolerance</groupId>
       <artifactId>microprofile-fault-tolerance-api</artifactId>
-      <version>${microprofile.fault-tolerance.version}</version>
+      <version>${version.microprofile.fault-tolerance}</version>
     </dependency>
 
     <dependency>
       <groupId>org.apache.geronimo.safeguard</groupId>
       <artifactId>safeguard-impl</artifactId>
-      <version>${microprofile.fault-tolerance.impl.version}</version>
+      <version>${version.microprofile.impl.fault-tolerance}</version>
       <exclusions>
         <exclusion>
           <groupId>org.apache.geronimo.specs</groupId>
@@ -94,7 +94,7 @@
     <dependency>
       <groupId>org.eclipse.microprofile.health</groupId>
       <artifactId>microprofile-health-api</artifactId>
-      <version>${microprofile.health.version}</version>
+      <version>${version.microprofile.health}</version>
       <exclusions>
         <exclusion>
           <groupId>javax.inject</groupId>
@@ -106,25 +106,25 @@
     <dependency>
       <groupId>org.apache.geronimo</groupId>
       <artifactId>geronimo-health</artifactId>
-      <version>${microprofile.health.impl.version}</version>
+      <version>${version.microprofile.impl.health}</version>
     </dependency>
 
     <dependency>
       <groupId>org.eclipse.microprofile.metrics</groupId>
       <artifactId>microprofile-metrics-api</artifactId>
-      <version>${microprofile.metrics.version}</version>
+      <version>${version.microprofile.metrics}</version>
     </dependency>
 
     <dependency>
       <groupId>org.apache.geronimo</groupId>
       <artifactId>geronimo-metrics</artifactId>
-      <version>${microprofile.metrics.impl.version}</version>
+      <version>${version.microprofile.impl.metrics}</version>
     </dependency>
 
     <dependency>
       <groupId>org.eclipse.microprofile.rest.client</groupId>
       <artifactId>microprofile-rest-client-api</artifactId>
-      <version>${microprofile.rest-client.version}</version>
+      <version>${version.microprofile.rest-client}</version>
       <exclusions>
         <exclusion>
           <groupId>javax.inject</groupId>
@@ -136,7 +136,7 @@
     <dependency>
       <groupId>org.apache.cxf</groupId>
       <artifactId>cxf-rt-rs-mp-client</artifactId>
-      <version>${microprofile.rest-client.impl.version}</version>
+      <version>${version.cxf}</version>
       <exclusions>
         <exclusion>
           <groupId>org.glassfish.jaxb</groupId>
@@ -221,13 +221,13 @@
     <dependency>
       <groupId>org.eclipse.microprofile.openapi</groupId>
       <artifactId>microprofile-openapi-api</artifactId>
-      <version>${microprofile.openapi.version}</version>
+      <version>${version.microprofile.openapi}</version>
     </dependency>
 
     <dependency>
       <groupId>org.apache.geronimo</groupId>
       <artifactId>geronimo-openapi-impl</artifactId>
-      <version>${microprofile.openapi.impl.version}</version>
+      <version>${version.microprofile.impl.openapi}</version>
     </dependency>
 
     <!-- Jackson required by OpenAPI Impl -->
@@ -248,7 +248,7 @@
     <dependency>
       <groupId>org.eclipse.microprofile.opentracing</groupId>
       <artifactId>microprofile-opentracing-api</artifactId>
-      <version>${microprofile.opentracing.version}</version>
+      <version>${version.microprofile.opentracing}</version>
       <exclusions>
         <exclusion>
           <groupId>org.apache.geronimo.specs</groupId>
@@ -260,13 +260,13 @@
     <dependency>
       <groupId>org.apache.geronimo</groupId>
       <artifactId>geronimo-opentracing</artifactId>
-      <version>${microprofile.opentracing.impl.version}</version>
+      <version>${version.microprofile.impl.opentracing}</version>
     </dependency>
 
     <dependency>
       <groupId>io.opentracing</groupId>
       <artifactId>opentracing-api</artifactId>
-      <version>${opentracing.api}</version>
+      <version>${version.io.opentracing}</version>
     </dependency>
   </dependencies>
 </project>

--- a/tomee/tomee-microprofile/tomee-microprofile-webapp/pom.xml
+++ b/tomee/tomee-microprofile/tomee-microprofile-webapp/pom.xml
@@ -42,7 +42,7 @@
     <dependency><!-- needed by myfaces -->
       <groupId>commons-beanutils</groupId>
       <artifactId>commons-beanutils</artifactId>
-      <version>${commons-beanutils.version}</version>
+      <version>${version.commons-beanutils}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
@@ -348,7 +348,7 @@
     <dependency>
       <groupId>org.apache.myfaces.core</groupId>
       <artifactId>myfaces-api</artifactId>
-      <version>${myfaces.version}</version>
+      <version>${version.myfaces}</version>
       <exclusions>
         <exclusion>
           <groupId>org.apache.geronimo.specs</groupId>
@@ -363,7 +363,7 @@
     <dependency>
       <groupId>org.apache.myfaces.core</groupId>
       <artifactId>myfaces-impl</artifactId>
-      <version>${myfaces.version}</version>
+      <version>${version.myfaces}</version>
       <exclusions>
         <exclusion>
           <groupId>org.apache.myfaces.core</groupId>
@@ -386,7 +386,7 @@
     <dependency>
       <groupId>org.apache.openwebbeans</groupId>
       <artifactId>openwebbeans-jsf</artifactId>
-      <version>${openwebbeans.version}</version>
+      <version>${version.openwebbeans}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.tomcat</groupId>

--- a/tomee/tomee-myfaces/pom.xml
+++ b/tomee/tomee-myfaces/pom.xml
@@ -35,13 +35,13 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>javaee-api</artifactId>
-      <version>${version.javaee-api}</version>
+      <version>${version.tomee.javaee-api}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.myfaces.core</groupId>
       <artifactId>myfaces-impl</artifactId>
-      <version>${myfaces.version}</version>
+      <version>${version.myfaces}</version>
       <scope>provided</scope>
       <exclusions>
         <exclusion>

--- a/tomee/tomee-plume-webapp/pom.xml
+++ b/tomee/tomee-plume-webapp/pom.xml
@@ -42,7 +42,7 @@
     <dependency><!-- needed by myfaces -->
       <groupId>commons-beanutils</groupId>
       <artifactId>commons-beanutils</artifactId>
-      <version>${commons-beanutils.version}</version>
+      <version>${version.commons-beanutils}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
@@ -344,19 +344,19 @@
     <dependency>
       <groupId>org.apache.batchee</groupId>
       <artifactId>batchee-jbatch</artifactId>
-      <version>${batchee.version}</version>
+      <version>${version.batchee}</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.geronimo.specs</groupId>
       <artifactId>geronimo-jcache_1.0_spec</artifactId>
-      <version>${geronimo-jcache_1.0_spec.version}</version>
+      <version>${version.geronimo-jcache_1.0_spec}</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-jcs-jcache</artifactId>
-      <version>${jcs.version}</version>
+      <version>${version.commons-jcs-cache}</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
@@ -381,7 +381,7 @@
     <dependency>
       <groupId>org.apache.openwebbeans</groupId>
       <artifactId>openwebbeans-jsf</artifactId>
-      <version>${openwebbeans.version}</version>
+      <version>${version.openwebbeans}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.tomcat</groupId>

--- a/tomee/tomee-plus-webapp/pom.xml
+++ b/tomee/tomee-plus-webapp/pom.xml
@@ -39,7 +39,7 @@
     <dependency><!-- needed by myfaces -->
       <groupId>commons-beanutils</groupId>
       <artifactId>commons-beanutils</artifactId>
-      <version>${commons-beanutils.version}</version>
+      <version>${version.commons-beanutils}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
@@ -353,19 +353,19 @@
     <dependency>
       <groupId>org.apache.batchee</groupId>
       <artifactId>batchee-jbatch</artifactId>
-      <version>${batchee.version}</version>
+      <version>${version.batchee}</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.geronimo.specs</groupId>
       <artifactId>geronimo-jcache_1.0_spec</artifactId>
-      <version>${geronimo-jcache_1.0_spec.version}</version>
+      <version>${version.geronimo-jcache_1.0_spec}</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-jcs-jcache</artifactId>
-      <version>${jcs.version}</version>
+      <version>${version.commons-jcs-cache}</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
@@ -390,7 +390,7 @@
     <dependency>
       <groupId>org.apache.myfaces.core</groupId>
       <artifactId>myfaces-api</artifactId>
-      <version>${myfaces.version}</version>
+      <version>${version.myfaces}</version>
       <exclusions>
         <exclusion>
           <groupId>org.apache.geronimo.specs</groupId>
@@ -405,7 +405,7 @@
     <dependency>
       <groupId>org.apache.myfaces.core</groupId>
       <artifactId>myfaces-impl</artifactId>
-      <version>${myfaces.version}</version>
+      <version>${version.myfaces}</version>
       <exclusions>
         <exclusion>
           <groupId>org.apache.myfaces.core</groupId>
@@ -428,7 +428,7 @@
     <dependency>
       <groupId>org.apache.openwebbeans</groupId>
       <artifactId>openwebbeans-jsf</artifactId>
-      <version>${openwebbeans.version}</version>
+      <version>${version.openwebbeans}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.tomcat</groupId>

--- a/tomee/tomee-security/pom.xml
+++ b/tomee/tomee-security/pom.xml
@@ -34,7 +34,7 @@
 
   <properties>
     <!-- Reset Jetty Version to not clash with HtmlUnit -->
-    <jetty.version />
+    <version.jetty />
   </properties>
 
   <dependencies>

--- a/tomee/tomee-webaccess/pom.xml
+++ b/tomee/tomee-webaccess/pom.xml
@@ -71,7 +71,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>${junit.version}</version>
+      <version>${version.junit}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -113,7 +113,7 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>${commons-io.version}</version>
+      <version>${version.commons-io}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -191,7 +191,7 @@
     <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
-      <version>${commons-codec.version}</version>
+      <version>${version.commons-codec}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
@@ -208,7 +208,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>javaee-api</artifactId>
-      <version>${version.javaee-api}</version>
+      <version>${version.tomee.javaee-api}</version>
       <classifier>tomcat</classifier>
       <scope>provided</scope>
     </dependency>
@@ -246,7 +246,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>${surefire.version}</version>
+        <version>${version.plugin.surefire}</version>
         <configuration>
           <systemPropertyVariables>
             <arquillian.tomee.path>${project.basedir}/target/arquillian-tomee</arquillian.tomee.path>

--- a/tomee/tomee-webapp/pom.xml
+++ b/tomee/tomee-webapp/pom.xml
@@ -124,7 +124,7 @@
     <dependency><!-- needed by myfaces -->
       <groupId>commons-beanutils</groupId>
       <artifactId>commons-beanutils</artifactId>
-      <version>${commons-beanutils.version}</version>
+      <version>${version.commons-beanutils}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
@@ -325,7 +325,7 @@
     <dependency>
       <groupId>org.apache.myfaces.core</groupId>
       <artifactId>myfaces-api</artifactId>
-      <version>${myfaces.version}</version>
+      <version>${version.myfaces}</version>
       <exclusions>
         <exclusion>
           <groupId>org.apache.geronimo.specs</groupId>
@@ -340,7 +340,7 @@
     <dependency>
       <groupId>org.apache.myfaces.core</groupId>
       <artifactId>myfaces-impl</artifactId>
-      <version>${myfaces.version}</version>
+      <version>${version.myfaces}</version>
       <exclusions>
         <exclusion>
           <groupId>org.apache.myfaces.core</groupId>
@@ -363,7 +363,7 @@
     <dependency>
       <groupId>org.apache.openwebbeans</groupId>
       <artifactId>openwebbeans-jsf</artifactId>
-      <version>${openwebbeans.version}</version>
+      <version>${version.openwebbeans}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.tomcat</groupId>

--- a/utils/log4j2-tomee/pom.xml
+++ b/utils/log4j2-tomee/pom.xml
@@ -30,7 +30,7 @@
 
   <properties>
     <tomee.build.name>${project.groupId}.util.log4j2</tomee.build.name>
-    <log4j2.version>2.3</log4j2.version>
+    <version.log4j2>2.19.0</version.log4j2>
     <log4j.groupId>org.apache.logging.log4j</log4j.groupId>
   </properties>
 
@@ -38,13 +38,13 @@
     <dependency>
       <groupId>${log4j.groupId}</groupId>
       <artifactId>log4j-api</artifactId>
-      <version>${log4j2.version}</version>
+      <version>${version.log4j2}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>${log4j.groupId}</groupId>
       <artifactId>log4j-core</artifactId>
-      <version>${log4j2.version}</version>
+      <version>${version.log4j2}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/utils/openejb-core-hibernate/pom.xml
+++ b/utils/openejb-core-hibernate/pom.xml
@@ -92,7 +92,7 @@
     <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-ehcache</artifactId>
-      <version>${version.hibernate}</version>
+      <version>${version.hibernate.orm}</version>
       <exclusions>
         <exclusion>
           <groupId>net.sf.ehcache</groupId>
@@ -103,23 +103,23 @@
     <dependency>
       <groupId>net.sf.ehcache</groupId>
       <artifactId>ehcache</artifactId>
-      <version>${ehcache.version}</version>
+      <version>${version.ehcache}</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-jdk14</artifactId>
-      <version>${slf4j.version}</version>
+      <version>${version.slf4j}</version>
     </dependency>
     <!--
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-log4j12</artifactId>
-      <version>${slf4j.version}</version>
+      <version>${version.slf4j}</version>
     </dependency>
     <dependency>
       <groupId>log4j</groupId>
       <artifactId>log4j</artifactId>
-      <version>${log4j.version}</version>
+      <version>${version.log4j}</version>
     </dependency>
     -->
   </dependencies>


### PR DESCRIPTION
WIP

Versions not to be upgraded:
* bval = 2.0.5 and not 2.0.6
* cxf = 3.4.8 and not 3.5.4

Removed properties:

    <pax-url.version>1.3.5</pax-url.version>
    <version.wagon>2.2</version.wagon>
    <plexus.version>1.5.5</plexus.version>
    <plexus-utils.version>3.0.10</plexus-utils.version>
    <org.apache.axis2.version>1.4.1</org.apache.axis2.version>
    <scannotation.version>1.0.2</scannotation.version>
    <geronimo-osgi.version>1.1</geronimo-osgi.version>
