### PR TITLE
TOMEE-4604 strip ssl keystore configuration params from outgoing URL.

### DIFF
--- a/server/openejb-client/src/main/java/org/apache/openejb/client/HttpConnectionFactory.java
+++ b/server/openejb-client/src/main/java/org/apache/openejb/client/HttpConnectionFactory.java
@@ -151,6 +151,7 @@ public class HttpConnectionFactory implements ConnectionFactory {
             }
 
             final StringBuilder sb = new StringBuilder();
+            // split on [&?] to account for failover URLs with multiple http URLs embedded
             for (String param : url.substring(queryStartIndex+1).split("[&?]")) {
                 final int p = param.indexOf('=');
                 if ((p < 0 && Arrays.binarySearch(params, param) < 0)

--- a/server/openejb-client/src/main/java/org/apache/openejb/client/HttpConnectionFactory.java
+++ b/server/openejb-client/src/main/java/org/apache/openejb/client/HttpConnectionFactory.java
@@ -155,7 +155,7 @@ public class HttpConnectionFactory implements ConnectionFactory {
             for (String param : url.substring(queryStartIndex+1).split("[&?]")) {
                 final int p = param.indexOf('=');
                 if ((p < 0 && Arrays.binarySearch(params, param) < 0)
-                        || (p > 0 && Arrays.binarySearch(params, param.substring(0, p)) < 0)) {
+                        || (p >= 0 && Arrays.binarySearch(params, param.substring(0, p)) < 0)) {
                     if (!sb.isEmpty()) { sb.append('&'); }
                     sb.append(param);
                 }

--- a/server/openejb-client/src/main/java/org/apache/openejb/client/HttpConnectionFactory.java
+++ b/server/openejb-client/src/main/java/org/apache/openejb/client/HttpConnectionFactory.java
@@ -60,7 +60,7 @@ public class HttpConnectionFactory implements ConnectionFactory {
     }
 
     public static class HttpConnection implements Connection {
-        private final static String []PARAMS_TO_STRIP = new String[]{
+        private static final String[] PARAMS_TO_STRIP = new String[]{
                 // must be sorted alphabetically
                 "authorization", "authorizationHeader", "basic.password", "basic.username",
                 "connectTimeout", "readTimeout",
@@ -141,10 +141,14 @@ public class HttpConnectionFactory implements ConnectionFactory {
             }
         }
 
-        private String stripQuery(final String url, final String []params) {
+        private String stripQuery(final String url, final String[] params) {
             final int queryStartIndex = url.indexOf('?');
-            if (queryStartIndex < 0) { return url; }
-            if (queryStartIndex + 1 == url.length()) { return url.substring(0, queryStartIndex); }
+            if (queryStartIndex < 0) {
+                return url;
+            }
+            if (queryStartIndex + 1 == url.length()) {
+                return url.substring(0, queryStartIndex);
+            }
 
             final StringBuilder sb = new StringBuilder();
             for (String param : url.substring(queryStartIndex+1).split("[&?]")) {

--- a/server/openejb-client/src/main/java/org/apache/openejb/client/HttpConnectionFactory.java
+++ b/server/openejb-client/src/main/java/org/apache/openejb/client/HttpConnectionFactory.java
@@ -29,6 +29,7 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentHashMap;
@@ -59,6 +60,13 @@ public class HttpConnectionFactory implements ConnectionFactory {
     }
 
     public static class HttpConnection implements Connection {
+        private final static String []PARAMS_TO_STRIP = new String[]{
+                // must be sorted alphabetically
+                "authorization", "authorizationHeader", "basic.password", "basic.username",
+                "connectTimeout", "readTimeout",
+                "sslKeyStore", "sslKeyStorePassword", "sslKeyStoreType",
+                "sslTrustStore", "sslTrustStorePassword", "sslTrustStoreType"
+        };
         private final byte[] buffer;
         private HttpURLConnection httpURLConnection;
         private InputStream inputStream;
@@ -89,15 +97,8 @@ public class HttpConnectionFactory implements ConnectionFactory {
                 authorization = "Basic " + printBase64Binary((basicUsername + (basicPassword != null ? ":" + basicPassword : "")).getBytes(StandardCharsets.UTF_8));
             }
 
-            final String newUrl =
-                    stripQuery(
-                        stripQuery(
-                            stripQuery(
-                                stripQuery(url.toExternalForm(), "authorization"),
-                        "basic.username"),
-                            "basic.password"),
-                "authorizationHeader");
-            httpURLConnection = (HttpURLConnection) (authorization == null ? url : new URL(newUrl)).openConnection();
+            final String newUrl = stripQuery(url.toExternalForm(), PARAMS_TO_STRIP);
+            httpURLConnection = (HttpURLConnection) new URL(newUrl).openConnection();
             httpURLConnection.setDoOutput(true);
 
             final int timeout;
@@ -140,20 +141,21 @@ public class HttpConnectionFactory implements ConnectionFactory {
             }
         }
 
-        private String stripQuery(final String url, final String param) {
-            String result = url;
-            do {
-                final int h = result.indexOf(param + '=');
-                int end = result.indexOf('&', h);
-                if (end < 0) {
-                    end = result.length();
+        private String stripQuery(final String url, final String []params) {
+            final int queryStartIndex = url.indexOf('?');
+            if (queryStartIndex < 0) { return url; }
+            if (queryStartIndex + 1 == url.length()) { return url.substring(0, queryStartIndex); }
+
+            final StringBuilder sb = new StringBuilder();
+            for (String param : url.substring(queryStartIndex+1).split("[&?]")) {
+                final int p = param.indexOf('=');
+                if ((p < 0 && Arrays.binarySearch(params, param) < 0)
+                        || (p > 0 && Arrays.binarySearch(params, param.substring(0, p)) < 0)) {
+                    if (!sb.isEmpty()) { sb.append('&'); }
+                    sb.append(param);
                 }
-                if (h <= 0) {
-                    return result.endsWith("?") ? result.substring(0, result.length() - 1) : result;
-                }
-                result = result.substring(0, h) +
-                        (end < 0 || end == result.length() ? "" : result.substring(end + 1, result.length()));
-            } while (true);
+            }
+            return url.substring(0, queryStartIndex) + (sb.isEmpty() ? "" : "?" + sb);
         }
 
         @Override

--- a/server/openejb-client/src/test/java/org/apache/openejb/client/HttpConnectionTest.java
+++ b/server/openejb-client/src/test/java/org/apache/openejb/client/HttpConnectionTest.java
@@ -19,6 +19,7 @@ package org.apache.openejb.client;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
+import jakarta.annotation.Nonnull;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -47,18 +48,28 @@ public class HttpConnectionTest {
                 exchange.sendResponseHeaders(200, 0);
 
                 final OutputStream responseBody = exchange.getResponseBody();
-                responseBody.write("secure page".getBytes());
+                responseBody.write("secure page|".getBytes());
                 final String query = exchange.getRequestURI().getQuery();
                 if (query != null) {
+                    responseBody.write("QUERY:".getBytes());
                     responseBody.write(query.getBytes());
+                } else {
+                    responseBody.write("NO_QUERY:".getBytes());
                 }
+                responseBody.write("|".getBytes());
                 final String authorization = exchange.getRequestHeaders().getFirst("Authorization");
                 if (authorization != null) {
+                    responseBody.write("AUTH:".getBytes("UTF-8"));
                     responseBody.write(authorization.getBytes("UTF-8"));
+                } else {
+                    responseBody.write("NO_AUTH:".getBytes("UTF-8"));
                 }
+                responseBody.write("|".getBytes());
                 final String authorization2 = exchange.getRequestHeaders().getFirst("AltAuthorization");
                 if (authorization2 != null) {
-                    responseBody.write(("alt" + authorization2).getBytes("UTF-8"));
+                    responseBody.write(("ALT_AUTH:" + authorization2).getBytes("UTF-8"));
+                } else {
+                    responseBody.write("NO_ALT_AUTH:".getBytes("UTF-8"));
                 }
                 responseBody.close();
             }
@@ -77,29 +88,9 @@ public class HttpConnectionTest {
         final String url = "http://localhost:" + server.getAddress().getPort() + "/e";
         for (int i = 0; i < 3; i++) {
             final Connection connection = factory.getConnection(new URI(url));
+            final String out = drainConnectionToString(connection);
 
-            BufferedReader br = null;
-            final StringBuilder sb = new StringBuilder();
-            String line;
-            try {
-                br = new BufferedReader(new InputStreamReader(connection.getInputStream()));
-                while ((line = br.readLine()) != null) {
-                    sb.append(line);
-                }
-            } catch (final IOException e) {
-                e.printStackTrace();
-            } finally {
-                if (br != null) {
-                    try {
-                        br.close();
-                    } catch (IOException e) {
-                        e.printStackTrace();
-                    }
-                }
-                connection.close();
-            }
-
-            Assert.assertTrue("should contain", sb.toString().contains("secure"));
+            Assert.assertEquals("secure page|NO_QUERY:|NO_AUTH:|NO_ALT_AUTH:", out);
         }
     }
 
@@ -109,29 +100,9 @@ public class HttpConnectionTest {
         final String url = "http://localhost:" + server.getAddress().getPort() + "/e?authorization=Basic%20token";
         for (int i = 0; i < 3; i++) {
             final Connection connection = factory.getConnection(new URI(url));
+            String out = drainConnectionToString(connection);
 
-            BufferedReader br = null;
-            final StringBuilder sb = new StringBuilder();
-            String line;
-            try {
-                br = new BufferedReader(new InputStreamReader(connection.getInputStream()));
-                while ((line = br.readLine()) != null) {
-                    sb.append(line);
-                }
-            } catch (final IOException e) {
-                e.printStackTrace();
-            } finally {
-                if (br != null) {
-                    try {
-                        br.close();
-                    } catch (IOException e) {
-                        e.printStackTrace();
-                    }
-                }
-                connection.close();
-            }
-
-            Assert.assertTrue("should contain", sb.toString().contains("secure pageBasic token"));
+            Assert.assertEquals("secure page|NO_QUERY:|AUTH:Basic token|NO_ALT_AUTH:", out);
         }
     }
 
@@ -141,29 +112,9 @@ public class HttpConnectionTest {
         final String url = "http://localhost:" + server.getAddress().getPort() + "/e?basic.password=pwd&basic.username=test&authorizationHeader=AltAuthorization";
         for (int i = 0; i < 3; i++) {
             final Connection connection = factory.getConnection(new URI(url));
+            String out = drainConnectionToString(connection);
 
-            BufferedReader br = null;
-            final StringBuilder sb = new StringBuilder();
-            String line;
-            try {
-                br = new BufferedReader(new InputStreamReader(connection.getInputStream()));
-                while ((line = br.readLine()) != null) {
-                    sb.append(line);
-                }
-            } catch (final IOException e) {
-                e.printStackTrace();
-            } finally {
-                if (br != null) {
-                    try {
-                        br.close();
-                    } catch (final IOException e) {
-                        e.printStackTrace();
-                    }
-                }
-                connection.close();
-            }
-
-            Assert.assertTrue("should contain", sb.toString().contains("secure pagealtBasic dGVzdDpwd2Q="));
+            Assert.assertEquals("secure page|NO_QUERY:|NO_AUTH:|ALT_AUTH:Basic dGVzdDpwd2Q=", out);
         }
     }
 
@@ -173,29 +124,8 @@ public class HttpConnectionTest {
         final String url = "http://localhost:" + server.getAddress().getPort() + "/e?basic.password=pwd&basic.username=te%26st&authorizationHeader=AltAuthorization";
         for (int i = 0; i < 3; i++) {
             final Connection connection = factory.getConnection(new URI(url));
-
-            BufferedReader br = null;
-            final StringBuilder sb = new StringBuilder();
-            String line;
-            try {
-                br = new BufferedReader(new InputStreamReader(connection.getInputStream()));
-                while ((line = br.readLine()) != null) {
-                    sb.append(line);
-                }
-            } catch (final IOException e) {
-                e.printStackTrace();
-            } finally {
-                if (br != null) {
-                    try {
-                        br.close();
-                    } catch (final IOException e) {
-                        e.printStackTrace();
-                    }
-                }
-                connection.close();
-            }
-
-            Assert.assertTrue("should contain", sb.toString().contains("secure pagealtBasic dGUmc3Q6cHdk"));
+            String out = drainConnectionToString(connection);
+            Assert.assertEquals("secure page|NO_QUERY:|NO_AUTH:|ALT_AUTH:Basic dGUmc3Q6cHdk", out);
         }
     }
 
@@ -204,6 +134,12 @@ public class HttpConnectionTest {
         final String baseHttp = "http://localhost:" + server.getAddress().getPort() + "/e?authorization=";
         final String uri = "failover:sticky+random:" + baseHttp + "Basic%20ABCD&" + baseHttp + "Basic%20EFG";
         final Connection connection = ConnectionManager.getConnection(new URI(uri));
+        final String out = drainConnectionToString(connection);
+        Assert.assertEquals("secure page|QUERY:http://localhost:" + server.getAddress().getPort() + "/e|AUTH:Basic ABCD|NO_ALT_AUTH:", out);
+    }
+
+    @Nonnull
+    private static String drainConnectionToString(Connection connection) throws IOException {
         BufferedReader br = null;
         final StringBuilder sb = new StringBuilder();
         String line;
@@ -225,6 +161,6 @@ public class HttpConnectionTest {
             connection.close();
         }
         final String out = sb.toString();
-        Assert.assertTrue(out, out.contains("secure pagehttp://localhost:" + server.getAddress().getPort() + "/eBasic ABCD"));
+        return out;
     }
 }

--- a/server/openejb-client/src/test/java/org/apache/openejb/client/HttpConnectionTest.java
+++ b/server/openejb-client/src/test/java/org/apache/openejb/client/HttpConnectionTest.java
@@ -19,7 +19,6 @@ package org.apache.openejb.client;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
-import jakarta.annotation.Nonnull;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -138,7 +137,24 @@ public class HttpConnectionTest {
         Assert.assertEquals("secure page|QUERY:http://localhost:" + server.getAddress().getPort() + "/e|AUTH:Basic ABCD|NO_ALT_AUTH:", out);
     }
 
-    @Nonnull
+    @Test
+    public void httpBasicStripsSpecifiedQueryParamsOnly() throws URISyntaxException, IOException {
+        final HttpConnectionFactory factory = new HttpConnectionFactory();
+        final String url = "http://localhost:" + server.getAddress().getPort() + "/e?authorization=Basic%20token&foo=bar&int=1";
+        final Connection connection = factory.getConnection(new URI(url));
+        final String out = drainConnectionToString(connection);
+        Assert.assertEquals("secure page|QUERY:foo=bar&int=1|AUTH:Basic token|NO_ALT_AUTH:", out);
+    }
+
+    @Test
+    public void httpStripsSSLQueryParams() throws URISyntaxException, IOException {
+        final HttpConnectionFactory factory = new HttpConnectionFactory();
+        final String url = "http://localhost:" + server.getAddress().getPort() + "/e?sslKeyStorePassword=changeit&foo=bar&int=1&sslTrustStorePassword=changeit";
+        final Connection connection = factory.getConnection(new URI(url));
+        final String out = drainConnectionToString(connection);
+        Assert.assertEquals("secure page|QUERY:foo=bar&int=1|NO_AUTH:|NO_ALT_AUTH:", out);
+    }
+
     private static String drainConnectionToString(Connection connection) throws IOException {
         BufferedReader br = null;
         final StringBuilder sb = new StringBuilder();
@@ -160,7 +176,6 @@ public class HttpConnectionTest {
             }
             connection.close();
         }
-        final String out = sb.toString();
-        return out;
+        return sb.toString();
     }
 }


### PR DESCRIPTION
Sorry for the refactor of HttpConnectionTest, but it was hard to understand why it fails without separators between parts of response.