### PR TITLE
[TOMEE-4061] TomEE 9.x dependencies update: hsqldb 2.7.1, jackson, etc. - MERGE FIRST

### DIFF
--- a/arquillian/arquillian-tomee-remote/pom.xml
+++ b/arquillian/arquillian-tomee-remote/pom.xml
@@ -183,7 +183,7 @@
     <dependency>
       <groupId>org.apache.derby</groupId>
       <artifactId>derby</artifactId>
-      <version>10.10.1.1</version>
+      <version>${version.derby}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/pom.xml
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/pom.xml
@@ -52,7 +52,7 @@
       <plugin>
         <groupId>org.apache.openjpa</groupId>
         <artifactId>openjpa-maven-plugin</artifactId>
-        <version>${openjpa.version}</version>
+        <version>${version.openjpa}</version>
         <configuration>
           <includes>org/apache/openejb/arquillian/tests/datasourcerealm/*.class</includes>
           <persistenceXmlFile>${project.basedir}/src/test/resources/META-INF/build-persistence.xml</persistenceXmlFile>
@@ -86,7 +86,7 @@
           <dependency>
             <groupId>org.apache.openjpa</groupId>
             <artifactId>openjpa</artifactId>
-            <version>${openjpa.version}</version>
+            <version>${version.openjpa}</version>
             <classifier>jakarta</classifier>
             <exclusions>
               <exclusion>

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/resources/hibernate-pom.xml
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-webprofile-tests/src/test/resources/hibernate-pom.xml
@@ -24,7 +24,7 @@
   <artifactId>hibernate-deps</artifactId>
 
   <properties>
-    <version.hibernate.orm>6.1.3.Final</version.hibernate.orm>
+    <version.hibernate.orm>6.1.4.Final</version.hibernate.orm>
     <version.hibernate.validator>7.0.5.Final</version.hibernate.validator>
   </properties>
   <dependencies>

--- a/boms/tomee-microprofile/pom.xml
+++ b/boms/tomee-microprofile/pom.xml
@@ -70,7 +70,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.13.4</version>
+      <version>2.13.4.2</version>
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>
@@ -1869,7 +1869,7 @@
     <dependency>
       <groupId>org.hsqldb</groupId>
       <artifactId>hsqldb</artifactId>
-      <version>2.7.0</version>
+      <version>2.7.1</version>
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>

--- a/boms/tomee-plume/pom.xml
+++ b/boms/tomee-plume/pom.xml
@@ -70,7 +70,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.13.4</version>
+      <version>2.13.4.2</version>
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>
@@ -2002,7 +2002,7 @@
     <dependency>
       <groupId>org.hsqldb</groupId>
       <artifactId>hsqldb</artifactId>
-      <version>2.7.0</version>
+      <version>2.7.1</version>
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>

--- a/boms/tomee-plus/pom.xml
+++ b/boms/tomee-plus/pom.xml
@@ -70,7 +70,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.13.4</version>
+      <version>2.13.4.2</version>
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>
@@ -2013,7 +2013,7 @@
     <dependency>
       <groupId>org.hsqldb</groupId>
       <artifactId>hsqldb</artifactId>
-      <version>2.7.0</version>
+      <version>2.7.1</version>
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>

--- a/boms/tomee-webprofile/pom.xml
+++ b/boms/tomee-webprofile/pom.xml
@@ -1275,7 +1275,7 @@
     <dependency>
       <groupId>org.hsqldb</groupId>
       <artifactId>hsqldb</artifactId>
-      <version>2.7.0</version>
+      <version>2.7.1</version>
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>

--- a/container/openejb-core/pom.xml
+++ b/container/openejb-core/pom.xml
@@ -292,20 +292,20 @@
                 <artifactItem>
                   <groupId>org.apache.derby</groupId>
                   <artifactId>derby</artifactId>
-                  <version>${derby.version}</version>
+                  <version>${version.derby}</version>
                   <type>jar</type>
                   <overWrite>false</overWrite>
                   <outputDirectory>${project.build.directory}/drivers</outputDirectory>
-                  <destFileName>derby-${derby.version}.jar</destFileName>
+                  <destFileName>derby-${version.derby}.jar</destFileName>
                 </artifactItem>
                 <artifactItem>
                   <groupId>org.apache.derby</groupId>
                   <artifactId>derby</artifactId>
-                  <version>${derby.version}</version>
+                  <version>${version.derby}</version>
                   <type>jar</type>
                   <overWrite>false</overWrite>
                   <outputDirectory>${project.build.directory}/drivers</outputDirectory>
-                  <destFileName>derby-${derby.version}.jar</destFileName>
+                  <destFileName>derby-${version.derby}.jar</destFileName>
                 </artifactItem>
               </artifactItems>
             </configuration>

--- a/examples/multi-jpa-provider-testing/src/test/resources/hibernate-pom.xml
+++ b/examples/multi-jpa-provider-testing/src/test/resources/hibernate-pom.xml
@@ -24,7 +24,7 @@
   <artifactId>hibernate-deps</artifactId>
 
   <properties>
-    <version.hibernate.orm>6.1.3.Final</version.hibernate.orm>
+    <version.hibernate.orm>6.1.4.Final</version.hibernate.orm>
     <version.hibernate.validator>7.0.5.Final</version.hibernate.validator>
   </properties>
   <dependencies>

--- a/examples/mvc-cxf-hibernate/pom.xml
+++ b/examples/mvc-cxf-hibernate/pom.xml
@@ -32,7 +32,7 @@
     <version.krazo>2.0.2</version.krazo>
     <version.arquillian>1.7.0.Alpha10</version.arquillian>
     <version.graphene.webdriver>2.3.1</version.graphene.webdriver>
-    <version.hibernate.orm>6.1.3.Final</version.hibernate.orm>
+    <version.hibernate.orm>6.1.4.Final</version.hibernate.orm>
     <version.hibernate.validator>7.0.5.Final</version.hibernate.validator>
   </properties>
   <build>

--- a/examples/websocket-tls-basic-auth/pom.xml
+++ b/examples/websocket-tls-basic-auth/pom.xml
@@ -28,7 +28,7 @@
     <jakartaee-api.version>9.1-M2</jakartaee-api.version>
     <jakarta.websocket-api.version>2.0.0</jakarta.websocket-api.version>
     <tomee.classifier>webprofile</tomee.classifier>
-    <tomcat.version>10.0.20</tomcat.version>
+    <tomcat.version>10.0.27</tomcat.version>
     <junit.version>4.13.2</junit.version>
   </properties>
   <dependencies>

--- a/examples/xa-datasource/pom.xml
+++ b/examples/xa-datasource/pom.xml
@@ -26,7 +26,7 @@
   <name>TomEE :: Examples :: XA Datasource configuration and usage</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <derby.version>10.12.1.1</derby.version>
+    <version.derby>10.14.2.0</version.derby>
     <tomee.version>9.0.0-M9-SNAPSHOT</tomee.version>
   </properties>
   <build>
@@ -102,17 +102,17 @@
     <dependency>
       <groupId>org.apache.derby</groupId>
       <artifactId>derby</artifactId>
-      <version>${derby.version}</version>
+      <version>${version.derby}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.derby</groupId>
       <artifactId>derbynet</artifactId>
-      <version>${derby.version}</version>
+      <version>${version.derby}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.derby</groupId>
       <artifactId>derbyclient</artifactId>
-      <version>${derby.version}</version>
+      <version>${version.derby}</version>
     </dependency>
     <dependency>
       <groupId>org.tomitribe</groupId>

--- a/itests/openejb-itests-beans/pom.xml
+++ b/itests/openejb-itests-beans/pom.xml
@@ -37,7 +37,7 @@
       <plugin>
         <groupId>org.apache.openjpa</groupId>
         <artifactId>openjpa-maven-plugin</artifactId>
-        <version>${openjpa.version}</version>
+        <version>${version.openjpa}</version>
 
         <configuration>
           <includes>org/apache/openejb/test/entity/**/*.class</includes>
@@ -83,7 +83,7 @@
           <dependency>
             <groupId>org.apache.openjpa</groupId>
             <artifactId>openjpa</artifactId>
-            <version>${openjpa.version}</version>
+            <version>${version.openjpa}</version>
             <classifier>jakarta</classifier>
             <exclusions>
               <exclusion>

--- a/maven/tomee-webapp-archetype/pom.xml
+++ b/maven/tomee-webapp-archetype/pom.xml
@@ -42,7 +42,7 @@ Licensed to the Apache Software Foundation (ASF) under one or more
               <target>
                 <replace file="${project.build.directory}/classes/archetype-resources/pom.xml" token="[TOMEE]" value="${project.version}" />
                 <replace file="${project.build.directory}/classes/archetype-resources/pom.xml" token="[OPENEJB]" value="${project.version}" />
-                <replace file="${project.build.directory}/classes/archetype-resources/pom.xml" token="[OPENJPA]" value="${openjpa.version}" />
+                <replace file="${project.build.directory}/classes/archetype-resources/pom.xml" token="[OPENJPA]" value="${version.openjpa}" />
                 <replace file="${project.build.directory}/classes/archetype-resources/pom.xml" token="[JAVAEE]" value="${version.jakartaee-api}" />
               </target>
             </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,6 @@
     <!-- todo needs to be updated at some point -->
     <geronimo-jcache_1.0_spec.version>1.0-alpha-1</geronimo-jcache_1.0_spec.version>
 
-    <openjpa.version>3.2.2</openjpa.version>
     <openwebbeans.version>2.0.27</openwebbeans.version>
     <jcs.version>2.1</jcs.version>
     <johnzon.version>1.2.19</johnzon.version>
@@ -147,7 +146,7 @@
     <version.shrinkwrap.descriptor>2.0.0</version.shrinkwrap.descriptor>
     <version.shrinkwrap.shrinkwrap>1.2.6</version.shrinkwrap.shrinkwrap>
 
-    <tomcat.version>10.0.23</tomcat.version>
+    <tomcat.version>10.0.27</tomcat.version>
 
     <cxf.version>3.5.0</cxf.version>
     <ehcache.version>3.10.0</ehcache.version>
@@ -202,15 +201,18 @@
     <log4j.version>1.2.17</log4j.version>
     <log4j2.version>2.19.0</log4j2.version>
     <osgi.framework.version>4.2.0</osgi.framework.version>
-    <derby.version>10.14.2.0</derby.version>
-    <version.hsqldb>2.7.0</version.hsqldb>
     <version.axiom>1.3.0</version.axiom>
     <version.xalan>2.7.2</version.xalan>
-    <version.hibernate.orm>6.1.3.Final</version.hibernate.orm>
-    <version.hibernate.validator>7.0.5.Final</version.hibernate.validator>
-    <version.eclipselink>3.0.3</version.eclipselink>
     <version.groovy>2.4.12</version.groovy>
     <version.ecj>4.6.1</version.ecj>
+
+    <version.deltaspike>1.9.6</version.deltaspike>
+    <version.openjpa>3.2.2</version.openjpa>
+    <version.eclipselink>3.0.3</version.eclipselink>
+    <version.hibernate.orm>6.1.4.Final</version.hibernate.orm>
+    <version.hibernate.validator>7.0.5.Final</version.hibernate.validator>
+    <version.derby>10.14.2.0</version.derby>
+    <version.hsqldb>2.7.1</version.hsqldb>
 
     <!-- arquillian related -->
     <version.arquillian.bom>1.1.13.Final</version.arquillian.bom>
@@ -227,20 +229,20 @@
     <microprofile.jwt.tck.version>2.0</microprofile.jwt.tck.version>
     <microprofile.jwt.impl.version>${project.version}</microprofile.jwt.impl.version>
 
-    <microprofile.fault-tolerance.version>4.0.1</microprofile.fault-tolerance.version>
-    <microprofile.fault-tolerance.tck.version>4.0.1</microprofile.fault-tolerance.tck.version>
+    <microprofile.fault-tolerance.version>4.0.2</microprofile.fault-tolerance.version>
+    <microprofile.fault-tolerance.tck.version>4.0.2</microprofile.fault-tolerance.tck.version>
     <microprofile.fault-tolerance.impl.version>6.0.0</microprofile.fault-tolerance.impl.version>
 
-    <microprofile.health.version>4.0</microprofile.health.version>
-    <microprofile.health.tck.version>4.0</microprofile.health.tck.version>
+    <microprofile.health.version>4.0.1</microprofile.health.version>
+    <microprofile.health.tck.version>4.0.1</microprofile.health.tck.version>
     <microprofile.health.impl.version>4.0.0</microprofile.health.impl.version>
 
     <microprofile.metrics.version>4.0.1</microprofile.metrics.version>
     <microprofile.metrics.tck.version>4.0.1</microprofile.metrics.tck.version>
     <microprofile.metrics.impl.version>4.0.0</microprofile.metrics.impl.version>
 
-    <microprofile.rest-client.version>3.0</microprofile.rest-client.version>
-    <microprofile.rest-client.tck.version>3.0</microprofile.rest-client.tck.version>
+    <microprofile.rest-client.version>3.0.1</microprofile.rest-client.version>
+    <microprofile.rest-client.tck.version>3.0.1</microprofile.rest-client.tck.version>
     <microprofile.rest-client.impl.version>${cxf.version}</microprofile.rest-client.impl.version>
 
     <microprofile.openapi.version>3.0</microprofile.openapi.version>
@@ -250,11 +252,13 @@
     <microprofile.opentracing.version>3.0</microprofile.opentracing.version>
     <microprofile.opentracing.tck.version>3.0</microprofile.opentracing.tck.version>
     <microprofile.opentracing.impl.version>3.0.0</microprofile.opentracing.impl.version>
+
     <opentracing.api>0.33.0</opentracing.api>
 
     <!-- Jackson required by OpenAPI Impl -->
-    <jackson.version>2.13.4</jackson.version>
-    <jackson.dataformat.version>2.13.4</jackson.dataformat.version>
+    <version.jackson>2.13.4</version.jackson>
+    <version.jackson.databind>2.13.4.2</version.jackson.databind>
+    <version.jackson.dataformat>2.13.4</version.jackson.dataformat>
     <!-- required by Jackson dataformat yaml -->
     <snakeyaml.version>1.33</snakeyaml.version>
 
@@ -1351,7 +1355,7 @@
       <dependency>
         <groupId>org.apache.openjpa</groupId>
         <artifactId>openjpa</artifactId>
-        <version>${openjpa.version}</version>
+        <version>${version.openjpa}</version>
         <classifier>jakarta</classifier>
         <exclusions>
           <exclusion>
@@ -1836,12 +1840,12 @@
       <dependency>
         <groupId>org.apache.derby</groupId>
         <artifactId>derbynet</artifactId>
-        <version>10.11.1.1</version>
+        <version>${version.derby}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.derby</groupId>
         <artifactId>derbyclient</artifactId>
-        <version>10.11.1.1</version>
+        <version>${version.derby}</version>
       </dependency>
       <dependency>
         <groupId>org.codehaus.groovy</groupId>
@@ -1930,13 +1934,13 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>${jackson.version}</version>
+        <version>${version.jackson.databind}</version>
       </dependency>
       <!-- Jackson required by OpenAPI Impl -->
       <dependency>
         <groupId>com.fasterxml.jackson.dataformat</groupId>
         <artifactId>jackson-dataformat-yaml</artifactId>
-        <version>${jackson.dataformat.version}</version>
+        <version>${version.jackson.dataformat}</version>
         <exclusions>
           <exclusion>
             <groupId>org.yaml</groupId>

--- a/tomee/tomee-plume-webapp/pom.xml
+++ b/tomee/tomee-plume-webapp/pom.xml
@@ -544,7 +544,7 @@
     <dependency>
       <groupId>org.apache.openjpa</groupId>
       <artifactId>openjpa</artifactId>
-      <version>${openjpa.version}</version>
+      <version>${version.openjpa}</version>
       <classifier>jakarta</classifier>
       <exclusions>
         <exclusion>

--- a/tomee/tomee-plus-webapp/pom.xml
+++ b/tomee/tomee-plus-webapp/pom.xml
@@ -574,7 +574,7 @@
     <dependency>
       <groupId>org.apache.openjpa</groupId>
       <artifactId>openjpa</artifactId>
-      <version>${openjpa.version}</version>
+      <version>${version.openjpa}</version>
       <classifier>jakarta</classifier>
       <exclusions>
         <exclusion>

--- a/tomee/tomee-webapp/pom.xml
+++ b/tomee/tomee-webapp/pom.xml
@@ -581,7 +581,7 @@
     <dependency>
       <groupId>org.apache.openjpa</groupId>
       <artifactId>openjpa</artifactId>
-      <version>${openjpa.version}</version>
+      <version>${version.openjpa}</version>
       <classifier>jakarta</classifier>
       <exclusions>
         <exclusion>


### PR DESCRIPTION
TomEE 9.x dependencies update: 
- [TOMEE-4096](https://issues.apache.org/jira/browse/TOMEE-4096) Tomcat 10.0.27
- [TOMEE-4086](https://issues.apache.org/jira/browse/TOMEE-4086) HSQLDB 2.7.1
- [TOMEE-4095](https://issues.apache.org/jira/browse/TOMEE-4095) jackson databind 2.13.4.2
- Derby 10.14.2.0
- [TOMEE-4093](https://issues.apache.org/jira/browse/TOMEE-4093) Hibernate 6.1.4.Final
- [TOMEE-4097](https://issues.apache.org/jira/browse/TOMEE-4097) MicroProfile Fault Tolerance API 4.0.2
- [TOMEE-4098](https://issues.apache.org/jira/browse/TOMEE-4098) MicroProfile Health API 4.0.1
- [TOMEE-4099](https://issues.apache.org/jira/browse/TOMEE-4099) MicroProfile Rest Client API 3.0.1
