### PR TITLE
[TOMEE-4140] Update Micro Profile to 6.0 except SmallRye Metrics

### DIFF
--- a/examples/mp-config-example/pom.xml
+++ b/examples/mp-config-example/pom.xml
@@ -24,7 +24,7 @@
   <name>TomEE :: Examples :: MicroProfile Config</name>
   <properties>
     <version.jakartaee-api>10.0-M1</version.jakartaee-api>
-    <version.microprofile.config>3.0.1</version.microprofile.config>
+    <version.microprofile.config>3.0.2</version.microprofile.config>
     <tomee.version>10.0.0-SNAPSHOT</tomee.version>
     <version.arquillian>1.7.0.Alpha10</version.arquillian>
   </properties>

--- a/examples/mp-custom-healthcheck/pom.xml
+++ b/examples/mp-custom-healthcheck/pom.xml
@@ -24,7 +24,7 @@
   <name>TomEE :: Examples :: Custom HealthCheck</name>
   <properties>
     <arquillian-junit-container.version>1.7.0.Alpha10</arquillian-junit-container.version>
-    <version.microprofile.health-api>4.0</version.microprofile.health-api>
+    <version.microprofile.health-api>4.0.1</version.microprofile.health-api>
     <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>
     <maven-war-plugin.version>3.1.0</maven-war-plugin.version>
     <jakartaee-api.version>10.0-M1</jakartaee-api.version>

--- a/examples/mp-faulttolerance-fallback/pom.xml
+++ b/examples/mp-faulttolerance-fallback/pom.xml
@@ -21,7 +21,7 @@
   <packaging>war</packaging>
   <name>TomEE :: Examples :: Microprofile Fault Tolerance :: Fallback</name>
   <properties>
-    <version.microprofile.fault-tolerance-api>1.0</version.microprofile.fault-tolerance-api>
+    <version.microprofile.fault-tolerance-api>4.0.2</version.microprofile.fault-tolerance-api>
     <arquillian-junit-container.version>1.7.0.Alpha10</arquillian-junit-container.version>
     <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>
     <maven-war-plugin.version>3.1.0</maven-war-plugin.version>

--- a/examples/mp-faulttolerance-retry/pom.xml
+++ b/examples/mp-faulttolerance-retry/pom.xml
@@ -23,7 +23,7 @@
   <packaging>war</packaging>
   <name>TomEE :: Examples :: Microprofile Fault Tolerance :: Retry</name>
   <properties>
-    <version.microprofile.fault-tolerance-api>1.0</version.microprofile.fault-tolerance-api>
+    <version.microprofile.fault-tolerance-api>4.0.2</version.microprofile.fault-tolerance-api>
     <arquillian-junit-container.version>1.7.0.Alpha10</arquillian-junit-container.version>
     <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>
     <maven-war-plugin.version>3.1.0</maven-war-plugin.version>

--- a/examples/mp-faulttolerance-timeout/pom.xml
+++ b/examples/mp-faulttolerance-timeout/pom.xml
@@ -23,7 +23,7 @@
   <packaging>war</packaging>
   <name>TomEE :: Examples :: Microprofile Fault Tolerance :: Timeout</name>
   <properties>
-    <version.microprofile.fault-tolerance-api>1.0</version.microprofile.fault-tolerance-api>
+    <version.microprofile.fault-tolerance-api>4.0.2</version.microprofile.fault-tolerance-api>
     <arquillian-junit-container.version>1.7.0.Alpha10</arquillian-junit-container.version>
     <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>
     <maven-war-plugin.version>3.1.0</maven-war-plugin.version>

--- a/examples/mp-metrics-counted/pom.xml
+++ b/examples/mp-metrics-counted/pom.xml
@@ -25,7 +25,7 @@
   <name>TomEE :: Examples :: Microprofile Metrics Counted</name>
   <properties>
     <version.jakartaee-api>10.0-M1</version.jakartaee-api>
-    <version.microprofile.metrics>3.0.1</version.microprofile.metrics>
+    <version.microprofile.metrics>5.0.0</version.microprofile.metrics>
     <version.arquillian.bom>1.7.0.Alpha10</version.arquillian.bom>
     <junit.version>4.13.2</junit.version>
     <docker.image.name>tomee/${project.artifactId}</docker.image.name>

--- a/examples/mp-metrics-gauge/pom.xml
+++ b/examples/mp-metrics-gauge/pom.xml
@@ -24,7 +24,7 @@
   <name>TomEE :: Examples :: MicroProfile Metrics Gauge</name>
   <properties>
     <version.jakartaee-api>10.0-M1</version.jakartaee-api>
-    <version.microprofile.metrics>3.0.1</version.microprofile.metrics>
+    <version.microprofile.metrics>5.0.0</version.microprofile.metrics>
     <version.arquillian.bom>1.7.0.Alpha10</version.arquillian.bom>
     <junit.version>4.13.2</junit.version>
     <tomee.version>10.0.0-SNAPSHOT</tomee.version>

--- a/examples/mp-metrics-histogram/pom.xml
+++ b/examples/mp-metrics-histogram/pom.xml
@@ -25,7 +25,7 @@
   <name>TomEE :: Examples :: Microprofile Metrics Histogram</name>
   <properties>
     <version.jakartaee-api>10.0-M1</version.jakartaee-api>
-    <version.microprofile.metrics>3.0.1</version.microprofile.metrics>
+    <version.microprofile.metrics>5.0.0</version.microprofile.metrics>
     <version.arquillian.bom>1.7.0.Alpha10</version.arquillian.bom>
     <junit.version>4.13.2</junit.version>
     <tomee.version>10.0.0-SNAPSHOT</tomee.version>

--- a/examples/mp-metrics-metered/pom.xml
+++ b/examples/mp-metrics-metered/pom.xml
@@ -24,7 +24,7 @@
   <packaging>war</packaging>
   <properties>
     <version.jakartaee-api>10.0-M1</version.jakartaee-api>
-    <version.microprofile.metrics>3.0.1</version.microprofile.metrics>
+    <version.microprofile.metrics>5.0.0</version.microprofile.metrics>
     <version.arquillian.bom>1.7.0.Alpha10</version.arquillian.bom>
     <junit.version>4.13.2</junit.version>
     <tomee.version>10.0.0-SNAPSHOT</tomee.version>

--- a/examples/mp-metrics-timed/pom.xml
+++ b/examples/mp-metrics-timed/pom.xml
@@ -24,7 +24,7 @@
   <name>TomEE :: Examples :: Microprofile Metrics Timed</name>
   <properties>
     <version.jakartaee-api>10.0-M1</version.jakartaee-api>
-    <version.microprofile.metrics>3.0.1</version.microprofile.metrics>
+    <version.microprofile.metrics>5.0.0</version.microprofile.metrics>
     <version.arquillian.bom>1.7.0.Alpha10</version.arquillian.bom>
     <junit.version>4.13.2</junit.version>
     <tomee.version>10.0.0-SNAPSHOT</tomee.version>

--- a/examples/mp-rest-client/pom.xml
+++ b/examples/mp-rest-client/pom.xml
@@ -24,7 +24,7 @@
   <packaging>war</packaging>
   <name>TomEE :: Examples :: Microprofile REST Client</name>
   <properties>
-    <version.microprofile.rest-client>3.0</version.microprofile.rest-client>
+    <version.microprofile.rest-client>3.0.1</version.microprofile.rest-client>
     <version.jakartaee-api>10.0-M1</version.jakartaee-api>
     <version.arquillian.bom>1.7.0.Alpha10</version.arquillian.bom>
     <junit.version>4.13.2</junit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -174,24 +174,24 @@
     <maven.compiler.release>11</maven.compiler.release>
 
     <!-- Micro Profile API -->
-    <version.microprofile>5.0</version.microprofile>
+    <version.microprofile>6.0</version.microprofile>
     <version.microprofile.config>3.0.2</version.microprofile.config>
     <version.microprofile.fault-tolerance>4.0.2</version.microprofile.fault-tolerance>
     <version.microprofile.health>4.0.1</version.microprofile.health>
-    <version.microprofile.jwt>2.0</version.microprofile.jwt>
-    <version.microprofile.metrics>4.0.1</version.microprofile.metrics>
-    <version.microprofile.openapi>3.0</version.microprofile.openapi>
+    <version.microprofile.jwt>2.1</version.microprofile.jwt>
+    <version.microprofile.metrics>5.0.0</version.microprofile.metrics>
+    <version.microprofile.openapi>3.1</version.microprofile.openapi>
     <version.microprofile.opentracing>3.0</version.microprofile.opentracing>
     <version.microprofile.rest-client>3.0.1</version.microprofile.rest-client>
 
     <version.io.opentracing>0.33.0</version.io.opentracing>
 
     <!-- Micro Profile Impl. -->
-    <version.microprofile.impl.config>3.0.0</version.microprofile.impl.config>
-    <version.microprofile.impl.fault-tolerance>6.0.0</version.microprofile.impl.fault-tolerance>
-    <version.microprofile.impl.health>4.0.0</version.microprofile.impl.health>
+    <version.microprofile.impl.config>3.1.1</version.microprofile.impl.config>
+    <version.microprofile.impl.fault-tolerance>6.1.0</version.microprofile.impl.fault-tolerance>
+    <version.microprofile.impl.health>4.0.1</version.microprofile.impl.health>
     <version.microprofile.impl.metrics>4.0.0</version.microprofile.impl.metrics>
-    <version.microprofile.impl.openapi>3.0.0</version.microprofile.impl.openapi>
+    <version.microprofile.impl.openapi>3.1.2</version.microprofile.impl.openapi>
     <version.microprofile.impl.opentracing>3.0.0</version.microprofile.impl.opentracing>
 
     <!-- Jackson and snakeyaml required by OpenAPI Impl -->


### PR DESCRIPTION
Edited:

This PR needs to be merged *AFTER* PR #997
* PR #997 

[TOMEE-4140] Update Micro Profile from 5.0 to 6.0 : 
* update MP Config from 3.0.1 to 3.0.2
* update MP Health from 4.0 to 4.0.1
* update MP JWT from 3.0 to 3.1
* update MP Metrics from 3.0.1/4.0.1 to 5.0.0
* update MP Open API from 3.0 to 3.1
* update MP Rest from 3.0 to 3.0.1
* update Small Rye except the Metrics stays at 4.0.0 (instead of updating to 5.0.0)

Small Rye Metrics 5.0.0 to be done in another PR
 
I cant run the TCKs at the moment.

The TCKs might not pass after this PR.
It is precisely intended to detect the failing TCKs.

