### PR TITLE
TOMEE-4357 - Add Jandex Index cache - 9.x

### DIFF
--- a/tomee/tomee-microprofile/mp-common/src/main/java/org/apache/tomee/microprofile/TomEEMicroProfileListener.java
+++ b/tomee/tomee-microprofile/mp-common/src/main/java/org/apache/tomee/microprofile/TomEEMicroProfileListener.java
@@ -51,7 +51,7 @@ import java.util.Enumeration;
 import java.util.List;
 import java.util.Set;
 import java.util.Map;
-import java.util.HashMap;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.stream.Collectors;
@@ -71,7 +71,7 @@ public class TomEEMicroProfileListener {
         "io.smallrye.faulttolerance.FaultToleranceExtension",
         };
 
-    private final Map<AppInfo, Index> indexCache = new HashMap<>();
+    private final Map<AppInfo, Index> indexCache = new ConcurrentHashMap<>();
 
     @SuppressWarnings("Duplicates")
     public void enhanceScannableUrls(@Observes final EnhanceScannableUrlsEvent enhanceScannableUrlsEvent) {


### PR DESCRIPTION
Add a Jandex index cache to TomEEMicroProfileListener

This will fix a issue with a longer startup time since TomEE 9

The processApplication method is called for every created application and will then create an index for all jars.
But the index is based on the AppInfo of the application. The AppInfo can have multiple applications.
So currently the same index is created for every single application which is unnecessary

This change will boost our start up time from 2min to ~45s