### PR TITLE
[TOMEE-4115] Tomcat update to 10.1.x (may be outdated, please look changes and consider merge or close)

### DIFF
--- a/boms/tomee-microprofile/src/main/resources/tomee/conf/catalina.properties
+++ b/boms/tomee-microprofile/src/main/resources/tomee/conf/catalina.properties
@@ -185,6 +185,7 @@ tomcat-util.jar,\
 tomcat-websocket.jar,\
 tools.jar,\
 websocket-api.jar,\
+websocket-client-api.jar,\
 wsdl4j*.jar,\
 xercesImpl.jar,\
 xml-apis.jar,\

--- a/boms/tomee-plume/src/main/resources/tomee/conf/catalina.properties
+++ b/boms/tomee-plume/src/main/resources/tomee/conf/catalina.properties
@@ -185,6 +185,7 @@ tomcat-util.jar,\
 tomcat-websocket.jar,\
 tools.jar,\
 websocket-api.jar,\
+websocket-client-api.jar,\
 wsdl4j*.jar,\
 xercesImpl.jar,\
 xml-apis.jar,\

--- a/boms/tomee-plus/src/main/resources/tomee/conf/catalina.properties
+++ b/boms/tomee-plus/src/main/resources/tomee/conf/catalina.properties
@@ -185,6 +185,7 @@ tomcat-util.jar,\
 tomcat-websocket.jar,\
 tools.jar,\
 websocket-api.jar,\
+websocket-client-api.jar,\
 wsdl4j*.jar,\
 xercesImpl.jar,\
 xml-apis.jar,\

--- a/boms/tomee-webprofile/src/main/resources/tomee/conf/catalina.properties
+++ b/boms/tomee-webprofile/src/main/resources/tomee/conf/catalina.properties
@@ -185,6 +185,7 @@ tomcat-util.jar,\
 tomcat-websocket.jar,\
 tools.jar,\
 websocket-api.jar,\
+websocket-client-api.jar,\
 wsdl4j*.jar,\
 xercesImpl.jar,\
 xml-apis.jar,\

--- a/pom.xml
+++ b/pom.xml
@@ -214,7 +214,7 @@
     <geronimo-mail_2.1_spec.version>1.0.0-M1</geronimo-mail_2.1_spec.version>
 
     <!-- Jakarta EE Impl. -->
-    <tomcat.version>10.0.27</tomcat.version>
+    <tomcat.version>10.1.5</tomcat.version>
     <!-- com.sun -->
     <saaj-impl.version>2.0.1</saaj-impl.version>
     <!-- org.apache -->

--- a/tomee/apache-tomee/src/test/java/org/apache/tomee/bootstrap/GenerateBoms.java
+++ b/tomee/apache-tomee/src/test/java/org/apache/tomee/bootstrap/GenerateBoms.java
@@ -220,6 +220,7 @@ public class GenerateBoms {
                     .or(startsWith("jakarta.").and(endsWith("-api")))
                     .or(startsWith("microprofile-").and(endsWith("-api")))
                     .or(startsWith("microprofile-").and(endsWith("-api-shade")))
+                    .or(startsWith("websocket-").and(endsWith("-api"))) // websocket-client-api.jar in Tomcat 10.1+
                     .or(startsWith("tomcat-").and(endsWith("-api")));
 
             final List<Artifact> apiArtifacts = distribution.getArtifacts().stream()
@@ -486,6 +487,9 @@ public class GenerateBoms {
             }
             if (jar.getName().equals("websocket-api.jar")) {
                 return new Artifact("org.apache.tomcat", "tomcat-websocket-api", "${tomcat.version}", null);
+            }
+            if (jar.getName().equals("websocket-client-api.jar")) {
+                return new Artifact("org.apache.tomcat", "tomcat-websocket-client-api", "${tomcat.version}", null);
             }
             if (jar.getName().equals("tomcat-coyote.jar")) {
                 return new Artifact("org.apache.tomcat", "tomcat-coyote", "${tomcat.version}", null);

--- a/tomee/tomee-catalina/src/main/java/org/apache/tomee/catalina/LazyStopStandardRoot.java
+++ b/tomee/tomee-catalina/src/main/java/org/apache/tomee/catalina/LazyStopStandardRoot.java
@@ -191,6 +191,21 @@ public class LazyStopStandardRoot implements WebResourceRoot, JmxEnabled {
         return delegate.getTrackLockedFiles();
     }
 
+    @Override
+    public void setArchiveIndexStrategy(final String s) {
+        delegate.setArchiveIndexStrategy(s);
+    }
+
+    @Override
+    public String getArchiveIndexStrategy() {
+        return delegate.getArchiveIndexStrategy();
+    }
+
+    @Override
+    public ArchiveIndexStrategy getArchiveIndexStrategyEnum() {
+        return delegate.getArchiveIndexStrategyEnum();
+    }
+
     public List<String> getTrackedResources() { // IDE?
         return StandardRoot.class.cast(delegate).getTrackedResources();
     }

--- a/tomee/tomee-embedded/pom.xml
+++ b/tomee/tomee-embedded/pom.xml
@@ -299,6 +299,11 @@
       <version>${tomcat.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.tomcat</groupId>
+      <artifactId>tomcat-websocket-client-api</artifactId>
+      <version>${tomcat.version}</version>
+    </dependency>
+    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>tomee-myfaces</artifactId>
       <version>${project.version}</version>


### PR DESCRIPTION
Tomcat 10.0 (EE 9) has reach EOL

EDIT: reworked this PR for TomEE v10 instead.

this updates tomcat to 10.1.5

old comment:

---- 
needs either
* TomEE 9.x become EOL itself in favor of TomEE 10.x OR
* Update TomEE with tomcat 10.1.2 (EE 10) AND TomEE 9.x goes Jakarta EE 10 compliant OR
* Update TomEE with tomcat 10.1.2 (EE 10) AND TomEE 9.x stays Jakarta EE 9 compliant (believed better option)

Quote from Tomcat website

>Apache Tomcat 10.1.x
>Apache Tomcat 10.1.x is the current focus of development. It implements the Servlet 6.0, JSP 3.1, EL 5.0, WebSocket 2.1 and Authentication 3.0 specifications (the versions required by Jakarta EE 10 platform).

>Apache Tomcat 10.0.x
>Apache Tomcat 10.0.x implements the Servlet 5.0, JSP 3.0, EL 4.0, WebSocket 2.0 and Authentication 2.0 specifications (the versions required by Jakarta EE 9 platform).

>Users of Tomcat 10.0 should be aware that Tomcat 10.0 has now reached [end of life](https://tomcat.apache.org/tomcat-10.0-eol.html). Users of Tomcat 10.0.x should upgrade to Tomcat 10.1.x or later.