### PR TITLE
Fix #TOMEE-4265: EarClassLoaderTest and EarWebAppFirstClassLoaderTest 

### DIFF
--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-jaxws-tests/src/test/java/org/apache/openejb/arquillian/tests/jaxws/EarClassLoaderTest.java
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-jaxws-tests/src/test/java/org/apache/openejb/arquillian/tests/jaxws/EarClassLoaderTest.java
@@ -48,7 +48,7 @@ public class EarClassLoaderTest {
                                         Maven.configureResolver()
                                                 .workOffline()
                                                 .withClassPathResolution(true)
-                                                .resolve("joda-time:joda-time:2.5")
+                                                .resolve("joda-time:joda-time:2.10.10")
                                                 .using(new AcceptScopesStrategy(ScopeType.COMPILE, ScopeType.RUNTIME))
                                                 .asFile()
                                 )
@@ -63,6 +63,6 @@ public class EarClassLoaderTest {
         // embedded case uses the classpath for a lot of reasons
         assumeFalse(System.getProperty("openejb.arquillian.adapter", "embedded").contains("embedded"));
         final String slurp = IO.slurp(new URL(url.toExternalForm() + (url.getPath().isEmpty() ? "/broken-web/" : "") + "joda"));
-        assertTrue(slurp.endsWith("broken-web/WEB-INF/lib/joda-time-2.5.jar"));
+        assertTrue(slurp.endsWith("broken-web/WEB-INF/lib/joda-time-2.10.10.jar"));
     }
 }

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-jaxws-tests/src/test/java/org/apache/openejb/arquillian/tests/jaxws/EarWebAppFirstClassLoaderTest.java
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-jaxws-tests/src/test/java/org/apache/openejb/arquillian/tests/jaxws/EarWebAppFirstClassLoaderTest.java
@@ -48,7 +48,7 @@ public class EarWebAppFirstClassLoaderTest {
         final File[] joda = Maven.configureResolver()
                 .workOffline()
                 .withClassPathResolution(true)
-                .resolve("joda-time:joda-time:2.5")
+                .resolve("joda-time:joda-time:2.10.10")
                 .using(new AcceptScopesStrategy(ScopeType.COMPILE, ScopeType.RUNTIME))
                 .asFile();
         return ShrinkWrap.create(EnterpriseArchive.class, "broken.ear")
@@ -70,7 +70,7 @@ public class EarWebAppFirstClassLoaderTest {
     public void checkIfWasCorretlyLoaded() throws IOException {
         assumeFalse(System.getProperty("openejb.arquillian.adapter", "embedded").contains("embedded"));
         final String slurp = IO.slurp(new URL(url.toExternalForm() + (url.getPath().isEmpty() ? "/broken-web/" : "") + "joda"));
-        assertTrue(slurp.endsWith("broken-web/WEB-INF/lib/joda-time-2.5.jar"));
-        assertFalse(slurp.endsWith("broken/lib/joda-time-2.5.jar")); // useless cause of the previous but to make it obvious
+        assertTrue(slurp.endsWith("broken-web/WEB-INF/lib/joda-time-2.10.10.jar"));
+        assertFalse(slurp.endsWith("broken/lib/joda-time-2.10.10.jar")); // useless cause of the previous but to make it obvious
     }
 }


### PR DESCRIPTION
Fix #TOMEE-4265: EarClassLoaderTest and EarWebAppFirstClassLoaderTest test failures on 8.0.16-SNAPSHOT. joda-time dependency was upgraded from 2.5 and the corresponding tests were not upgraded to 2.10.10