### PR TITLE
Disable JSON-P / JSON-B Default Registration in JAX-RS 3.1 (from CXF 4.1.0-SNAPSHOT)

### DIFF
--- a/examples/mp-custom-healthcheck/src/test/java/org/superbiz/test/WeatherServiceTest.java
+++ b/examples/mp-custom-healthcheck/src/test/java/org/superbiz/test/WeatherServiceTest.java
@@ -26,6 +26,7 @@ import jakarta.ws.rs.client.ClientBuilder;
 import jakarta.ws.rs.client.WebTarget;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import org.apache.cxf.BusFactory;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.junit.InSequence;
@@ -64,6 +65,8 @@ public class WeatherServiceTest {
     @Before
     public void before() {
         this.client = ClientBuilder.newClient();
+        //disable json-p / json-b default registration in JAX-RS 3.1
+        BusFactory.getDefaultBus().setProperty("skip.jakarta.json.providers.registration", "true");
     }
 
     @Test

--- a/examples/mp-rest-jwt-public-key/src/test/java/org/superbiz/bookstore/BookstoreTest.java
+++ b/examples/mp-rest-jwt-public-key/src/test/java/org/superbiz/bookstore/BookstoreTest.java
@@ -23,6 +23,8 @@ import com.nimbusds.jose.crypto.RSASSASigner;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
 import net.minidev.json.JSONObject;
+import org.apache.cxf.Bus;
+import org.apache.cxf.BusFactory;
 import org.apache.cxf.feature.LoggingFeature;
 import org.apache.cxf.jaxrs.client.WebClient;
 import org.apache.johnzon.jaxrs.JohnzonProvider;
@@ -69,6 +71,10 @@ public class BookstoreTest {
 
     @Test
     public void movieRestTest() throws Exception {
+        final Bus bus = BusFactory.getDefaultBus();
+        //disable json-p / json-b default registration in JAX-RS 3.1
+        bus.setProperty("skip.jakarta.json.providers.registration", "true");
+
         final WebClient webClient = WebClient
                 .create(base.toExternalForm(), singletonList(new JohnzonProvider<>()),
                         singletonList(new LoggingFeature()), null);
@@ -81,7 +87,6 @@ public class BookstoreTest {
                 .get(String.class);
         LOGGER.info("responsePayload = " + responsePayload);
         assertEquals("alice", responsePayload);
-
 
         // Testing REST endpoint with group claims manager
         Book newBook = new Book(1, "The Lord of the Rings", "J.R.R.Tolkien");

--- a/server/openejb-cxf-rs/src/main/java/org/apache/openejb/server/cxf/rs/CxfRSService.java
+++ b/server/openejb-cxf-rs/src/main/java/org/apache/openejb/server/cxf/rs/CxfRSService.java
@@ -213,7 +213,8 @@ public class CxfRSService extends RESTService {
     private void initCxfProviders(final Bus bus) {
         if (noProvidersExplicitlyAdded(bus)) {
             bus.setProperty("skip.default.json.provider.registration", "true"); // client jaxrs, we want johnzon not jettison
-            bus.setProperty("skip.jakarta.json.providers.registration", "true");  // Make sure default JAXRS 3.1 JSON-P/JSON-B providers are not loaded
+            bus.setProperty("skip.jakarta.json.providers.registration",
+                SystemInstance.get().getProperty("openejb.jaxrs.skip.jakarta.json.providers.registration", "true"));  // Make sure default JAXRS 3.1 JSON-P/JSON-B providers are not loaded
 
             final Collection<Object> defaults = new ArrayList<>();
             List<String> jsonProviders;

--- a/server/openejb-cxf-rs/src/main/java/org/apache/openejb/server/cxf/rs/CxfRSService.java
+++ b/server/openejb-cxf-rs/src/main/java/org/apache/openejb/server/cxf/rs/CxfRSService.java
@@ -213,6 +213,7 @@ public class CxfRSService extends RESTService {
     private void initCxfProviders(final Bus bus) {
         if (noProvidersExplicitlyAdded(bus)) {
             bus.setProperty("skip.default.json.provider.registration", "true"); // client jaxrs, we want johnzon not jettison
+            bus.setProperty("skip.jakarta.json.providers.registration", "true");  // Make sure default JAXRS 3.1 JSON-P/JSON-B providers are not loaded
 
             final Collection<Object> defaults = new ArrayList<>();
             List<String> jsonProviders;

--- a/tck/jax-rs/jax-rs-tests-embedded/pom.xml
+++ b/tck/jax-rs/jax-rs-tests-embedded/pom.xml
@@ -152,6 +152,7 @@
                                 <password>j2ee</password>
                                 <authuser>javajoe</authuser>
                                 <authpassword>javajoe</authpassword>
+                                <openejb.jaxrs.skip.jakarta.json.providers.registration>false</openejb.jaxrs.skip.jakarta.json.providers.registration>
                             </systemPropertyVariables>
                         </configuration>
                     </plugin>

--- a/tck/jax-rs/jax-rs-tests/pom.xml
+++ b/tck/jax-rs/jax-rs-tests/pom.xml
@@ -168,6 +168,7 @@
                                 <password>j2ee</password>
                                 <authuser>javajoe</authuser>
                                 <authpassword>javajoe</authpassword>
+                                <openejb.jaxrs.skip.jakarta.json.providers.registration>false</openejb.jaxrs.skip.jakarta.json.providers.registration>
                             </systemPropertyVariables>
                         </configuration>
                     </plugin>


### PR DESCRIPTION
Adjust TomEE to latest CXF JAX-RS 3.1 related changes which are failing the build, cf. https://github.com/apache/cxf/commit/b6d1e6978bdea139d6d093656f92979b7d6cb204 for CXF details

- https://ci-builds.apache.org/job/Tomee/view/tomee-10.x/job/pull-request-manual/152/
- JAX-RS TCK -> ok