### PR TITLE
TOMEE-4474 - TomEE does not launch on Java 24

### DIFF
--- a/container/openejb-core/src/main/java/org/apache/openejb/core/security/PolicyJDK24.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/core/security/PolicyJDK24.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.openejb.core.security;
+
+import java.security.Policy;
+
+/**
+ * A utility class to manage the Java Security Policy in a thread-safe manner.
+ * This class provides methods to get and set the security policy, ensuring
+ * that changes are synchronized across threads.
+ */
+public class PolicyJDK24 {
+
+    private static volatile Policy policy;
+
+    /**
+     * @return the policy
+     */
+    public static synchronized Policy getPolicy() {
+        return policy;
+    }
+
+    /**
+     * @param policy the policy to set
+     */
+    public static synchronized void setPolicy(Policy policy) {
+        PolicyJDK24.policy = policy;
+    }
+
+
+
+}

--- a/container/openejb-core/src/main/java/org/apache/openejb/core/security/jacc/BasicJaccProvider.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/core/security/jacc/BasicJaccProvider.java
@@ -18,6 +18,7 @@
 package org.apache.openejb.core.security.jacc;
 
 import org.apache.openejb.core.security.JaccProvider;
+import org.apache.openejb.core.security.PolicyJDK24;
 import org.apache.openejb.loader.SystemInstance;
 import org.apache.openejb.spi.SecurityService;
 
@@ -66,7 +67,7 @@ public class BasicJaccProvider extends JaccProvider {
     private final java.security.Policy systemPolicy;
 
     public BasicJaccProvider() {
-        systemPolicy = Policy.getPolicy();
+        systemPolicy = PolicyJDK24.getPolicy();
     }
 
     public PolicyConfiguration getPolicyConfiguration(final String contextID, final boolean remove) throws PolicyContextException {

--- a/server/openejb-client/src/main/java/org/apache/openejb/client/JaasIdentityResolver.java
+++ b/server/openejb-client/src/main/java/org/apache/openejb/client/JaasIdentityResolver.java
@@ -17,15 +17,16 @@
  */
 package org.apache.openejb.client;
 
+import org.apache.openejb.client.util.JDK24Subject;
+
 import javax.security.auth.Subject;
-import java.security.AccessController;
 import java.util.Set;
 
 public class JaasIdentityResolver implements IdentityResolver {
 
     @Override
     public Object getIdentity() {
-        final Subject subject = Subject.getSubject(AccessController.getContext());
+        final Subject subject = JDK24Subject.currentSubject();
         if (subject == null) {
             return null;
         }

--- a/server/openejb-client/src/main/java/org/apache/openejb/client/util/JDK24Subject.java
+++ b/server/openejb-client/src/main/java/org/apache/openejb/client/util/JDK24Subject.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.openejb.client.util;
+
+import javax.security.auth.Subject;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+
+public class JDK24Subject {
+
+    private static final MethodHandle CURRENT = lookupCurrent();
+
+    /**
+     * Maps to Subject.current() is available, otherwise maps to Subject.getSubject()
+     * @return the current subject
+     */
+    public static Subject currentSubject() {
+        try {
+            return (Subject) CURRENT.invoke();
+        } catch (Throwable t) {
+            throw new RuntimeException(t);
+        }
+    }
+
+    private static MethodHandle lookupCurrent() {
+        final MethodHandles.Lookup lookup = MethodHandles.lookup();
+        try {
+            // Subject.getSubject(AccessControlContext) is deprecated for removal and replaced by
+            // Subject.current().
+            // Lookup first the new API, since for Java versions where both exists, the
+            // new API delegates to the old API (for example Java 18, 19 and 20).
+            // Otherwise (Java 17), lookup the old API.
+            return lookup.findStatic(Subject.class, "current",
+                    MethodType.methodType(Subject.class));
+        } catch (NoSuchMethodException e) {
+            final MethodHandle getContext = lookupGetContext();
+            final MethodHandle getSubject = lookupGetSubject();
+            return MethodHandles.filterReturnValue(getContext, getSubject);
+        } catch (IllegalAccessException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    private static MethodHandle lookupGetSubject() {
+        final MethodHandles.Lookup lookup = MethodHandles.lookup();
+        try {
+            final Class<?> contextClazz =
+                    ClassLoader.getSystemClassLoader()
+                            .loadClass("java.security.AccessControlContext");
+            return lookup.findStatic(Subject.class, "getSubject",
+                    MethodType.methodType(Subject.class, contextClazz));
+        } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    private static MethodHandle lookupGetContext() {
+        try {
+            // Use reflection to work with Java versions that have and don't have AccessController.
+            final Class<?> controllerClazz =
+                    ClassLoader.getSystemClassLoader().loadClass("java.security.AccessController");
+            final Class<?> contextClazz =
+                    ClassLoader.getSystemClassLoader()
+                            .loadClass("java.security.AccessControlContext");
+
+            MethodHandles.Lookup lookup = MethodHandles.lookup();
+            return lookup.findStatic(controllerClazz, "getContext",
+                    MethodType.methodType(contextClazz));
+        } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException e) {
+            throw new AssertionError(e);
+        }
+    }
+}

--- a/server/openejb-client/src/test/java/org/apache/openejb/client/MainTest.java
+++ b/server/openejb-client/src/test/java/org/apache/openejb/client/MainTest.java
@@ -18,6 +18,7 @@
 package org.apache.openejb.client;
 
 import junit.framework.TestCase;
+import org.apache.openejb.client.util.JDK24Subject;
 
 import javax.naming.Binding;
 import javax.naming.Context;
@@ -87,7 +88,7 @@ public class MainTest extends TestCase {
     public static class SecureMain {
 
         public static void main(String[] args) {
-            Subject subject = Subject.getSubject(AccessController.getContext());
+            Subject subject = JDK24Subject.currentSubject();
 
             // verify subject
             assertEquals("Should have one principal", 1, subject.getPrincipals().size());
@@ -109,7 +110,7 @@ public class MainTest extends TestCase {
     public static class NormalMain {
 
         public static void main(String[] args) {
-            Subject subject = Subject.getSubject(AccessController.getContext());
+            Subject subject = JDK24Subject.currentSubject();
 
             assertNull("subject is not null", subject);
 


### PR DESCRIPTION
Support Java 24 at Runtime at the cost of loosing EJB Method Security, which does not work due to the deprecation / removal of SecurityManager in Java 21+ anyway.

Other suggestion to deal with it are very welcome ;-)

https://ci-builds.apache.org/job/Tomee/job/pull-request-manual/163/