### PR TITLE
add an integration test for optional beans

### DIFF
--- a/itests/openejb-itests-optional-classes/3rdpartydep/pom.xml
+++ b/itests/openejb-itests-optional-classes/3rdpartydep/pom.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+
+<!-- $Rev$ $Date$ -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.tomee.itests</groupId>
+        <artifactId>openejb-itests-optional-classes</artifactId>
+        <version>10.0.0-M1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>opt-3rdparty</artifactId>
+</project>

--- a/itests/openejb-itests-optional-classes/3rdpartydep/src/main/java/org/apache/tomee/itests/optional/thirdparty/ThirdPartyApi.java
+++ b/itests/openejb-itests-optional-classes/3rdpartydep/src/main/java/org/apache/tomee/itests/optional/thirdparty/ThirdPartyApi.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.tomee.itests.optional.thirdparty;
 
 /**

--- a/itests/openejb-itests-optional-classes/3rdpartydep/src/main/java/org/apache/tomee/itests/optional/thirdparty/ThirdPartyApi.java
+++ b/itests/openejb-itests-optional-classes/3rdpartydep/src/main/java/org/apache/tomee/itests/optional/thirdparty/ThirdPartyApi.java
@@ -1,0 +1,10 @@
+package org.apache.tomee.itests.optional.thirdparty;
+
+/**
+ * This is an example of an optional 3rd party library
+ * used in the opt-lib project.
+ */
+public interface ThirdPartyApi {
+
+    int meaningOfLife();
+}

--- a/itests/openejb-itests-optional-classes/3rdpartydep/src/main/resources/META-INF/beans.xml
+++ b/itests/openejb-itests-optional-classes/3rdpartydep/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements. See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership. The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License. You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       version="3.0" bean-discovery-mode="all">
+    <trim/>
+</beans>

--- a/itests/openejb-itests-optional-classes/app/pom.xml
+++ b/itests/openejb-itests-optional-classes/app/pom.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+
+<!-- $Rev$ $Date$ -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.tomee.itests</groupId>
+        <artifactId>openejb-itests-optional-classes</artifactId>
+        <version>10.0.0-M1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>opt-app</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.tomee.itests</groupId>
+            <artifactId>opt-lib</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.tomee</groupId>
+            <artifactId>openejb-core</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/itests/openejb-itests-optional-classes/app/src/main/resources/META-INF/beans.xml
+++ b/itests/openejb-itests-optional-classes/app/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements. See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership. The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License. You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       version="3.0" bean-discovery-mode="all">
+    <trim/>
+</beans>

--- a/itests/openejb-itests-optional-classes/app/src/test/java/org/apache/tomee/itests/optional/app/OptionalDependencyResolutionTest.java
+++ b/itests/openejb-itests-optional-classes/app/src/test/java/org/apache/tomee/itests/optional/app/OptionalDependencyResolutionTest.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.tomee.itests.optional.app;
+
+import java.util.Properties;
+import java.util.Set;
+
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+
+import org.apache.openejb.OpenEjbContainer;
+import org.apache.openejb.core.LocalInitialContext;
+import org.apache.openejb.core.LocalInitialContextFactory;
+import org.apache.tomee.itests.optional.optlib.Car;
+import org.apache.tomee.itests.optional.optlib.SomeBean;
+import org.apache.tomee.itests.optional.optlib.Vehicle;
+import org.junit.Test;
+
+import jakarta.enterprise.inject.spi.Bean;
+import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.enterprise.inject.spi.CDI;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author <a href="mailto:struberg@apache.org">Mark Struberg</a>
+ */
+public class OptionalDependencyResolutionTest {
+
+    @Test
+    public void testContainerBoot() throws NamingException {
+        // we use classic discovery via the classpath
+        Properties p = new Properties();
+        p.put(Context.INITIAL_CONTEXT_FACTORY, LocalInitialContextFactory.class.getName());
+        p.put(LocalInitialContext.ON_CLOSE, LocalInitialContext.Close.DESTROY.name());
+        try
+        {
+            this.getClass().getClassLoader().loadClass("org.apache.openejb.server.ServiceManager");
+            p.put(OpenEjbContainer.OPENEJB_EMBEDDED_REMOTABLE, "true");
+        }
+        catch (final Exception e)
+        {
+            // ignored
+        }
+
+        Context context = new InitialContext(p);
+
+        final BeanManager beanManager = CDI.current().getBeanManager();
+        assertNotNull(beanManager);
+
+        final Set<Bean<?>> someBeanBeans = beanManager.getBeans(SomeBean.class);
+        assertTrue(!someBeanBeans.isEmpty());
+
+        // as there should be a NoClassDefFound of the ThirdPartyApi.class we did not pick up
+        // the Car but only the Bicycle
+        final Set<Bean<?>> optionalBeanBeans = beanManager.getBeans(Vehicle.class);
+        assertEquals(1, optionalBeanBeans.size());
+        final Vehicle vehicle = CDI.current().select(Vehicle.class).get();
+        assertFalse(vehicle.motorized());
+    }
+}

--- a/itests/openejb-itests-optional-classes/lib_with_optional_dep/pom.xml
+++ b/itests/openejb-itests-optional-classes/lib_with_optional_dep/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+
+<!-- $Rev$ $Date$ -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.tomee.itests</groupId>
+        <artifactId>openejb-itests-optional-classes</artifactId>
+        <version>10.0.0-M1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>opt-lib</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.tomee.itests</groupId>
+            <artifactId>opt-3rdparty</artifactId>
+            <version>${project.version}</version>
+            <optional>true</optional> <!-- do not pass as transitive dependency! -->
+        </dependency>
+    </dependencies>
+</project>

--- a/itests/openejb-itests-optional-classes/lib_with_optional_dep/src/main/java/org/apache/tomee/itests/optional/optlib/Bicycle.java
+++ b/itests/openejb-itests-optional-classes/lib_with_optional_dep/src/main/java/org/apache/tomee/itests/optional/optlib/Bicycle.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.tomee.itests.optional.optlib;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+/**
+ *
+ */
+@ApplicationScoped
+public class Bicycle implements Vehicle {
+    @Override
+    public boolean motorized() {
+        return false;
+    }
+}

--- a/itests/openejb-itests-optional-classes/lib_with_optional_dep/src/main/java/org/apache/tomee/itests/optional/optlib/Car.java
+++ b/itests/openejb-itests-optional-classes/lib_with_optional_dep/src/main/java/org/apache/tomee/itests/optional/optlib/Car.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.tomee.itests.optional.optlib;
+
+import org.apache.tomee.itests.optional.thirdparty.ThirdPartyApi;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Alternative;
+
+/**
+ * This bean will not get picked up in the app as the ThirdPartyApi class
+ * will not be available over there!
+ */
+@ApplicationScoped
+@Alternative
+@Priority(1000)
+public class Car implements Vehicle, ThirdPartyApi {
+
+    @Override
+    public int meaningOfLife() {
+        return 42;
+    }
+
+    @Override
+    public boolean motorized() {
+        return true;
+    }
+}

--- a/itests/openejb-itests-optional-classes/lib_with_optional_dep/src/main/java/org/apache/tomee/itests/optional/optlib/SomeBean.java
+++ b/itests/openejb-itests-optional-classes/lib_with_optional_dep/src/main/java/org/apache/tomee/itests/optional/optlib/SomeBean.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.tomee.itests.optional.optlib;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+/**
+ * Some sample bean
+ */
+@ApplicationScoped
+public class SomeBean {
+
+    public String doSomething() {
+        return "nice";
+    }
+}

--- a/itests/openejb-itests-optional-classes/lib_with_optional_dep/src/main/java/org/apache/tomee/itests/optional/optlib/Vehicle.java
+++ b/itests/openejb-itests-optional-classes/lib_with_optional_dep/src/main/java/org/apache/tomee/itests/optional/optlib/Vehicle.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.tomee.itests.optional.optlib;
+
+/**
+ * @author <a href="mailto:struberg@apache.org">Mark Struberg</a>
+ */
+public interface Vehicle {
+
+    boolean motorized();
+}

--- a/itests/openejb-itests-optional-classes/lib_with_optional_dep/src/main/resources/META-INF/beans.xml
+++ b/itests/openejb-itests-optional-classes/lib_with_optional_dep/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements. See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership. The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License. You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       version="3.0" bean-discovery-mode="all">
+    <trim/>
+</beans>

--- a/itests/openejb-itests-optional-classes/pom.xml
+++ b/itests/openejb-itests-optional-classes/pom.xml
@@ -20,51 +20,42 @@
 <!-- $Rev$ $Date$ -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <artifactId>tomee-project</artifactId>
     <groupId>org.apache.tomee</groupId>
+    <artifactId>itests</artifactId>
     <version>10.0.0-M1-SNAPSHOT</version>
   </parent>
 
-  <modelVersion>4.0.0</modelVersion>
-  <artifactId>itests</artifactId>
+  <groupId>org.apache.tomee.itests</groupId>
+  <artifactId>openejb-itests-optional-classes</artifactId>
+
   <packaging>pom</packaging>
-  <name>TomEE :: iTests</name>
+  <name>TomEE :: iTests :: Optional Classes</name>
+
+  <properties>
+    <tomee.build.name>${project.groupId}.itests.optional</tomee.build.name>
+  </properties>
 
   <modules>
-    <module>tomee-server-composer</module>
-    <module>tomee-server-version</module>
-    <module>microprofile-jwt-itests</module>
-    <module>failover</module>
-    <module>failover-ejb</module>
-    <module>legacy-client</module>
-    <module>legacy-server</module>
-    <module>openejb-itests-app</module>
-    <module>openejb-itests-beans</module>
-    <module>openejb-itests-client</module>
-    <module>openejb-itests-interceptor-beans</module>
-    <module>openejb-itests-servlets</module>
-    <module>openejb-itests-web</module>
-    <module>jaxrs</module>
-    <module>itest-common</module>
-    <module>itest-util</module>
-    <module>tomee-security-itests</module>
-    <module>tomee-microprofile-itests</module>
-    <module>openejb-itests-optional-classes</module>
+    <module>3rdpartydep</module>
+    <module>lib_with_optional_dep</module>
+    <module>app</module>
   </modules>
 
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-javadoc-plugin</artifactId>
-        <version>${version.plugin.javadoc}</version>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.tomee</groupId>
+      <artifactId>jakartaee-api</artifactId>
+      <version>${version.jakartaee-api}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+  </dependencies>
 </project>
 


### PR DESCRIPTION
if a class creates a NoClassDefFoundError or ClassNotFoundException then it's simply not an eligible bean class.

All works fine in TomEE 10!