### PR TITLE
[tomee-9.x] Fix TOMEE-4222 - LoginToContinue causes IllegalArgumentException: setAttribute: Non-serializable attribute

### DIFF
--- a/tomee/tomee-security/src/main/java/org/apache/tomee/security/http/SavedAuthentication.java
+++ b/tomee/tomee-security/src/main/java/org/apache/tomee/security/http/SavedAuthentication.java
@@ -22,7 +22,10 @@ import java.util.Set;
 
 import static java.util.Collections.unmodifiableSet;
 
-public final class SavedAuthentication {
+import java.io.Serializable;
+
+public final class SavedAuthentication implements Serializable {
+    private static final long serialVersionUID = 1L;
     private final Principal principal;
     private final Set<String> groups;
 

--- a/tomee/tomee-security/src/main/java/org/apache/tomee/security/http/SavedRequest.java
+++ b/tomee/tomee-security/src/main/java/org/apache/tomee/security/http/SavedRequest.java
@@ -19,6 +19,8 @@ package org.apache.tomee.security.http;
 import org.apache.tomcat.util.buf.ByteChunk;
 
 import jakarta.servlet.http.Cookie;
+
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -30,7 +32,8 @@ import java.util.Map;
 /**
  * Mostly copied from org.apache.catalina.authenticator.SavedRequest.
  */
-public final class SavedRequest {
+public final class SavedRequest implements Serializable {
+    private static final long serialVersionUID = 1L;
 
     SavedRequest() {
     }

--- a/tomee/tomee-security/src/test/java/org/apache/tomee/security/http/SavedAuthenticationTest.java
+++ b/tomee/tomee-security/src/test/java/org/apache/tomee/security/http/SavedAuthenticationTest.java
@@ -1,0 +1,18 @@
+package org.apache.tomee.security.http;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.Serializable;
+import java.util.HashSet;
+
+import org.junit.Test;
+
+public class SavedAuthenticationTest {
+
+  @Test
+  public void testSerializable() {
+    final SavedAuthentication savedAuthentication = new SavedAuthentication(null, new HashSet<>());
+    assertTrue("SavedAuthentication must implement Serializable, since it will be set as a session attribute",
+        savedAuthentication instanceof Serializable);
+  }
+}

--- a/tomee/tomee-security/src/test/java/org/apache/tomee/security/http/SavedAuthenticationTest.java
+++ b/tomee/tomee-security/src/test/java/org/apache/tomee/security/http/SavedAuthenticationTest.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.tomee.security.http;
 
 import static org.junit.Assert.assertTrue;
@@ -7,7 +23,7 @@ import java.util.HashSet;
 
 import org.junit.Test;
 
-public class SavedAuthenticationTest {
+class SavedAuthenticationTest {
 
   @Test
   public void testSerializable() {

--- a/tomee/tomee-security/src/test/java/org/apache/tomee/security/http/SavedRequestTest.java
+++ b/tomee/tomee-security/src/test/java/org/apache/tomee/security/http/SavedRequestTest.java
@@ -1,0 +1,16 @@
+package org.apache.tomee.security.http;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.Serializable;
+
+import org.junit.Test;
+
+public class SavedRequestTest {
+  @Test
+  public void testSerializable() {
+    final SavedRequest savedRequest = new SavedRequest();
+    assertTrue("SavedRequest  must implement Serializable, since it will be set as a session attribute",
+        savedRequest instanceof Serializable);
+  }
+}

--- a/tomee/tomee-security/src/test/java/org/apache/tomee/security/http/SavedRequestTest.java
+++ b/tomee/tomee-security/src/test/java/org/apache/tomee/security/http/SavedRequestTest.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.tomee.security.http;
 
 import static org.junit.Assert.assertTrue;
@@ -6,7 +22,7 @@ import java.io.Serializable;
 
 import org.junit.Test;
 
-public class SavedRequestTest {
+class SavedRequestTest {
   @Test
   public void testSerializable() {
     final SavedRequest savedRequest = new SavedRequest();


### PR DESCRIPTION
(cherry picked from commit 4d9f032368d4cac936ed40c1ad7771ca4021b8b6)