### PR TITLE
Use new shibboleth Maven repository URLs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -917,7 +917,7 @@
     <repository>
       <id>B_shibboleth</id>
       <name>OpenSAML</name>
-      <url>https://build.shibboleth.net/nexus/content/groups/public</url>
+      <url>https://build.shibboleth.net/maven/releases</url>
       <releases>
         <enabled>true</enabled>
       </releases>


### PR DESCRIPTION
```
As of 20 January 2022, the following Maven repository URLs are being redirected : 
https://build.shibboleth.net/nexus/content/groups/public  
to
https://build.shibboleth.net/maven/releases 
```

see https://shibboleth.atlassian.net/wiki/spaces/DEV/pages/2891317253/MavenRepositories#Old-Shibboleth-Maven-Repository-URLs