### PR TITLE
Remove obsolete EJBContext methods 

### DIFF
--- a/container/openejb-core/src/main/java/org/apache/openejb/core/BaseContext.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/core/BaseContext.java
@@ -46,11 +46,9 @@ import jakarta.transaction.SystemException;
 import jakarta.transaction.UserTransaction;
 import java.io.ObjectStreamException;
 import java.io.Serializable;
-import java.security.Identity;
 import java.security.Principal;
 import java.util.Collection;
 import java.util.Map;
-import java.util.Properties;
 
 
 /**
@@ -89,6 +87,7 @@ public abstract class BaseContext implements EJBContext, Serializable {
         return new IllegalStateException(call + " cannot be called in " + operation);
     }
 
+    @Override
     public Map<String, Object> getContextData() {
         doCheck(Call.getContextData);
         return ThreadContext.getThreadContext().get(InvocationContext.class).getContextData();
@@ -101,6 +100,7 @@ public abstract class BaseContext implements EJBContext, Serializable {
         }
     }
 
+    @Override
     public EJBHome getEJBHome() {
         final ThreadContext threadContext = ThreadContext.getThreadContext();
         final BeanContext di = threadContext.getBeanContext();
@@ -108,6 +108,7 @@ public abstract class BaseContext implements EJBContext, Serializable {
         return di.getEJBHome();
     }
 
+    @Override
     public EJBLocalHome getEJBLocalHome() {
         final ThreadContext threadContext = ThreadContext.getThreadContext();
         final BeanContext di = threadContext.getBeanContext();
@@ -115,6 +116,7 @@ public abstract class BaseContext implements EJBContext, Serializable {
         return di.getEJBLocalHome();
     }
 
+    @Override
     public Principal getCallerPrincipal() {
         doCheck(Call.getCallerPrincipal);
         Principal callerPrincipal = getCallerPrincipal(securityService);
@@ -239,19 +241,7 @@ public abstract class BaseContext implements EJBContext, Serializable {
         return di.isBeanManagedTransaction();
     }
 
-
-    public final Properties getEnvironment() {
-        throw new UnsupportedOperationException();
-    }
-
-    public final Identity getCallerIdentity() {
-        throw new UnsupportedOperationException();
-    }
-
-    public final boolean isCallerInRole(final Identity identity) {
-        throw new UnsupportedOperationException();
-    }
-
+    @Override
     public Object lookup(final String name) {
         final ThreadContext threadContext = ThreadContext.getThreadContext();
         final BeanContext beanContext = threadContext.getBeanContext();


### PR DESCRIPTION
The `EJBContext` methods `getEnvironment`, `getCallerIdentity` and `isCallerInRole(Identity)` were removed in Jakarta EE 9, but their implementations remain in `BaseContext`.

This PR suggests we remove these now-obsolete methods and also add `@Override` annotations to prevent future removals going unnoticed.

This also removed the depdency on the deprecated for-removal `java.security.Identity` class and allows TomEE to run on future JREs where this class has been removed. 