### PR TITLE
TOMEE-4410 - Better Exception when accesing injected HttpServletRequest if no request is active

### DIFF
--- a/tomee/tomee-catalina/src/main/java/org/apache/tomee/catalina/HttpServletRequestProxy.java
+++ b/tomee/tomee-catalina/src/main/java/org/apache/tomee/catalina/HttpServletRequestProxy.java
@@ -44,6 +44,10 @@ public interface HttpServletRequestProxy extends HttpServletRequest, Serializabl
 
             try {
                 HttpServletRequest obj = OpenEJBSecurityListener.requests.get();
+                if (obj == null) {
+                    throw new RequestNotActiveException("Method '%s' was invoked on HttpServletRequest, but no servlet request is active on the current thread".formatted(method.getName()));
+                }
+
                 return method.invoke(obj, args);
             } catch (final InvocationTargetException ite) {
                 throw ite.getCause();

--- a/tomee/tomee-catalina/src/main/java/org/apache/tomee/catalina/RequestNotActiveException.java
+++ b/tomee/tomee-catalina/src/main/java/org/apache/tomee/catalina/RequestNotActiveException.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.tomee.catalina;
+
+/**
+ * Thrown when a {@link jakarta.servlet.http.HttpServletRequest} is invoked on a thread with no active servlet request
+ */
+public class RequestNotActiveException extends IllegalStateException {
+    public RequestNotActiveException(String message) {
+        super(message);
+    }
+}

--- a/tomee/tomee-catalina/src/test/java/org/apache/tomee/catalina/HttpServletRequestProxyTest.java
+++ b/tomee/tomee-catalina/src/test/java/org/apache/tomee/catalina/HttpServletRequestProxyTest.java
@@ -45,4 +45,12 @@ public class HttpServletRequestProxyTest {
 
         Assert.assertNotNull(readRequest);
     }
+
+    @Test
+    public void noRequestActive() {
+        final HttpServletRequest request = HttpServletRequestProxy.get();
+
+        RequestNotActiveException exception = Assert.assertThrows(RequestNotActiveException.class, () -> request.getRequestURI());
+        Assert.assertEquals("Method 'getRequestURI' was invoked on HttpServletRequest, but no servlet request is active on the current thread", exception.getMessage());
+    }
 }


### PR DESCRIPTION
As the title says, see https://issues.apache.org/jira/browse/TOMEE-4410