### PR TITLE
TOMEE-4120

### DIFF
--- a/server/openejb-client/src/main/java/org/apache/openejb/client/EJBInvocationHandler.java
+++ b/server/openejb-client/src/main/java/org/apache/openejb/client/EJBInvocationHandler.java
@@ -208,8 +208,8 @@ public abstract class EJBInvocationHandler implements InvocationHandler, Seriali
     	l.lock();
 
     	try {
-        	// this map lookup must be the synchronized even though it is a ConcurrentHashMap to avoid race condition with the clean up below
-    		Set<WeakReference<EJBInvocationHandler>> set = liveHandleRegistry.get(key);
+        	// this map lookup must be synchronized even though it is a ConcurrentHashMap to avoid race condition with the clean up below
+    		final Set<WeakReference<EJBInvocationHandler>> set = liveHandleRegistry.get(key);
     		if (set == null) {
     			set = new HashSet<WeakReference<EJBInvocationHandler>>();
     			liveHandleRegistry.put(key, set);
@@ -218,10 +218,10 @@ public abstract class EJBInvocationHandler implements InvocationHandler, Seriali
 
     		// loop through and remove old references that have been garbage collected
     		for (Iterator<Map.Entry<Object,Set<WeakReference<EJBInvocationHandler>>>> i = liveHandleRegistry.entrySet().iterator(); i.hasNext(); ) {
-    			Map.Entry<Object,Set<WeakReference<EJBInvocationHandler>>> entry = i.next();
-    			Set<WeakReference<EJBInvocationHandler>> s = entry.getValue();
+                final Map.Entry<Object,Set<WeakReference<EJBInvocationHandler>>> entry = i.next();
+                final Set<WeakReference<EJBInvocationHandler>> s = entry.getValue();
     			for (Iterator<WeakReference<EJBInvocationHandler>> j = s.iterator(); j.hasNext(); ) {
-    				WeakReference<EJBInvocationHandler> ref = j.next();
+                    final WeakReference<EJBInvocationHandler> ref = j.next();
     				if (ref.get() == null) {
     					j.remove(); // clean up old WeakReference
     				}

--- a/server/openejb-client/src/main/java/org/apache/openejb/client/EJBInvocationHandler.java
+++ b/server/openejb-client/src/main/java/org/apache/openejb/client/EJBInvocationHandler.java
@@ -37,6 +37,8 @@ import java.rmi.NoSuchObjectException;
 import java.rmi.RemoteException;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -202,25 +204,35 @@ public abstract class EJBInvocationHandler implements InvocationHandler, Seriali
     }
 
     protected static void registerHandler(final Object key, final EJBInvocationHandler handler) {
-        Set<WeakReference<EJBInvocationHandler>> set = liveHandleRegistry.get(key);
+    	final ReentrantLock l = lock;
+    	l.lock();
 
-        if (set == null) {
-            set = new HashSet<WeakReference<EJBInvocationHandler>>();
-            final Set<WeakReference<EJBInvocationHandler>> current = liveHandleRegistry.putIfAbsent(key, set);
-            // someone else added the set
-            if (current != null) {
-                set = current;
-            }
-        }
+    	try {
+        	// this map lookup must be the synchronized even though it is a ConcurrentHashMap to avoid race condition with the clean up below
+    		Set<WeakReference<EJBInvocationHandler>> set = liveHandleRegistry.get(key);
+    		if (set == null) {
+    			set = new HashSet<WeakReference<EJBInvocationHandler>>();
+    			liveHandleRegistry.put(key, set);
+    		}
+    		set.add(new WeakReference<EJBInvocationHandler>(handler));
 
-        final ReentrantLock l = lock;
-        l.lock();
-
-        try {
-            set.add(new WeakReference<EJBInvocationHandler>(handler));
-        } finally {
-            l.unlock();
-        }
+    		// loop through and remove old references that have been garbage collected
+    		for (Iterator<Map.Entry<Object,Set<WeakReference<EJBInvocationHandler>>>> i = liveHandleRegistry.entrySet().iterator(); i.hasNext(); ) {
+    			Map.Entry<Object,Set<WeakReference<EJBInvocationHandler>>> entry = i.next();
+    			Set<WeakReference<EJBInvocationHandler>> s = entry.getValue();
+    			for (Iterator<WeakReference<EJBInvocationHandler>> j = s.iterator(); j.hasNext(); ) {
+    				WeakReference<EJBInvocationHandler> ref = j.next();
+    				if (ref.get() == null) {
+    					j.remove(); // clean up old WeakReference
+    				}
+    			}
+    			if (s.isEmpty()) {
+    				i.remove(); // no more handlers for this primary key, remove map entry
+    			}
+    		}
+    	} finally {
+    		l.unlock();
+    	}
     }
 
     /**

--- a/server/openejb-client/src/main/java/org/apache/openejb/client/EntityEJBHomeHandler.java
+++ b/server/openejb-client/src/main/java/org/apache/openejb/client/EntityEJBHomeHandler.java
@@ -56,7 +56,6 @@ public class EntityEJBHomeHandler extends EJBHomeHandler {
                 } else {
                     handler = EJBObjectHandler.createEJBObjectHandler(executor, ejb, server, client, primKey, authenticationInfo);
                     handler.setEJBHomeProxy((EJBHomeProxy) proxy);
-                    registerHandler(ejb.deploymentID + ":" + primKey, handler);
                     return handler.createEJBObjectProxy();
                 }
 
@@ -69,7 +68,6 @@ public class EntityEJBHomeHandler extends EJBHomeHandler {
                     if (primKey != null) {
                         handler = EJBObjectHandler.createEJBObjectHandler(executor, ejb, server, client, primKey, authenticationInfo);
                         handler.setEJBHomeProxy((EJBHomeProxy) proxy);
-                        registerHandler(ejb.deploymentID + ":" + primKey, handler);
                         primaryKeys[i] = handler.createEJBObjectProxy();
                     }
                 }
@@ -83,7 +81,6 @@ public class EntityEJBHomeHandler extends EJBHomeHandler {
                     if (primKey != null) {
                         handler = EJBObjectHandler.createEJBObjectHandler(executor, ejb, server, client, primKey, authenticationInfo);
                         handler.setEJBHomeProxy((EJBHomeProxy) proxy);
-                        registerHandler(ejb.deploymentID + ":" + primKey, handler);
                         primaryKeys[i] = handler.createEJBObjectProxy();
                     }
                 }


### PR DESCRIPTION
Fix for memory link in bmp entity finder registration (JIRA TOMEE-4120)
Also eliminated double registration of the same handler
