### PR TITLE
Update pom.xml to enforce maven version (currently at least 3.9.8)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -491,6 +491,26 @@
         </configuration>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>3.5.0</version>
+        <executions>
+          <execution>
+            <id>enforce-versions</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireMavenVersion>
+		  <version>3.9.8</version>
+                </requireMavenVersion>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>	    
+      <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
         <extensions>true</extensions>


### PR DESCRIPTION
suggested change as of bugs found in maven 3.9.6 in https://issues.apache.org/jira/browse/TOMEE-4416

Using https://maven.apache.org/enforcer/maven-enforcer-plugin (can be used to enforce eg. jdk version as well)