### PR TITLE
TOMEE-4454 - Missing artifacts in BOM generated files due to webapp removal

### DIFF
--- a/boms/tomee-microprofile/pom.xml
+++ b/boms/tomee-microprofile/pom.xml
@@ -1796,17 +1796,6 @@
     </dependency>
     <dependency>
       <groupId>org.apache.tomee</groupId>
-      <artifactId>tomee-microprofile-webapp</artifactId>
-      <version>${project.version}</version>
-      <exclusions>
-        <exclusion>
-          <artifactId>*</artifactId>
-          <groupId>*</groupId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.tomee</groupId>
       <artifactId>tomee-mojarra</artifactId>
       <version>${project.version}</version>
       <exclusions>

--- a/boms/tomee-plume/pom.xml
+++ b/boms/tomee-plume/pom.xml
@@ -1884,17 +1884,6 @@
     </dependency>
     <dependency>
       <groupId>org.apache.tomee</groupId>
-      <artifactId>tomee-plume-webapp</artifactId>
-      <version>${project.version}</version>
-      <exclusions>
-        <exclusion>
-          <artifactId>*</artifactId>
-          <groupId>*</groupId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.tomee</groupId>
       <artifactId>tomee-security</artifactId>
       <version>${project.version}</version>
       <exclusions>

--- a/boms/tomee-plus/pom.xml
+++ b/boms/tomee-plus/pom.xml
@@ -1906,17 +1906,6 @@
     </dependency>
     <dependency>
       <groupId>org.apache.tomee</groupId>
-      <artifactId>tomee-plus-webapp</artifactId>
-      <version>${project.version}</version>
-      <exclusions>
-        <exclusion>
-          <artifactId>*</artifactId>
-          <groupId>*</groupId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.tomee</groupId>
       <artifactId>tomee-security</artifactId>
       <version>${project.version}</version>
       <exclusions>

--- a/boms/tomee-webprofile/pom.xml
+++ b/boms/tomee-webprofile/pom.xml
@@ -1212,17 +1212,6 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.apache.tomee</groupId>
-      <artifactId>tomee-webapp</artifactId>
-      <version>${project.version}</version>
-      <exclusions>
-        <exclusion>
-          <artifactId>*</artifactId>
-          <groupId>*</groupId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
       <groupId>org.apache.ws.xmlschema</groupId>
       <artifactId>xmlschema-core</artifactId>
       <version>2.3.1</version>

--- a/tomee/apache-tomee/src/test/java/org/apache/tomee/bootstrap/GenerateBoms.java
+++ b/tomee/apache-tomee/src/test/java/org/apache/tomee/bootstrap/GenerateBoms.java
@@ -362,6 +362,15 @@ public class GenerateBoms {
                 .filter(jar -> !jar.getName().equals("catalina-ant.jar"))
                 .filter(jar -> !jar.getName().startsWith("tomcat-i18n"))
                 .filter(jar -> !jar.getName().startsWith("jakartaee-migration"))
+                 /*
+                  Webapp distributions removed from BOM generation per:
+                    - https://issues.apache.org/jira/browse/TOMEE-3724
+                    - https://lists.apache.org/thread/31w7336d5ycqhmoy4pngbsjg3odm0yqx
+                  */
+                .filter(jar -> !jar.getName().startsWith("tomee-plume-webapp"))
+                .filter(jar -> !jar.getName().startsWith("tomee-plus-webapp"))
+                .filter(jar -> !jar.getName().startsWith("tomee-microprofile-webapp"))
+                .filter(jar -> !jar.getName().startsWith("tomee-webapp"))
                 .map(from)
                 .filter(Objects::nonNull)
                 .sorted()


### PR DESCRIPTION
The tomee-webapps are no longer deployed to a remote Maven repository, see https://issues.apache.org/jira/browse/TOMEE-3724

As a result, their artifacts should be excluded from the BOM generation process to prevent missing dependencies. Currently, the 10.0.0-GA BOMS are unusable.

This PR updates the BOM generation logic to filter out web app artifacts, ensuring that only valid, published artifacts are included.