### PR TITLE
TOMEE-4088 TomEE 8.x + hsqldb 2.7.1 instead of workaround for CVE-2022-41853

### DIFF
--- a/boms/tomee-microprofile/pom.xml
+++ b/boms/tomee-microprofile/pom.xml
@@ -48,7 +48,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>2.14.0-rc1</version>
+      <version>2.14.0-rc2</version>
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>
@@ -59,7 +59,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.14.0-rc1</version>
+      <version>2.14.0-rc2</version>
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>
@@ -70,7 +70,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.14.0-rc1</version>
+      <version>2.14.0-rc2</version>
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>
@@ -81,7 +81,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-yaml</artifactId>
-      <version>2.14.0-rc1</version>
+      <version>2.14.0-rc2</version>
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>

--- a/boms/tomee-plume/pom.xml
+++ b/boms/tomee-plume/pom.xml
@@ -48,7 +48,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>2.14.0-rc1</version>
+      <version>2.14.0-rc2</version>
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>
@@ -59,7 +59,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.14.0-rc1</version>
+      <version>2.14.0-rc2</version>
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>
@@ -70,7 +70,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.14.0-rc1</version>
+      <version>2.14.0-rc2</version>
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>
@@ -81,7 +81,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-yaml</artifactId>
-      <version>2.14.0-rc1</version>
+      <version>2.14.0-rc2</version>
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>

--- a/boms/tomee-plus/pom.xml
+++ b/boms/tomee-plus/pom.xml
@@ -48,7 +48,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>2.14.0-rc1</version>
+      <version>2.14.0-rc2</version>
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>
@@ -59,7 +59,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.14.0-rc1</version>
+      <version>2.14.0-rc2</version>
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>
@@ -70,7 +70,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.14.0-rc1</version>
+      <version>2.14.0-rc2</version>
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>
@@ -81,7 +81,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-yaml</artifactId>
-      <version>2.14.0-rc1</version>
+      <version>2.14.0-rc2</version>
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>

--- a/container/openejb-loader/src/main/java/org/apache/openejb/loader/SystemInstance.java
+++ b/container/openejb-loader/src/main/java/org/apache/openejb/loader/SystemInstance.java
@@ -145,13 +145,6 @@ public final class SystemInstance {
         if (getProperty("hsqldb.reconfig_logging") == null) {
             setProperty("hsqldb.reconfig_logging", "false", true);
         }
-
-        // TOMEE-4086
-        // Prevent CVE-2022-41853 by setting hsqldb.method_class_names if it isn't set.
-        // See: https://github.com/advisories/GHSA-77xx-rxvh-q682
-        if (getProperty("hsqldb.method_class_names") == null) {
-            setProperty("hsqldb.method_class_names", "invalid", true);
-        }
     }
 
     public <E> E fireEvent(final E event) {

--- a/pom.xml
+++ b/pom.xml
@@ -216,7 +216,7 @@
     <version.eclipselink>2.7.11</version.eclipselink>
     <version.hibernate>5.6.12.Final</version.hibernate>
     <version.derby>10.14.2.0</version.derby>
-    <version.hsqldb>2.7.0</version.hsqldb>
+    <version.hsqldb>2.7.1</version.hsqldb>
 
     <!-- arquillian related -->
     <version.arquillian.bom>1.1.13.Final</version.arquillian.bom>
@@ -244,8 +244,8 @@
     <opentracing.api>0.31.0</opentracing.api>
 
     <!-- Jackson required by OpenAPI Impl -->
-    <jackson.version>2.14.0-rc1</jackson.version>
-    <jackson.dataformat.version>2.14.0-rc1</jackson.dataformat.version>
+    <version.jackson>2.14.0-rc2</version.jackson>
+    <version.jackson.dataformat>2.14.0-rc2</version.jackson.dataformat>
     <!-- required by Jackson dataformat yaml -->
     <snakeyaml.version>1.33</snakeyaml.version>
 
@@ -2017,13 +2017,13 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>${jackson.version}</version>
+        <version>${version.jackson}</version>
       </dependency>
       <!-- Jackson required by OpenAPI Impl -->
       <dependency>
         <groupId>com.fasterxml.jackson.dataformat</groupId>
         <artifactId>jackson-dataformat-yaml</artifactId>
-        <version>${jackson.dataformat.version}</version>
+        <version>${version.jackson.dataformat}</version>
         <exclusions>
           <exclusion>
             <groupId>org.yaml</groupId>


### PR DESCRIPTION
removed workaround upon dependency update hsqldb 2.7.1