### PR TITLE
TOMEE-4424 - improved JAX-RS request matching if a welcome-file is defined

### DIFF
--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-jaxrs-tests/src/test/java/org/apache/openejb/arquillian/tests/jaxrs/servlets/welcomefile/MyFiletypeServlet.java
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-jaxrs-tests/src/test/java/org/apache/openejb/arquillian/tests/jaxrs/servlets/welcomefile/MyFiletypeServlet.java
@@ -1,0 +1,15 @@
+package org.apache.openejb.arquillian.tests.jaxrs.servlets.welcomefile;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+
+public class MyFiletypeServlet extends HttpServlet {
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        resp.getWriter().print("filetype matched");
+    }
+}

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-jaxrs-tests/src/test/java/org/apache/openejb/arquillian/tests/jaxrs/servlets/welcomefile/MyFiletypeServlet.java
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-jaxrs-tests/src/test/java/org/apache/openejb/arquillian/tests/jaxrs/servlets/welcomefile/MyFiletypeServlet.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.openejb.arquillian.tests.jaxrs.servlets.welcomefile;
 
 import jakarta.servlet.ServletException;

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-jaxrs-tests/src/test/java/org/apache/openejb/arquillian/tests/jaxrs/servlets/welcomefile/MyRestApi.java
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-jaxrs-tests/src/test/java/org/apache/openejb/arquillian/tests/jaxrs/servlets/welcomefile/MyRestApi.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.openejb.arquillian.tests.jaxrs.servlets.welcomefile;
 
 import jakarta.ws.rs.GET;

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-jaxrs-tests/src/test/java/org/apache/openejb/arquillian/tests/jaxrs/servlets/welcomefile/MyRestApi.java
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-jaxrs-tests/src/test/java/org/apache/openejb/arquillian/tests/jaxrs/servlets/welcomefile/MyRestApi.java
@@ -1,0 +1,14 @@
+package org.apache.openejb.arquillian.tests.jaxrs.servlets.welcomefile;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Response;
+
+@Path("/api")
+public class MyRestApi {
+    @GET
+    @Path("/test")
+    public Response getTest() {
+        return Response.ok("Hello world!").build();
+    }
+}

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-jaxrs-tests/src/test/java/org/apache/openejb/arquillian/tests/jaxrs/servlets/welcomefile/MyRestApplication.java
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-jaxrs-tests/src/test/java/org/apache/openejb/arquillian/tests/jaxrs/servlets/welcomefile/MyRestApplication.java
@@ -1,0 +1,6 @@
+package org.apache.openejb.arquillian.tests.jaxrs.servlets.welcomefile;
+
+import jakarta.ws.rs.core.Application;
+
+public class MyRestApplication extends Application {
+}

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-jaxrs-tests/src/test/java/org/apache/openejb/arquillian/tests/jaxrs/servlets/welcomefile/MyRestApplication.java
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-jaxrs-tests/src/test/java/org/apache/openejb/arquillian/tests/jaxrs/servlets/welcomefile/MyRestApplication.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.openejb.arquillian.tests.jaxrs.servlets.welcomefile;
 
 import jakarta.ws.rs.core.Application;

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-jaxrs-tests/src/test/java/org/apache/openejb/arquillian/tests/jaxrs/servlets/welcomefile/ServletsWithWelcomeFileTest.java
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-jaxrs-tests/src/test/java/org/apache/openejb/arquillian/tests/jaxrs/servlets/welcomefile/ServletsWithWelcomeFileTest.java
@@ -1,0 +1,56 @@
+package org.apache.openejb.arquillian.tests.jaxrs.servlets.welcomefile;
+
+import org.apache.openejb.arquillian.tests.jaxrs.JaxrsTest;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.descriptor.api.Descriptors;
+import org.jboss.shrinkwrap.descriptor.api.webapp30.WebAppDescriptor;
+import org.jboss.shrinkwrap.descriptor.api.webcommon30.WebAppVersionType;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Arquillian.class)
+public class ServletsWithWelcomeFileTest extends JaxrsTest {
+    @Deployment(testable = false)
+    public static WebArchive createDeployment() {
+        WebAppDescriptor webXml = Descriptors.create(WebAppDescriptor.class)
+                .version(WebAppVersionType._3_0)
+                .createServlet()
+                    .servletName("My Filetype Servlet")
+                    .servletClass(MyFiletypeServlet.class.getName())
+                .up()
+                .createServletMapping()
+                    .servletName("My Filetype Servlet")
+                    .urlPattern("*.mine")
+                .up()
+                .createWelcomeFileList()
+                    .welcomeFile("index.mine")
+                .up();
+
+        return ShrinkWrap.create(WebArchive.class)
+                .addClasses(MyRestApi.class, MyRestApplication.class, MyFiletypeServlet.class)
+                .setWebXML(new StringAsset(webXml.exportAsString()));
+    }
+
+    @Test
+    public void welcomeFileOnRoot() throws IOException {
+        assertEquals("filetype matched", get("/"));
+    }
+
+    @Test
+    public void fileExtension() throws IOException {
+        assertEquals("filetype matched", get("/test.mine"));
+    }
+
+    @Test
+    public void jaxRsWithTrailingSlash() throws IOException {
+        assertEquals("Hello world!", get("/api/test/"));
+    }
+}

--- a/arquillian/arquillian-tomee-tests/arquillian-tomee-jaxrs-tests/src/test/java/org/apache/openejb/arquillian/tests/jaxrs/servlets/welcomefile/ServletsWithWelcomeFileTest.java
+++ b/arquillian/arquillian-tomee-tests/arquillian-tomee-jaxrs-tests/src/test/java/org/apache/openejb/arquillian/tests/jaxrs/servlets/welcomefile/ServletsWithWelcomeFileTest.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.openejb.arquillian.tests.jaxrs.servlets.welcomefile;
 
 import org.apache.openejb.arquillian.tests.jaxrs.JaxrsTest;


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/TOMEE-4424

Fulll build is running: https://ci-builds.apache.org/job/Tomee/view/tomee-10.x/job/pull-request-manual/146/