### PR TITLE
[TOMEE-4128] Jakarta MVC API and Krazo (Impl.) provided in TomEE 9.x 'plume' and 'plus' server flavors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -239,7 +239,9 @@
     <version.hibernate.orm>6.1.4.Final</version.hibernate.orm>
     <version.hibernate.validator>7.0.5.Final</version.hibernate.validator>
 
+    <!-- Other API and Impl. not in Jakarta EE -->
     <geronimo-jcache_1.0_spec.version>1.0-alpha-1</geronimo-jcache_1.0_spec.version>
+    <version.mvc>2.0.1</version.mvc>
     <version.krazo>2.0.2</version.krazo>
     <version.deltaspike>1.9.6</version.deltaspike>
 

--- a/tck/mvc-tck/pom.xml
+++ b/tck/mvc-tck/pom.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.tomee</groupId>
+    <artifactId>tck</artifactId>
+    <version>9.0.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>mvc-tck</artifactId>
+  <name>TomEE :: TCK :: Jakarta MVC TCK</name>
+
+  <profiles>
+    <profile>
+      <id>mvc-tck</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>tomee-plus</id>
+                <goals>
+                  <goal>test</goal>
+                </goals>
+                <configuration>
+                  <systemPropertyVariables combine.children="append">
+                    <arquillian.launch>tomee-plus</arquillian.launch>
+                  </systemPropertyVariables>
+                </configuration>
+              </execution>
+              <execution>
+                <id>tomee-plume</id>
+                <goals>
+                  <goal>test</goal>
+                </goals>
+                <configuration>
+                  <systemPropertyVariables combine.children="append">
+                    <arquillian.launch>tomee-plume</arquillian.launch>
+                  </systemPropertyVariables>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
+  <dependencies>
+
+    <dependency>
+      <groupId>jakarta.mvc.tck</groupId>
+      <artifactId>mvc-tck-api</artifactId>
+      <version>${version.mvc}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.mvc.tck</groupId>
+      <artifactId>mvc-tck-tests</artifactId>
+      <version>${version.mvc}</version>
+      <scope>test</scope>
+    </dependency>
+
+  </dependencies>
+
+</project>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -42,6 +42,7 @@
     <module>bval-tomee</module>
     <module>bval-signature-test</module>
     <module>microprofile-tck</module>
+    <module>mvc-tck</module>
   </modules>
 
   <build>

--- a/tomee/tomee-plume-webapp/pom.xml
+++ b/tomee/tomee-plume-webapp/pom.xml
@@ -595,6 +595,17 @@
       <artifactId>jakarta.faces</artifactId>
       <scope>runtime</scope>
     </dependency>
+    <!-- Jakarta MVC -->
+    <dependency>
+      <groupId>jakarta.mvc</groupId>
+      <artifactId>jakarta.mvc-api</artifactId>
+      <version>${version.mvc}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.krazo</groupId>
+      <artifactId>krazo-cxf</artifactId>
+      <version>${version.krazo}</version>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/tomee/tomee-plus-webapp/pom.xml
+++ b/tomee/tomee-plus-webapp/pom.xml
@@ -620,6 +620,17 @@
       <version>3.2</version>
       <scope>test</scope>
     </dependency>
+    <!-- Jakarta MVC -->
+    <dependency>
+      <groupId>jakarta.mvc</groupId>
+      <artifactId>jakarta.mvc-api</artifactId>
+      <version>${version.mvc}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.krazo</groupId>
+      <artifactId>krazo-cxf</artifactId>
+      <version>${version.krazo}</version>
+    </dependency>
   </dependencies>
   <build>
     <plugins>


### PR DESCRIPTION
This PR modifies the dependencies for plume and plus, adding the following dependencies:
* Jakarta MVC API
* Krazo CXF

this allows an application to avoid depending on the implementation choices (CXF)
now an app can depend on the API instead.

** please build on CI before merging **