### PR TITLE
[TOMEE-4402] Remove JCache (JSR 107) API and its implementation

### DIFF
--- a/boms/tomee-plume-api/pom.xml
+++ b/boms/tomee-plume-api/pom.xml
@@ -53,17 +53,6 @@
     </dependency>
     <dependency>
       <groupId>org.apache.geronimo.specs</groupId>
-      <artifactId>geronimo-jcache_1.0_spec</artifactId>
-      <version>1.0-alpha-1</version>
-      <exclusions>
-        <exclusion>
-          <artifactId>*</artifactId>
-          <groupId>*</groupId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.geronimo.specs</groupId>
       <artifactId>geronimo-mail_2.1_spec</artifactId>
       <version>1.0.0-M1</version>
       <exclusions>

--- a/boms/tomee-plume/pom.xml
+++ b/boms/tomee-plume/pom.xml
@@ -663,28 +663,6 @@
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
-      <artifactId>commons-jcs-core</artifactId>
-      <version>2.2.1</version>
-      <exclusions>
-        <exclusion>
-          <artifactId>*</artifactId>
-          <groupId>*</groupId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-jcs-jcache</artifactId>
-      <version>2.2.1</version>
-      <exclusions>
-        <exclusion>
-          <artifactId>*</artifactId>
-          <groupId>*</groupId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
       <version>3.16.0</version>
       <exclusions>
@@ -951,17 +929,6 @@
       <groupId>org.apache.geronimo.mail</groupId>
       <artifactId>geronimo-mail_2.1_provider</artifactId>
       <version>1.0.0</version>
-      <exclusions>
-        <exclusion>
-          <artifactId>*</artifactId>
-          <groupId>*</groupId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.geronimo.specs</groupId>
-      <artifactId>geronimo-jcache_1.0_spec</artifactId>
-      <version>1.0-alpha-1</version>
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>

--- a/boms/tomee-plus-api/pom.xml
+++ b/boms/tomee-plus-api/pom.xml
@@ -53,17 +53,6 @@
     </dependency>
     <dependency>
       <groupId>org.apache.geronimo.specs</groupId>
-      <artifactId>geronimo-jcache_1.0_spec</artifactId>
-      <version>1.0-alpha-1</version>
-      <exclusions>
-        <exclusion>
-          <artifactId>*</artifactId>
-          <groupId>*</groupId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.geronimo.specs</groupId>
       <artifactId>geronimo-mail_2.1_spec</artifactId>
       <version>1.0.0-M1</version>
       <exclusions>

--- a/boms/tomee-plus/pom.xml
+++ b/boms/tomee-plus/pom.xml
@@ -663,28 +663,6 @@
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
-      <artifactId>commons-jcs-core</artifactId>
-      <version>2.2.1</version>
-      <exclusions>
-        <exclusion>
-          <artifactId>*</artifactId>
-          <groupId>*</groupId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-jcs-jcache</artifactId>
-      <version>2.2.1</version>
-      <exclusions>
-        <exclusion>
-          <artifactId>*</artifactId>
-          <groupId>*</groupId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
       <version>3.16.0</version>
       <exclusions>
@@ -951,17 +929,6 @@
       <groupId>org.apache.geronimo.mail</groupId>
       <artifactId>geronimo-mail_2.1_provider</artifactId>
       <version>1.0.0</version>
-      <exclusions>
-        <exclusion>
-          <artifactId>*</artifactId>
-          <groupId>*</groupId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.geronimo.specs</groupId>
-      <artifactId>geronimo-jcache_1.0_spec</artifactId>
-      <version>1.0-alpha-1</version>
       <exclusions>
         <exclusion>
           <artifactId>*</artifactId>

--- a/container/openejb-core/src/main/java/org/apache/openejb/cdi/OptimizedLoaderService.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/cdi/OptimizedLoaderService.java
@@ -197,23 +197,6 @@ public class OptimizedLoaderService implements LoaderService {
                 break;
             case "org.apache.batchee.container.cdi.BatchCDIInjectionExtension": // see org.apache.openejb.batchee.BatchEEServiceManager
                 return "true".equals(systemInstance.getProperty("tomee.batchee.cdi.use-extension", "false"));
-            case "org.apache.commons.jcs.jcache.cdi.MakeJCacheCDIInterceptorFriendly":
-                final String spi = "META-INF/services/javax.cache.spi.CachingProvider";
-                try {
-                    final Enumeration<URL> appResources = Thread.currentThread().getContextClassLoader().getResources(spi);
-                    if (appResources != null && appResources.hasMoreElements()) {
-                        final Collection<URL> containerResources = Collections.list(containerLoader.getResources(spi));
-                        do {
-                            if (!containerResources.contains(appResources.nextElement())) {
-                                log.info("Skipping JCS CDI integration cause another provide was found in the application");
-                                return true;
-                            }
-                        } while (appResources.hasMoreElements());
-                    }
-                } catch (final Exception e) {
-                    // no-op
-                }
-                break;
             default:
         }
         return false;

--- a/container/openejb-core/src/main/java/org/apache/openejb/config/DeploymentLoader.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/config/DeploymentLoader.java
@@ -1117,7 +1117,6 @@ public class DeploymentLoader implements DeploymentFilterable {
                                 if ((skipContainerFolders && file.isDirectory())
                                         // few hardcoded exclusions, TODO: see if we should filter them in previous call of applyBuiltinExcludes()
                                         || name.endsWith("tomcat-websocket.jar")
-                                        || name.startsWith("commons-jcs-")
                                         || name.startsWith("xx-arquillian-tomee")
                                         || ("lib".equals(name) && file.isDirectory() &&
                                             new File(JavaSecurityManagers.getSystemProperty("openejb.base", "-")).equals(file.getParentFile()))) {

--- a/container/openejb-core/src/main/java/org/apache/openejb/config/TldScanner.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/config/TldScanner.java
@@ -328,7 +328,7 @@ public class TldScanner {
             urlSet = applyBuiltinExcludes(
                     urlSet,
                     Filters.tokens("taglibs-shade", "taglibs-standard-impl", "taglibs-standard-jstlel", "jakarta.faces-2.", "jakarta.faces-2", "spring-security-taglibs", "spring-webmvc"),
-                    Filters.prefixes("commons-jcs-", "myfaces-", "tomcat-websocket.jar")); // myfaces is hardcoded in tomee
+                    Filters.prefixes("myfaces-", "tomcat-websocket.jar")); // myfaces is hardcoded in tomee
         } catch (final IOException e) {
             DeploymentLoader.LOGGER.warning("Error scanning class loader for JSP tag libraries", e);
         }

--- a/container/openejb-core/src/main/resources/default.exclusions
+++ b/container/openejb-core/src/main/resources/default.exclusions
@@ -56,8 +56,6 @@ commons-digester-
 commons-discovery-
 commons-httpclient-
 commons-io-
-commons-jcs-core-
-commons-jcs-jcache-
 commons-lang-
 commons-lang3-
 commons-logging-

--- a/pom.xml
+++ b/pom.xml
@@ -161,7 +161,6 @@
     <version.commons-dbcp2>2.12.0</version.commons-dbcp2>
     <version.commons-discovery>0.5</version.commons-discovery>
     <version.commons-io>2.16.1</version.commons-io>
-    <version.commons-jcs-cache>2.2.1</version.commons-jcs-cache>
     <version.commons-lang3>3.16.0</version.commons-lang3>
     <version.commons-net>3.11.1</version.commons-net>
     <version.commons-pool>2.12.0</version.commons-pool>
@@ -231,7 +230,6 @@
     <!-- Other API and Impl. not in Jakarta EE -->
     <version.wss4j>3.0.3</version.wss4j>
     <version.xmlsec>3.0.4</version.xmlsec>
-    <version.geronimo-jcache_1.0_spec>1.0-alpha-1</version.geronimo-jcache_1.0_spec>
     <version.krazo>2.0.2</version.krazo>
     <version.jose4j>0.9.6</version.jose4j>
     <version.sxc>0.9</version.sxc>

--- a/tck/cdi-tomee/pom.xml
+++ b/tck/cdi-tomee/pom.xml
@@ -186,19 +186,6 @@
       </exclusions>
     </dependency>
 
-    <!-- debugging: said otherwise you can remove them, kept to ease future debugging if needed -->
-    <dependency>
-      <groupId>org.apache.geronimo.specs</groupId>
-      <artifactId>geronimo-jcache_1.0_spec</artifactId>
-      <version>${version.geronimo-jcache_1.0_spec}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-jcs-jcache</artifactId>
-      <version>${version.commons-jcs-cache}</version>
-      <scope>test</scope>
-    </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>tomee-catalina</artifactId>

--- a/tomee/tomee-plume-webapp/pom.xml
+++ b/tomee/tomee-plume-webapp/pom.xml
@@ -352,18 +352,6 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.apache.geronimo.specs</groupId>
-      <artifactId>geronimo-jcache_1.0_spec</artifactId>
-      <version>${version.geronimo-jcache_1.0_spec}</version>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-jcs-jcache</artifactId>
-      <version>${version.commons-jcs-cache}</version>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.geronimo.components</groupId>
       <artifactId>geronimo-connector</artifactId>
       <exclusions>

--- a/tomee/tomee-plus-webapp/pom.xml
+++ b/tomee/tomee-plus-webapp/pom.xml
@@ -352,18 +352,6 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.apache.geronimo.specs</groupId>
-      <artifactId>geronimo-jcache_1.0_spec</artifactId>
-      <version>${version.geronimo-jcache_1.0_spec}</version>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-jcs-jcache</artifactId>
-      <version>${version.commons-jcs-cache}</version>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.geronimo.components</groupId>
       <artifactId>geronimo-connector</artifactId>
       <exclusions>


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/TOMEE-4402
JCache was afaik never part of the Jakarta EE specification and JCS is still using the javax.* namespace for CDI

So this has been broken since the first TomEE 9 releases but nobody complained