### PR TITLE
Make sure providers aren't scanned if Application returns classes or singletons.

### DIFF
--- a/mp-jwt/src/main/java/org/apache/tomee/microprofile/jwt/jaxrs/MPJWPProviderRegistration.java
+++ b/mp-jwt/src/main/java/org/apache/tomee/microprofile/jwt/jaxrs/MPJWPProviderRegistration.java
@@ -24,7 +24,7 @@ import org.apache.tomee.microprofile.jwt.bval.ValidationInterceptorsFeature;
 /**
  * OpenEJB/TomEE hack to register a new provider on the fly
  * Could be package in tomee only or done in another way
- *
+ * <p>
  * As soon as Roberto is done with the packaging, we can remove all this and providers are going to be scanned automatically
  */
 public class MPJWPProviderRegistration {

--- a/server/openejb-rest/src/main/java/org/apache/openejb/server/rest/RESTService.java
+++ b/server/openejb-rest/src/main/java/org/apache/openejb/server/rest/RESTService.java
@@ -364,8 +364,8 @@ public abstract class RESTService implements ServerService, SelfManaging {
                 .filter(Objects::nonNull)
                 .anyMatch(aClass -> aClass.getDeclaredMethods().length > 0);
 
-        // if (useDiscoveredProviders(appInfo, !hasExplicitlyDefinedApplication)) {
-        if (useDiscoveredProviders(appInfo)) {
+        if (useDiscoveredProviders(appInfo, !hasExplicitlyDefinedApplication)) {
+        // if (useDiscoveredProviders(appInfo)) {
             final Set<String> jaxRsProviders = new HashSet<>(webApp.jaxRsProviders);
             jaxRsProviders.addAll(appInfo.jaxRsProviders);
             additionalProviders.addAll(appProviders(jaxRsProviders, classLoader));

--- a/tck/microprofile-tck/opentracing/src/test/java/org.apache.tomee.microprofile.tck.opentracing/MicroProfileOpenTracingTCKDeploymentPackager.java
+++ b/tck/microprofile-tck/opentracing/src/test/java/org.apache.tomee.microprofile.tck.opentracing/MicroProfileOpenTracingTCKDeploymentPackager.java
@@ -51,7 +51,6 @@ public class MicroProfileOpenTracingTCKDeploymentPackager extends ServletProtoco
         webArchive.addAsLibrary(jarLocation(ThreadLocalScopeManager.class));
         webArchive.addAsWebInfResource("META-INF/beans.xml");
         webArchive.addClass(MicroProfileOpenTracingTCKTracer.class);
-        webArchive.addClass(MicroProfileOpenTracingExceptionMapper.class);
         ;
 
         System.out.println(webArchive.toString(true));

--- a/tck/microprofile-tck/opentracing/src/test/resources/META-INF/services/jakarta.ws.rs.ext.Providers
+++ b/tck/microprofile-tck/opentracing/src/test/resources/META-INF/services/jakarta.ws.rs.ext.Providers
@@ -1,2 +1,0 @@
-org.apache.tomee.microprofile.tck.opentracing.MicroProfileOpenTrackingContextResolver
-org.apache.tomee.microprofile.tck.opentracing.MicroProfileOpenTracingExceptionMapper

--- a/tomee/tomee-microprofile/mp-common/pom.xml
+++ b/tomee/tomee-microprofile/mp-common/pom.xml
@@ -171,6 +171,12 @@
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <artifactId>openejb-cxf-rs</artifactId>
+      <groupId>org.apache.tomee</groupId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
 
     <!-- MicroProfile -->
 

--- a/tomee/tomee-microprofile/mp-common/src/main/java/org/apache/tomee/microprofile/opentracing/MicroProfileOpenTracingExceptionMapper.java
+++ b/tomee/tomee-microprofile/mp-common/src/main/java/org/apache/tomee/microprofile/opentracing/MicroProfileOpenTracingExceptionMapper.java
@@ -14,10 +14,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.tomee.microprofile.tck.opentracing;
+package org.apache.tomee.microprofile.opentracing;
 
-import jakarta.ws.rs.ext.Provider;
 import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.Provider;
 
 @Provider
 public class MicroProfileOpenTracingExceptionMapper implements jakarta.ws.rs.ext.ExceptionMapper<RuntimeException> {


### PR DESCRIPTION
Register OpenTracing providers during MP initialization