### PR TITLE
TOMEE-4518 - remove transaction propagation

### DIFF
--- a/container/openejb-core/src/main/java/org/apache/openejb/cdi/OWBContextThreadListener.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/cdi/OWBContextThreadListener.java
@@ -34,7 +34,7 @@ public class OWBContextThreadListener implements ThreadContextListener {
     private final ThreadSingletonService singletonService = SystemInstance.get().getComponent(ThreadSingletonService.class);
 
     @Override
-    public void contextEntered(final ThreadContext oldContext, final ThreadContext newContext, boolean propagateTx) {
+    public void contextEntered(final ThreadContext oldContext, final ThreadContext newContext) {
         final BeanContext beanContext = newContext.getBeanContext();
         if (beanContext == null) { // OWBContextHolder will be null so calling contextExited will throw a NPE
             return;

--- a/container/openejb-core/src/main/java/org/apache/openejb/cdi/RequestScopedThreadContextListener.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/cdi/RequestScopedThreadContextListener.java
@@ -31,7 +31,7 @@ import jakarta.enterprise.context.spi.Context;
  */
 public class RequestScopedThreadContextListener implements ThreadContextListener {
     @Override
-    public void contextEntered(final ThreadContext oldContext, final ThreadContext newContext, boolean propagateTx) {
+    public void contextEntered(final ThreadContext oldContext, final ThreadContext newContext) {
 
         final BeanContext beanContext = newContext.getBeanContext();
 

--- a/container/openejb-core/src/main/java/org/apache/openejb/config/ConvertContextServiceDefinitions.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/config/ConvertContextServiceDefinitions.java
@@ -85,9 +85,9 @@ public class ConvertContextServiceDefinitions extends BaseConvertDefinitions {
         def.setType(jakarta.enterprise.concurrent.ContextService.class.getName());
 
         final Properties p = def.getProperties();
-        put(p, "propagated", Join.join(",", contextService.getPropagated()));
-        put(p, "cleared", Join.join(",", contextService.getCleared()));
-        put(p, "unchanged", Join.join(",", contextService.getUnchanged()));
+        put(p, "Propagated", Join.join(",", contextService.getPropagated()));
+        put(p, "Cleared", Join.join(",", contextService.getCleared()));
+        put(p, "Unchanged", Join.join(",", contextService.getUnchanged()));
 
         // to force it to be bound in JndiEncBuilder
         put(p, "JndiName", def.getJndi());

--- a/container/openejb-core/src/main/java/org/apache/openejb/core/ThreadContext.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/core/ThreadContext.java
@@ -39,7 +39,7 @@ public class ThreadContext {
         return threadStorage.get();
     }
 
-    public static ThreadContext enter(final ThreadContext newContext, final boolean propagateTx) {
+    public static ThreadContext enter(final ThreadContext newContext) {
         if (newContext == null) {
             throw new NullPointerException("newContext is null");
         }
@@ -56,7 +56,7 @@ public class ThreadContext {
         // notify listeners
         for (final ThreadContextListener listener : listeners) {
             try {
-                listener.contextEntered(oldContext, newContext, propagateTx);
+                listener.contextEntered(oldContext, newContext);
             } catch (final Throwable e) {
                 log.warning("ThreadContextListener threw an exception", e);
             }
@@ -65,10 +65,6 @@ public class ThreadContext {
         // return old context so it can be used for exit call below
         return oldContext;
 
-    }
-
-    public static ThreadContext enter(final ThreadContext newContext) {
-        return enter(newContext, true);
     }
 
     public static void exit(final ThreadContext oldContext) {

--- a/container/openejb-core/src/main/java/org/apache/openejb/core/ThreadContextListener.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/core/ThreadContextListener.java
@@ -23,9 +23,8 @@ public interface ThreadContextListener {
      *
      * @param oldContext  the old context that was associated with the thread
      * @param newContext  the new context that is now associated with the thread
-     * @param propagateTx
      */
-    void contextEntered(ThreadContext oldContext, ThreadContext newContext, boolean propagateTx);
+    void contextEntered(ThreadContext oldContext, ThreadContext newContext);
 
     /**
      * A context has exited.  The reentered context is already associated with the thread.

--- a/container/openejb-core/src/main/java/org/apache/openejb/core/ivm/BaseEjbProxyHandler.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/core/ivm/BaseEjbProxyHandler.java
@@ -87,7 +87,7 @@ public abstract class BaseEjbProxyHandler implements InvocationHandler, Serializ
     static {
         ThreadContext.addThreadContextListener(new ThreadContextListener() {
             @Override
-            public void contextEntered(final ThreadContext oldContext, final ThreadContext newContext, boolean propagateTx) {
+            public void contextEntered(final ThreadContext oldContext, final ThreadContext newContext) {
                 // no-op
             }
 

--- a/container/openejb-core/src/main/java/org/apache/openejb/core/security/AbstractSecurityService.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/core/security/AbstractSecurityService.java
@@ -175,7 +175,7 @@ public abstract class AbstractSecurityService implements DestroyableResource, Se
     }
 
     @Override
-    public void contextEntered(final ThreadContext oldContext, final ThreadContext newContext, boolean propagateTx) {
+    public void contextEntered(final ThreadContext oldContext, final ThreadContext newContext) {
         final String moduleID = newContext.getBeanContext().getModuleID();
         JavaSecurityManagers.setContextID(moduleID);
 

--- a/container/openejb-core/src/main/java/org/apache/openejb/core/transaction/EjbTransactionUtil.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/core/transaction/EjbTransactionUtil.java
@@ -36,9 +36,9 @@ public final class EjbTransactionUtil {
     static {
         ThreadContext.addThreadContextListener(new ThreadContextListener() {
             @Override
-            public void contextEntered(final ThreadContext oldContext, final ThreadContext newContext, boolean propagateTx) {
+            public void contextEntered(final ThreadContext oldContext, final ThreadContext newContext) {
                 // propagate current tx environment to the new ThreadContext
-                if (oldContext != null && propagateTx) {
+                if (oldContext != null) {
                     newContext.setTransactionPolicy(oldContext.getTransactionPolicy());
                 }
             }

--- a/container/openejb-core/src/main/java/org/apache/openejb/threads/impl/ApplicationThreadContextProvider.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/threads/impl/ApplicationThreadContextProvider.java
@@ -73,7 +73,7 @@ public class ApplicationThreadContextProvider implements ThreadContextProvider, 
 
             // Don't touch ThreadContext if it is already correct or none was captured
             boolean changeThreadContext = threadContext != null && threadContext != ThreadContext.getThreadContext();
-            ThreadContext oldThreadContext = changeThreadContext ? ThreadContext.enter(threadContext, false) : null;
+            ThreadContext oldThreadContext = changeThreadContext ? ThreadContext.enter(threadContext) : null;
             return new ApplicationThreadContextRestorer(oldCl, oldThreadContext, changeThreadContext);
         }
     }

--- a/container/openejb-core/src/main/java/org/apache/openejb/threads/impl/SecurityThreadContextProvider.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/threads/impl/SecurityThreadContextProvider.java
@@ -114,7 +114,7 @@ public class SecurityThreadContextProvider implements ThreadContextProvider, Ser
             final ThreadContext oldCtx;
             if (threadContext != null) {
                 final ThreadContext newContext = new ThreadContext(threadContext);
-                oldCtx = ThreadContext.enter(newContext, false);
+                oldCtx = ThreadContext.enter(newContext);
                 if (sc != null) {
                     newContext.set(AbstractSecurityService.SecurityContext.class, sc);
                 }

--- a/docs/admin/configuration/resources.adoc
+++ b/docs/admin/configuration/resources.adoc
@@ -487,29 +487,10 @@ Declarable in tomee.xml via
 
 [source,xml]
 ----
-<Resource id="Foo" type="ContextService" />
-----
-
-Declarable in properties via
-
-[source,properties]
-----
-Foo = new://Resource?type=ContextService
-----
-
-
-== JndiProvider: inject remote clients
-
-A thread factory for a `ManagedExecutorService`.
-Default implementation is `org.apache.openejb.threads.impl.ManagedThreadFactoryImpl`.
-
-Declarable in tomee.xml via
-
-[source,xml]
-----
-<Resource id="Foo" type="ManagedThreadFactory">
-    Prefix = openejb-managed-thread-
-    Lazy = true
+<Resource id="Foo" type="ContextService">
+  Propagated = Remaining
+  Cleared = Transaction
+  Unchanged = MyFoo
 </Resource>
 ----
 
@@ -517,34 +498,13 @@ Declarable in properties via
 
 [source,properties]
 ----
-Foo = new://Resource?type=ManagedThreadFactory
-Foo.Prefix = openejb-managed-thread-
-Foo.Lazy = true
+Foo = new://Resource?type=ContextService
+Foo.Propagated = Remaining
+Foo.Cleared = Transaction
+Foo.Unchanged = MyFoo
 ----
 
 === Configuration
-
-==== Prefix
-
-The thread prefix (suffixed with thread id).
-
-
-
-== ContextService
-
-A concurrency utilities for JavaEE context service. It allows to create
-contextual proxies (inheriting from security, classloader...contexts).
-
-Declarable in tomee.xml via
-
-[source,xml]
-----
-<Resource id="Foo" type="ContextService" />
-----
-
-Declarable in properties via
-
-[source,properties]
-----
-Foo = new://Resource?type=ContextService
-----
+==== Propagated, Cleared, Unchanged
+Contexts to be propagated, cleared or ignored.
+Propagating the built-in type 'Transaction' is not supported!

--- a/tomee/tomee-catalina/src/main/java/org/apache/tomee/catalina/TomcatThreadContextListener.java
+++ b/tomee/tomee-catalina/src/main/java/org/apache/tomee/catalina/TomcatThreadContextListener.java
@@ -73,7 +73,7 @@ public class TomcatThreadContextListener implements ThreadContextListener {
      * {@inheritDoc}
      */
     @Override
-    public void contextEntered(final ThreadContext oldContext, final ThreadContext newContext, final boolean propagateTx) {
+    public void contextEntered(final ThreadContext oldContext, final ThreadContext newContext) {
         // save off the old context if possible
         try {
             final Data data = new Data(getThreadName());


### PR DESCRIPTION
See [TOMEE-4518](https://issues.apache.org/jira/browse/TOMEE-4518) and [this thread](https://lists.apache.org/list.html?dev@tomee.apache.org) on the dev list

Maybe we should think out loud about failing the deployment of a `ContextService` if it defines `Propagated*=Transaction`. This however brings up questions again like what to do in this case:
```
<Resource id="Foo" type="ContextService">
  Propagated = Remaining
  Cleared =
  Unchanged =
</Resource>
```
And if we should completely abort the TomEE startup if an illegal ContextService is detected in `tomee.xml`. What if it has `Lazy=true`? So I chose to not enforce this via code yet.