### PR TITLE
TOMEE-4610 - RemoteException is not chained with AuthenticationException at openejb-client authentication

### DIFF
--- a/server/openejb-client/src/main/java/org/apache/openejb/client/JNDIContext.java
+++ b/server/openejb-client/src/main/java/org/apache/openejb/client/JNDIContext.java
@@ -377,7 +377,7 @@ public class JNDIContext implements InitialContextFactory, Context {
         try {
             res = requestAuthorization(req);
         } catch (RemoteException e) {
-            throw new AuthenticationException(e.getLocalizedMessage());
+            throw (AuthenticationException) new AuthenticationException(e.getLocalizedMessage()).initCause(e);
         }
 
         switch (res.getResponseCode()) {

--- a/server/openejb-client/src/main/java/org/apache/openejb/client/JNDIContext.java
+++ b/server/openejb-client/src/main/java/org/apache/openejb/client/JNDIContext.java
@@ -767,7 +767,7 @@ public class JNDIContext implements InitialContextFactory, Context {
         try {
             response = LogoutResponse.class.cast(Client.request(request, new LogoutResponse(), server));
         } catch (final RemoteException e) {
-            throw new AuthenticationException(e.getLocalizedMessage());
+            throw (AuthenticationException) new AuthenticationException(e.getLocalizedMessage()).initCause(e);
         }
 
         switch (response.getResponseCode()) {


### PR DESCRIPTION
Hello

One of our middleware is using openejb-client 10.0.0.
The openejb-client authentication often fails: it requires a certificate that is inside a smartcard, that can be unavailable for many reasons.
While debugging I noticed that the real reasons of why the authentication fails is hidden by `JNDIContext#authenticate`:
The `RemoteException` that is catched is not chained to the `AuthenticationException` that is rethrowed.
It seems to be an oversight.
This patch is chaining the `RemoteException` to the `AuthenticationException`.