### PR TITLE
[TOMEE-4061] TomEE 9.x + Derby 10.15.2.0, upon other dependencies update

### DIFF
--- a/arquillian/arquillian-tomee-remote/pom.xml
+++ b/arquillian/arquillian-tomee-remote/pom.xml
@@ -186,6 +186,12 @@
       <version>${version.derby}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.derby</groupId>
+      <artifactId>derbytools</artifactId>
+      <version>${version.derby}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/container/openejb-core/src/test/java/org/apache/openejb/resource/jdbc/driver/AlternateDriverJarTest.java
+++ b/container/openejb-core/src/test/java/org/apache/openejb/resource/jdbc/driver/AlternateDriverJarTest.java
@@ -58,11 +58,7 @@ public class AlternateDriverJarTest {
         p.put("JdbcOne.Password", PASSWORD);
         p.put("JdbcOne.JtaManaged", "false");
 
-        final File file = new File(drivers, "derby-10.14.2.0.jar");
-        Assert.assertTrue("Failed to find: " + file, file.exists());
-
-        p.put("JdbcTwo", "new://Resource?type=DataSource&classpath="
-            + file.getAbsolutePath().replace("\\", "/"));
+        p.put("JdbcTwo", "new://Resource?type=DataSource&classpath=mvn:org.apache.derby:derby:10.14.2.0");
         p.put("JdbcTwo.JdbcDriver", "org.apache.derby.jdbc.EmbeddedDriver");
         p.put("JdbcTwo.JdbcUrl", "jdbc:derby:memory:JdbcTwo;create=true");
         p.put("JdbcTwo.UserName", USER);

--- a/examples/xa-datasource/pom.xml
+++ b/examples/xa-datasource/pom.xml
@@ -26,7 +26,7 @@
   <name>TomEE :: Examples :: XA Datasource configuration and usage</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <version.derby>10.14.2.0</version.derby>
+    <version.derby>10.15.2.0</version.derby>
     <tomee.version>9.0.1-SNAPSHOT</tomee.version>
   </properties>
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -244,7 +244,7 @@
     <version.deltaspike>1.9.6</version.deltaspike>
 
     <!-- JDBC Drivers -->
-    <version.derby>10.14.2.0</version.derby>
+    <version.derby>10.15.2.0</version.derby>
     <version.hsqldb>2.7.1</version.hsqldb>
 
     <!-- unused properties -->


### PR DESCRIPTION
This is a tentative to update Derby to 10.15.x, upon other dep updates.

Derby 10.15.x is modular, it might break CI, please merge wisely.

TO BE MERGED AFTER: 
* PR #938 
* PR #953 

TomEE 9.x dependencies update: 
- Derby 10.15.2.0
