### PR TITLE
Fixed exclusions (related to TOMEE-4294)

### DIFF
--- a/tomee/tomee-microprofile/mp-common/pom.xml
+++ b/tomee/tomee-microprofile/mp-common/pom.xml
@@ -149,10 +149,7 @@
       <groupId>org.eclipse.microprofile.health</groupId>
       <artifactId>microprofile-health-api</artifactId>
       <exclusions>
-        <exclusion>
-          <groupId>javax.inject</groupId>
-          <artifactId>javax.inject</artifactId>
-        </exclusion>
+
       </exclusions>
     </dependency>
 
@@ -180,10 +177,7 @@
       <groupId>org.eclipse.microprofile.rest.client</groupId>
       <artifactId>microprofile-rest-client-api</artifactId>
       <exclusions>
-        <exclusion>
-          <groupId>javax.inject</groupId>
-          <artifactId>javax.inject</artifactId>
-        </exclusion>
+
       </exclusions>
     </dependency>
 
@@ -235,6 +229,14 @@
       <groupId>io.smallrye</groupId>
       <artifactId>smallrye-health</artifactId>
       <exclusions>
+        <exclusion>
+          <groupId>jakarta.enterprise</groupId>
+          <artifactId>jakarta.enterprise.cdi-api</artifactId>
+        </exclusion>
+		<exclusion>
+          <groupId>jakarta.json</groupId>
+          <artifactId>jakarta.json-api</artifactId>
+        </exclusion>
         <exclusion>
           <groupId>*</groupId>
           <artifactId>microprofile-health-api</artifactId>
@@ -314,20 +316,8 @@
           <artifactId>jaxb-xjc</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>javax.json</groupId>
-          <artifactId>javax.json-api</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>javax.ws.rs</groupId>
-          <artifactId>javax.ws.rs-api</artifactId>
-        </exclusion>
-        <exclusion>
           <groupId>jakarta.ws.rs</groupId>
           <artifactId>jakarta.ws.rs-api</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>javax.annotation</groupId>
-          <artifactId>javax.annotation-api</artifactId>
         </exclusion>
         <exclusion>
           <groupId>jakarta.activation</groupId>

--- a/tomee/tomee-microprofile/mp-common/pom.xml
+++ b/tomee/tomee-microprofile/mp-common/pom.xml
@@ -233,7 +233,7 @@
           <groupId>jakarta.enterprise</groupId>
           <artifactId>jakarta.enterprise.cdi-api</artifactId>
         </exclusion>
-		<exclusion>
+        <exclusion>
           <groupId>jakarta.json</groupId>
           <artifactId>jakarta.json-api</artifactId>
         </exclusion>


### PR DESCRIPTION
Fixed exclusions (related to TOMEE-4294)

otherwise you have a duplicate CDI classes on classpath when running with tomee embedded maven plugin