### PR TITLE
[TOMEE-4060] Tomcat 9.0.67 and dependencies update

### DIFF
--- a/container/openejb-core/pom.xml
+++ b/container/openejb-core/pom.xml
@@ -293,20 +293,20 @@
                 <artifactItem>
                   <groupId>org.apache.derby</groupId>
                   <artifactId>derby</artifactId>
-                  <version>${derby.version}</version>
+                  <version>${version.derby}</version>
                   <type>jar</type>
                   <overWrite>false</overWrite>
                   <outputDirectory>${project.build.directory}/drivers</outputDirectory>
-                  <destFileName>derby-${derby.version}.jar</destFileName>
+                  <destFileName>derby-${version.derby}.jar</destFileName>
                 </artifactItem>
                 <artifactItem>
                   <groupId>org.apache.derby</groupId>
                   <artifactId>derby</artifactId>
-                  <version>${derby.version}</version>
+                  <version>${version.derby}</version>
                   <type>jar</type>
                   <overWrite>false</overWrite>
                   <outputDirectory>${project.build.directory}/drivers</outputDirectory>
-                  <destFileName>derby-${derby.version}.jar</destFileName>
+                  <destFileName>derby-${version.derby}.jar</destFileName>
                 </artifactItem>
               </artifactItems>
             </configuration>

--- a/examples/alternate-descriptors/pom.xml
+++ b/examples/alternate-descriptors/pom.xml
@@ -73,7 +73,7 @@
     <dependency>
       <groupId>org.apache.openjpa</groupId>
       <artifactId>openjpa</artifactId>
-      <version>3.0.0</version>
+      <version>3.2.2</version>
       <scope>provided</scope>
       <exclusions>
         <exclusion>

--- a/examples/multi-jpa-provider-testing/pom.xml
+++ b/examples/multi-jpa-provider-testing/pom.xml
@@ -134,7 +134,7 @@
     <dependency>
       <groupId>org.apache.openjpa</groupId>
       <artifactId>openjpa</artifactId>
-      <version>3.0.0</version>
+      <version>3.2.2</version>
       <scope>test</scope>
     </dependency>
     <dependency> <!-- just a facade pom which will bring hibernate for us -->

--- a/examples/rest-example/pom.xml
+++ b/examples/rest-example/pom.xml
@@ -29,7 +29,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <tomee.version>8.0.13-SNAPSHOT</tomee.version>
-    <version.openjpa>3.0.0</version.openjpa>
+    <version.openjpa>3.2.2</version.openjpa>
   </properties>
 
   <repositories>

--- a/examples/tomee-jersey-eclipselink/pom.xml
+++ b/examples/tomee-jersey-eclipselink/pom.xml
@@ -27,7 +27,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <version.eclipselink>2.7.7</version.eclipselink>
+    <version.eclipselink>2.7.11</version.eclipselink>
     <tomee.version>8.0.13-SNAPSHOT</tomee.version>
     <arquillian_universe.version>1.2.0.1</arquillian_universe.version>
   </properties>

--- a/examples/xa-datasource/pom.xml
+++ b/examples/xa-datasource/pom.xml
@@ -28,7 +28,7 @@
   <name>TomEE :: Examples :: XA Datasource configuration and usage</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <derby.version>10.12.1.1</derby.version>
+    <version.derby>10.14.2.0</version.derby>
     <tomee.version>8.0.13-SNAPSHOT</tomee.version>
   </properties>
 
@@ -109,19 +109,19 @@
     <dependency>
       <groupId>org.apache.derby</groupId>
       <artifactId>derby</artifactId>
-      <version>${derby.version}</version>
+      <version>${version.derby}</version>
     </dependency>
 
     <dependency>
       <groupId>org.apache.derby</groupId>
       <artifactId>derbynet</artifactId>
-      <version>${derby.version}</version>
+      <version>${version.derby}</version>
     </dependency>
 
     <dependency>
       <groupId>org.apache.derby</groupId>
       <artifactId>derbyclient</artifactId>
-      <version>${derby.version}</version>
+      <version>${version.derby}</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,7 @@
     <version.shrinkwrap.descriptor>2.0.0</version.shrinkwrap.descriptor>
     <version.shrinkwrap.shrinkwrap>1.2.6</version.shrinkwrap.shrinkwrap>
 
-    <tomcat.version>9.0.65</tomcat.version>
+    <tomcat.version>9.0.67</tomcat.version>
 
     <cxf.version>3.4.8</cxf.version>
     <ehcache.version>2.10.6</ehcache.version>
@@ -191,13 +191,13 @@
     <commons-io.version>2.11.0</commons-io.version>
     <commons-net.version>3.8.0</commons-net.version>
 
-    <bval.version>2.0.5</bval.version>
+    <bval.version>2.0.6</bval.version>
     <org.apache.activemq.version>5.16.5</org.apache.activemq.version>
     <junit.version>4.13.2</junit.version>
     <junit.jupiter.version>5.8.2</junit.jupiter.version>
     <org.apache.axis2.version>1.4.1</org.apache.axis2.version>
     <scannotation.version>1.0.2</scannotation.version>
-    <geronimo.connector.version>3.1.4</geronimo.connector.version>
+    <geronimo.connector.version>3.1.5</geronimo.connector.version>
     <geronimo-osgi.version>1.1</geronimo-osgi.version>
     <myfaces.version>2.3.10</myfaces.version>
     <mojarra.version>2.3.18</mojarra.version>
@@ -205,8 +205,6 @@
     <log4j.version>1.2.17</log4j.version>
     <log4j2.version>2.19.0</log4j2.version>
     <osgi.framework.version>4.2.0</osgi.framework.version>
-    <derby.version>10.14.2.0</derby.version>
-    <version.hsqldb>2.7.0</version.hsqldb>
     <version.axiom>1.3.0</version.axiom>
     <version.xalan>2.7.2</version.xalan>
     <version.groovy>2.4.12</version.groovy>
@@ -217,6 +215,8 @@
     <version.openjpa>3.2.2</version.openjpa>
     <version.eclipselink>2.7.11</version.eclipselink>
     <version.hibernate>5.6.12.Final</version.hibernate>
+    <version.derby>10.14.2.0</version.derby>
+    <version.hsqldb>2.7.0</version.hsqldb>
 
     <!-- arquillian related -->
     <version.arquillian.bom>1.1.13.Final</version.arquillian.bom>


### PR DESCRIPTION
Updates : 
- [TOMEE-4060](https://issues.apache.org/jira/browse/TOMEE-4064) Tomcat 9.0.67
- [TOMEE-4064](https://issues.apache.org/jira/browse/TOMEE-4064) OpenJPA 3.2.2 (examples)
- [TOMEE-4064](https://issues.apache.org/jira/browse/TOMEE-4064) EclipseLink 2.7.11 (examples)
- [TOMEE-4064](https://issues.apache.org/jira/browse/TOMEE-4064) Derby 10.14.2.0
- [TOMEE-4062](https://issues.apache.org/jira/browse/TOMEE-4062) Apache BVal 2.0.6
- [TOMEE-4063](https://issues.apache.org/jira/browse/TOMEE-4063) Geronimo Transcation Manager 3.1.5
