### PR TITLE
[TOMEE-4053] Dependency properties cleanup; TomEE 8.0.x branch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -197,7 +197,6 @@
     <version.batchee>1.0.2</version.batchee>
     <version.bval>2.0.5</version.bval>
     <version.cxf>3.4.10</version.cxf>
-    <version.woodstox>6.4.0</version.woodstox>
     <version.geronimo.components>3.1.5</version.geronimo.components>
     <version.geronimo-javamail_1.6_mail>1.0.1</version.geronimo-javamail_1.6_mail>
     <version.johnzon>1.2.19</version.johnzon>
@@ -213,6 +212,7 @@
     <version.hibernate.validator>6.2.5.Final</version.hibernate.validator>
 
     <!-- Other API and Impl. not in Jakarta EE -->
+    <version.woodstox>6.4.0</version.woodstox>
     <version.ehcache>2.10.6</version.ehcache>
     <version.geronimo-jcache_1.0_spec>1.0-alpha-1</version.geronimo-jcache_1.0_spec>
     <version.krazo>1.1.1</version.krazo>


### PR DESCRIPTION
woodstox is not a Jakarta EE implementation; therefore the version property can move to the "Other API and Impl. not in Jakarta EE" section

please care about the branch in which this PR is merged (change to tomee-8.x if need be)