### PR TITLE
TOMEE-4589 - Trim whitespace in numeric/enum descriptor values

### DIFF
--- a/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/Addressing$JAXB.java
+++ b/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/Addressing$JAXB.java
@@ -96,15 +96,15 @@ public class Addressing$JAXB
         for (XoXMLStreamReader elementReader: reader.getChildElements()) {
             if (("enabled" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: enabled
-                Boolean enabled = ("1".equals(elementReader.getElementText())||"true".equals(elementReader.getElementText()));
+                Boolean enabled = ("1".equals(elementReader.getElementText().trim())||"true".equals(elementReader.getElementText().trim()));
                 addressing.enabled = enabled;
             } else if (("required" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: required
-                Boolean required = ("1".equals(elementReader.getElementText())||"true".equals(elementReader.getElementText()));
+                Boolean required = ("1".equals(elementReader.getElementText().trim())||"true".equals(elementReader.getElementText().trim()));
                 addressing.required = required;
             } else if (("responses" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: responses
-                AddressingResponses responses = parseAddressingResponses(elementReader, context, elementReader.getElementText());
+                AddressingResponses responses = parseAddressingResponses(elementReader, context, elementReader.getElementText().trim());
                 if (responses!= null) {
                     addressing.responses = responses;
                 }

--- a/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/Application$JAXB.java
+++ b/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/Application$JAXB.java
@@ -208,7 +208,7 @@ public class Application$JAXB
                 icon.add(iconItem);
             } else if (("initialize-in-order" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: initializeInOrder
-                Boolean initializeInOrder = ("1".equals(elementReader.getElementText())||"true".equals(elementReader.getElementText()));
+                Boolean initializeInOrder = ("1".equals(elementReader.getElementText().trim())||"true".equals(elementReader.getElementText().trim()));
                 application.initializeInOrder = initializeInOrder;
             } else if (("module" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: module

--- a/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/ApplicationClient$JAXB.java
+++ b/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/ApplicationClient$JAXB.java
@@ -156,7 +156,7 @@ public class ApplicationClient$JAXB
                 applicationClient.id = id;
             } else if (("metadata-complete" == attribute.getLocalName())&&(("" == attribute.getNamespace())||(attribute.getNamespace() == null))) {
                 // ATTRIBUTE: metadataComplete
-                Boolean metadataComplete = ("1".equals(attribute.getValue())||"true".equals(attribute.getValue()));
+                Boolean metadataComplete = ("1".equals(attribute.getValue().trim())||"true".equals(attribute.getValue().trim()));
                 applicationClient.metadataComplete = metadataComplete;
             } else if (("version" == attribute.getLocalName())&&(("" == attribute.getNamespace())||(attribute.getNamespace() == null))) {
                 // ATTRIBUTE: version

--- a/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/ApplicationException$JAXB.java
+++ b/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/ApplicationException$JAXB.java
@@ -111,11 +111,11 @@ public class ApplicationException$JAXB
                 applicationException.exceptionClass = exceptionClass;
             } else if (("rollback" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: rollback
-                Boolean rollback = ("1".equals(elementReader.getElementText())||"true".equals(elementReader.getElementText()));
+                Boolean rollback = ("1".equals(elementReader.getElementText().trim())||"true".equals(elementReader.getElementText().trim()));
                 applicationException.rollback = rollback;
             } else if (("inherited" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: inherited
-                Boolean inherited = ("1".equals(elementReader.getElementText())||"true".equals(elementReader.getElementText()));
+                Boolean inherited = ("1".equals(elementReader.getElementText().trim())||"true".equals(elementReader.getElementText().trim()));
                 applicationException.inherited = inherited;
             } else {
                 context.unexpectedElement(elementReader, new QName("http://java.sun.com/xml/ns/javaee", "exception-class"), new QName("http://java.sun.com/xml/ns/javaee", "rollback"), new QName("http://java.sun.com/xml/ns/javaee", "inherited"));

--- a/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/CmrField$JAXB.java
+++ b/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/CmrField$JAXB.java
@@ -126,7 +126,7 @@ public class CmrField$JAXB
                 cmrField.cmrFieldName = cmrFieldName;
             } else if (("cmr-field-type" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: cmrFieldType
-                CmrFieldType cmrFieldType = parseCmrFieldType(elementReader, context, elementReader.getElementText());
+                CmrFieldType cmrFieldType = parseCmrFieldType(elementReader, context, elementReader.getElementText().trim());
                 if (cmrFieldType!= null) {
                     cmrField.cmrFieldType = cmrFieldType;
                 }

--- a/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/ConcurrentMethod$JAXB.java
+++ b/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/ConcurrentMethod$JAXB.java
@@ -110,7 +110,7 @@ public class ConcurrentMethod$JAXB
                 concurrentMethod.method = method;
             } else if (("lock" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: lock
-                ConcurrentLockType lock = parseConcurrentLockType(elementReader, context, elementReader.getElementText());
+                ConcurrentLockType lock = parseConcurrentLockType(elementReader, context, elementReader.getElementText().trim());
                 if (lock!= null) {
                     concurrentMethod.lock = lock;
                 }

--- a/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/ConfigProperty$JAXB.java
+++ b/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/ConfigProperty$JAXB.java
@@ -150,15 +150,15 @@ public class ConfigProperty$JAXB
                 configProperty.configPropertyValue = configPropertyValue;
             } else if (("config-property-ignore" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: configPropertyIgnore
-                Boolean configPropertyIgnore = ("1".equals(elementReader.getElementText())||"true".equals(elementReader.getElementText()));
+                Boolean configPropertyIgnore = ("1".equals(elementReader.getElementText().trim())||"true".equals(elementReader.getElementText().trim()));
                 configProperty.configPropertyIgnore = configPropertyIgnore;
             } else if (("config-property-supports-dynamic-updates" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: configPropertySupportsDynamicUpdates
-                Boolean configPropertySupportsDynamicUpdates = ("1".equals(elementReader.getElementText())||"true".equals(elementReader.getElementText()));
+                Boolean configPropertySupportsDynamicUpdates = ("1".equals(elementReader.getElementText().trim())||"true".equals(elementReader.getElementText().trim()));
                 configProperty.configPropertySupportsDynamicUpdates = configPropertySupportsDynamicUpdates;
             } else if (("config-property-confidential" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: configPropertyConfidential
-                Boolean configPropertyConfidential = ("1".equals(elementReader.getElementText())||"true".equals(elementReader.getElementText()));
+                Boolean configPropertyConfidential = ("1".equals(elementReader.getElementText().trim())||"true".equals(elementReader.getElementText().trim()));
                 configProperty.configPropertyConfidential = configPropertyConfidential;
             } else {
                 context.unexpectedElement(elementReader, new QName("http://java.sun.com/xml/ns/javaee", "description"), new QName("http://java.sun.com/xml/ns/javaee", "config-property-name"), new QName("http://java.sun.com/xml/ns/javaee", "config-property-type"), new QName("http://java.sun.com/xml/ns/javaee", "config-property-value"), new QName("http://java.sun.com/xml/ns/javaee", "config-property-ignore"), new QName("http://java.sun.com/xml/ns/javaee", "config-property-supports-dynamic-updates"), new QName("http://java.sun.com/xml/ns/javaee", "config-property-confidential"));

--- a/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/Connector$JAXB.java
+++ b/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/Connector$JAXB.java
@@ -110,7 +110,7 @@ public class Connector$JAXB
                 connector.version = Adapters.collapsedStringAdapterAdapter.unmarshal(attribute.getValue());
             } else if (("metadata-complete" == attribute.getLocalName())&&(("" == attribute.getNamespace())||(attribute.getNamespace() == null))) {
                 // ATTRIBUTE: metadataComplete
-                Boolean metadataComplete = ("1".equals(attribute.getValue())||"true".equals(attribute.getValue()));
+                Boolean metadataComplete = ("1".equals(attribute.getValue().trim())||"true".equals(attribute.getValue().trim()));
                 connector.metadataComplete = metadataComplete;
             } else if (XMLConstants.W3C_XML_SCHEMA_INSTANCE_NS_URI!= attribute.getNamespace()) {
                 context.unexpectedAttribute(attribute, new QName("", "id"), new QName("", "version"), new QName("", "metadata-complete"));

--- a/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/ContainerConcurrency$JAXB.java
+++ b/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/ContainerConcurrency$JAXB.java
@@ -129,7 +129,7 @@ public class ContainerConcurrency$JAXB
                 method.add(methodItem);
             } else if (("concurrency-attribute" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: lock
-                ConcurrentLockType lock = parseConcurrentLockType(elementReader, context, elementReader.getElementText());
+                ConcurrentLockType lock = parseConcurrentLockType(elementReader, context, elementReader.getElementText().trim());
                 if (lock!= null) {
                     containerConcurrency.lock = lock;
                 }

--- a/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/ContainerTransaction$JAXB.java
+++ b/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/ContainerTransaction$JAXB.java
@@ -129,7 +129,7 @@ public class ContainerTransaction$JAXB
                 method.add(methodItem);
             } else if (("trans-attribute" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: transAttribute
-                TransAttribute transAttribute = parseTransAttribute(elementReader, context, elementReader.getElementText());
+                TransAttribute transAttribute = parseTransAttribute(elementReader, context, elementReader.getElementText().trim());
                 if (transAttribute!= null) {
                     containerTransaction.transAttribute = transAttribute;
                 }

--- a/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/CookieConfig$JAXB.java
+++ b/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/CookieConfig$JAXB.java
@@ -150,15 +150,15 @@ public class CookieConfig$JAXB
                 cookieConfig.comment = comment;
             } else if (("http-only" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: httpOnly
-                Boolean httpOnly = ("1".equals(elementReader.getElementText())||"true".equals(elementReader.getElementText()));
+                Boolean httpOnly = ("1".equals(elementReader.getElementText().trim())||"true".equals(elementReader.getElementText().trim()));
                 cookieConfig.httpOnly = httpOnly;
             } else if (("secure" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: secure
-                Boolean secure = ("1".equals(elementReader.getElementText())||"true".equals(elementReader.getElementText()));
+                Boolean secure = ("1".equals(elementReader.getElementText().trim())||"true".equals(elementReader.getElementText().trim()));
                 cookieConfig.secure = secure;
             } else if (("max-age" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: maxAge
-                Integer maxAge = Integer.valueOf(elementReader.getElementText());
+                Integer maxAge = Integer.valueOf(elementReader.getElementText().trim());
                 cookieConfig.maxAge = maxAge;
             } else {
                 context.unexpectedElement(elementReader, new QName("http://java.sun.com/xml/ns/javaee", "name"), new QName("http://java.sun.com/xml/ns/javaee", "domain"), new QName("http://java.sun.com/xml/ns/javaee", "path"), new QName("http://java.sun.com/xml/ns/javaee", "comment"), new QName("http://java.sun.com/xml/ns/javaee", "http-only"), new QName("http://java.sun.com/xml/ns/javaee", "secure"), new QName("http://java.sun.com/xml/ns/javaee", "max-age"));

--- a/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/DataSource$JAXB.java
+++ b/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/DataSource$JAXB.java
@@ -156,7 +156,7 @@ public class DataSource$JAXB
                 dataSource.serverName = serverName;
             } else if (("port-number" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: portNumber
-                Integer portNumber = Integer.valueOf(elementReader.getElementText());
+                Integer portNumber = Integer.valueOf(elementReader.getElementText().trim());
                 dataSource.portNumber = portNumber;
             } else if (("database-name" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: databaseName
@@ -224,37 +224,37 @@ public class DataSource$JAXB
                 property.add(propertyItem);
             } else if (("login-timeout" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: loginTimeout
-                Integer loginTimeout = Integer.valueOf(elementReader.getElementText());
+                Integer loginTimeout = Integer.valueOf(elementReader.getElementText().trim());
                 dataSource.loginTimeout = loginTimeout;
             } else if (("transactional" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: transactional
-                Boolean transactional = ("1".equals(elementReader.getElementText())||"true".equals(elementReader.getElementText()));
+                Boolean transactional = ("1".equals(elementReader.getElementText().trim())||"true".equals(elementReader.getElementText().trim()));
                 dataSource.transactional = transactional;
             } else if (("isolation-level" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: isolationLevel
-                IsolationLevel isolationLevel = parseIsolationLevel(elementReader, context, elementReader.getElementText());
+                IsolationLevel isolationLevel = parseIsolationLevel(elementReader, context, elementReader.getElementText().trim());
                 if (isolationLevel!= null) {
                     dataSource.isolationLevel = isolationLevel;
                 }
             } else if (("initial-pool-size" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: initialPoolSize
-                Integer initialPoolSize = Integer.valueOf(elementReader.getElementText());
+                Integer initialPoolSize = Integer.valueOf(elementReader.getElementText().trim());
                 dataSource.initialPoolSize = initialPoolSize;
             } else if (("max-pool-size" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: maxPoolSize
-                Integer maxPoolSize = Integer.valueOf(elementReader.getElementText());
+                Integer maxPoolSize = Integer.valueOf(elementReader.getElementText().trim());
                 dataSource.maxPoolSize = maxPoolSize;
             } else if (("min-pool-size" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: minPoolSize
-                Integer minPoolSize = Integer.valueOf(elementReader.getElementText());
+                Integer minPoolSize = Integer.valueOf(elementReader.getElementText().trim());
                 dataSource.minPoolSize = minPoolSize;
             } else if (("max-idle-time" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: maxIdleTime
-                Integer maxIdleTime = Integer.valueOf(elementReader.getElementText());
+                Integer maxIdleTime = Integer.valueOf(elementReader.getElementText().trim());
                 dataSource.maxIdleTime = maxIdleTime;
             } else if (("max-statements" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: maxStatements
-                Integer maxStatements = Integer.valueOf(elementReader.getElementText());
+                Integer maxStatements = Integer.valueOf(elementReader.getElementText().trim());
                 dataSource.maxStatements = maxStatements;
             } else {
                 context.unexpectedElement(elementReader, new QName("http://java.sun.com/xml/ns/javaee", "description"), new QName("http://java.sun.com/xml/ns/javaee", "name"), new QName("http://java.sun.com/xml/ns/javaee", "class-name"), new QName("http://java.sun.com/xml/ns/javaee", "server-name"), new QName("http://java.sun.com/xml/ns/javaee", "port-number"), new QName("http://java.sun.com/xml/ns/javaee", "database-name"), new QName("http://java.sun.com/xml/ns/javaee", "url"), new QName("http://java.sun.com/xml/ns/javaee", "user"), new QName("http://java.sun.com/xml/ns/javaee", "password"), new QName("http://java.sun.com/xml/ns/javaee", "property"), new QName("http://java.sun.com/xml/ns/javaee", "login-timeout"), new QName("http://java.sun.com/xml/ns/javaee", "transactional"), new QName("http://java.sun.com/xml/ns/javaee", "isolation-level"), new QName("http://java.sun.com/xml/ns/javaee", "initial-pool-size"), new QName("http://java.sun.com/xml/ns/javaee", "max-pool-size"), new QName("http://java.sun.com/xml/ns/javaee", "min-pool-size"), new QName("http://java.sun.com/xml/ns/javaee", "max-idle-time"), new QName("http://java.sun.com/xml/ns/javaee", "max-statements"));

--- a/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/EjbJar$JAXB.java
+++ b/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/EjbJar$JAXB.java
@@ -113,7 +113,7 @@ public class EjbJar$JAXB
                 ejbJar.id = id;
             } else if (("metadata-complete" == attribute.getLocalName())&&(("" == attribute.getNamespace())||(attribute.getNamespace() == null))) {
                 // ATTRIBUTE: metadataComplete
-                Boolean metadataComplete = ("1".equals(attribute.getValue())||"true".equals(attribute.getValue()));
+                Boolean metadataComplete = ("1".equals(attribute.getValue().trim())||"true".equals(attribute.getValue().trim()));
                 ejbJar.metadataComplete = metadataComplete;
             } else if (("version" == attribute.getLocalName())&&(("" == attribute.getNamespace())||(attribute.getNamespace() == null))) {
                 // ATTRIBUTE: version

--- a/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/EjbLocalRef$JAXB.java
+++ b/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/EjbLocalRef$JAXB.java
@@ -131,7 +131,7 @@ public class EjbLocalRef$JAXB
                 ejbLocalRef.ejbRefName = ejbRefName;
             } else if (("ejb-ref-type" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: ejbRefType
-                EjbRefType ejbRefType = parseEjbRefType(elementReader, context, elementReader.getElementText());
+                EjbRefType ejbRefType = parseEjbRefType(elementReader, context, elementReader.getElementText().trim());
                 if (ejbRefType!= null) {
                     ejbLocalRef.ejbRefType = ejbRefType;
                 }

--- a/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/EjbRef$JAXB.java
+++ b/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/EjbRef$JAXB.java
@@ -131,7 +131,7 @@ public class EjbRef$JAXB
                 ejbRef.ejbRefName = ejbRefName;
             } else if (("ejb-ref-type" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: ejbRefType
-                EjbRefType ejbRefType = parseEjbRefType(elementReader, context, elementReader.getElementText());
+                EjbRefType ejbRefType = parseEjbRefType(elementReader, context, elementReader.getElementText().trim());
                 if (ejbRefType!= null) {
                     ejbRef.ejbRefType = ejbRefType;
                 }

--- a/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/EjbRelationshipRole$JAXB.java
+++ b/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/EjbRelationshipRole$JAXB.java
@@ -132,7 +132,7 @@ public class EjbRelationshipRole$JAXB
                 ejbRelationshipRole.ejbRelationshipRoleName = ejbRelationshipRoleName;
             } else if (("multiplicity" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: multiplicity
-                Multiplicity multiplicity = parseMultiplicity(elementReader, context, elementReader.getElementText());
+                Multiplicity multiplicity = parseMultiplicity(elementReader, context, elementReader.getElementText().trim());
                 if (multiplicity!= null) {
                     ejbRelationshipRole.multiplicity = multiplicity;
                 }

--- a/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/EntityBean$JAXB.java
+++ b/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/EntityBean$JAXB.java
@@ -292,7 +292,7 @@ public class EntityBean$JAXB
                 entityBean.ejbClass = ejbClass;
             } else if (("persistence-type" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: persistenceType
-                PersistenceType persistenceType = parsePersistenceType(elementReader, context, elementReader.getElementText());
+                PersistenceType persistenceType = parsePersistenceType(elementReader, context, elementReader.getElementText().trim());
                 if (persistenceType!= null) {
                     entityBean.persistenceType = persistenceType;
                 }
@@ -324,7 +324,7 @@ public class EntityBean$JAXB
                 entityBean.reentrant = reentrant;
             } else if (("cmp-version" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: cmpVersion
-                CmpVersion cmpVersion = parseCmpVersion(elementReader, context, elementReader.getElementText());
+                CmpVersion cmpVersion = parseCmpVersion(elementReader, context, elementReader.getElementText().trim());
                 if (cmpVersion!= null) {
                     entityBean.cmpVersion = cmpVersion;
                 }

--- a/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/ErrorPage$JAXB.java
+++ b/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/ErrorPage$JAXB.java
@@ -99,7 +99,7 @@ public class ErrorPage$JAXB
         for (XoXMLStreamReader elementReader: reader.getChildElements()) {
             if (("error-code" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: errorCode
-                BigInteger errorCode = new BigInteger(elementReader.getElementText());
+                BigInteger errorCode = new BigInteger(elementReader.getElementText().trim());
                 errorPage.errorCode = errorCode;
             } else if (("exception-type" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: exceptionType

--- a/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/FacesConfig$JAXB.java
+++ b/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/FacesConfig$JAXB.java
@@ -148,7 +148,7 @@ public class FacesConfig$JAXB
                 facesConfig.version = Adapters.collapsedStringAdapterAdapter.unmarshal(attribute.getValue());
             } else if (("metadata-complete" == attribute.getLocalName())&&(("" == attribute.getNamespace())||(attribute.getNamespace() == null))) {
                 // ATTRIBUTE: metadataComplete
-                Boolean metadataComplete = ("1".equals(attribute.getValue())||"true".equals(attribute.getValue()));
+                Boolean metadataComplete = ("1".equals(attribute.getValue().trim())||"true".equals(attribute.getValue().trim()));
                 facesConfig.metadataComplete = metadataComplete;
             } else if (XMLConstants.W3C_XML_SCHEMA_INSTANCE_NS_URI!= attribute.getNamespace()) {
                 context.unexpectedAttribute(attribute, new QName("", "id"), new QName("", "version"), new QName("", "metadata-complete"));

--- a/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/FacesRedirect$JAXB.java
+++ b/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/FacesRedirect$JAXB.java
@@ -98,7 +98,7 @@ public class FacesRedirect$JAXB
                 facesRedirect.id = id;
             } else if (("include-view-params" == attribute.getLocalName())&&(("" == attribute.getNamespace())||(attribute.getNamespace() == null))) {
                 // ATTRIBUTE: includeViewParams
-                Boolean includeViewParams = ("1".equals(attribute.getValue())||"true".equals(attribute.getValue()));
+                Boolean includeViewParams = ("1".equals(attribute.getValue().trim())||"true".equals(attribute.getValue().trim()));
                 facesRedirect.includeViewParams = includeViewParams;
             } else if (XMLConstants.W3C_XML_SCHEMA_INSTANCE_NS_URI!= attribute.getNamespace()) {
                 context.unexpectedAttribute(attribute, new QName("", "id"), new QName("", "include-view-params"));

--- a/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/Filter$JAXB.java
+++ b/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/Filter$JAXB.java
@@ -164,7 +164,7 @@ public class Filter$JAXB
                 filter.filterClass = filterClass;
             } else if (("async-supported" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: asyncSupported
-                Boolean asyncSupported = ("1".equals(elementReader.getElementText())||"true".equals(elementReader.getElementText()));
+                Boolean asyncSupported = ("1".equals(elementReader.getElementText().trim())||"true".equals(elementReader.getElementText().trim()));
                 filter.asyncSupported = asyncSupported;
             } else if (("init-param" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: initParam

--- a/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/FilterMapping$JAXB.java
+++ b/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/FilterMapping$JAXB.java
@@ -164,7 +164,7 @@ public class FilterMapping$JAXB
                 // ELEMENT: dispatcher
                 Dispatcher dispatcherItem = null;
                 if (!elementReader.isXsiNil()) {
-                    dispatcherItem = parseDispatcher(elementReader, context, elementReader.getElementText());
+                    dispatcherItem = parseDispatcher(elementReader, context, elementReader.getElementText().trim());
                 }
                 if (dispatcher == null) {
                     dispatcher = filterMapping.dispatcher;

--- a/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/InterceptorBinding$JAXB.java
+++ b/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/InterceptorBinding$JAXB.java
@@ -155,11 +155,11 @@ public class InterceptorBinding$JAXB
                 interceptorBinding.interceptorOrder = interceptorOrder;
             } else if (("exclude-default-interceptors" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: excludeDefaultInterceptors
-                Boolean excludeDefaultInterceptors = ("1".equals(elementReader.getElementText())||"true".equals(elementReader.getElementText()));
+                Boolean excludeDefaultInterceptors = ("1".equals(elementReader.getElementText().trim())||"true".equals(elementReader.getElementText().trim()));
                 interceptorBinding.excludeDefaultInterceptors = excludeDefaultInterceptors;
             } else if (("exclude-class-interceptors" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: excludeClassInterceptors
-                Boolean excludeClassInterceptors = ("1".equals(elementReader.getElementText())||"true".equals(elementReader.getElementText()));
+                Boolean excludeClassInterceptors = ("1".equals(elementReader.getElementText().trim())||"true".equals(elementReader.getElementText().trim()));
                 interceptorBinding.excludeClassInterceptors = excludeClassInterceptors;
             } else if (("method" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: method

--- a/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/JMSConnectionFactory$JAXB.java
+++ b/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/JMSConnectionFactory$JAXB.java
@@ -206,15 +206,15 @@ public class JMSConnectionFactory$JAXB
                 JMSConnectionFactory.clientId = clientId;
             } else if (("transactional" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: transactional
-                Boolean transactional = ("1".equals(elementReader.getElementText())||"true".equals(elementReader.getElementText()));
+                Boolean transactional = ("1".equals(elementReader.getElementText().trim())||"true".equals(elementReader.getElementText().trim()));
                 JMSConnectionFactory.transactional = transactional;
             } else if (("max-pool-size" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: maxPoolSize
-                Integer maxPoolSize = Integer.valueOf(elementReader.getElementText());
+                Integer maxPoolSize = Integer.valueOf(elementReader.getElementText().trim());
                 JMSConnectionFactory.maxPoolSize = maxPoolSize;
             } else if (("min-pool-size" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: minPoolSize
-                Integer minPoolSize = Integer.valueOf(elementReader.getElementText());
+                Integer minPoolSize = Integer.valueOf(elementReader.getElementText().trim());
                 JMSConnectionFactory.minPoolSize = minPoolSize;
             } else if (("property" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: property

--- a/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/JspPropertyGroup$JAXB.java
+++ b/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/JspPropertyGroup$JAXB.java
@@ -159,7 +159,7 @@ public class JspPropertyGroup$JAXB
                 urlPattern.add(urlPatternItem);
             } else if (("el-ignored" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: elIgnored
-                Boolean elIgnored = ("1".equals(elementReader.getElementText())||"true".equals(elementReader.getElementText()));
+                Boolean elIgnored = ("1".equals(elementReader.getElementText().trim())||"true".equals(elementReader.getElementText().trim()));
                 jspPropertyGroup.elIgnored = elIgnored;
             } else if (("page-encoding" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: pageEncoding
@@ -176,11 +176,11 @@ public class JspPropertyGroup$JAXB
                 jspPropertyGroup.pageEncoding = pageEncoding;
             } else if (("scripting-invalid" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: scriptingInvalid
-                Boolean scriptingInvalid = ("1".equals(elementReader.getElementText())||"true".equals(elementReader.getElementText()));
+                Boolean scriptingInvalid = ("1".equals(elementReader.getElementText().trim())||"true".equals(elementReader.getElementText().trim()));
                 jspPropertyGroup.scriptingInvalid = scriptingInvalid;
             } else if (("is-xml" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: isXml
-                Boolean isXml = ("1".equals(elementReader.getElementText())||"true".equals(elementReader.getElementText()));
+                Boolean isXml = ("1".equals(elementReader.getElementText().trim())||"true".equals(elementReader.getElementText().trim()));
                 jspPropertyGroup.isXml = isXml;
             } else if (("include-prelude" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: includePrelude
@@ -226,11 +226,11 @@ public class JspPropertyGroup$JAXB
                 includeCoda.add(includeCodaItem);
             } else if (("deferred-syntax-allowed-as-literal" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: deferredSyntaxAllowedAsLiteral
-                Boolean deferredSyntaxAllowedAsLiteral = ("1".equals(elementReader.getElementText())||"true".equals(elementReader.getElementText()));
+                Boolean deferredSyntaxAllowedAsLiteral = ("1".equals(elementReader.getElementText().trim())||"true".equals(elementReader.getElementText().trim()));
                 jspPropertyGroup.deferredSyntaxAllowedAsLiteral = deferredSyntaxAllowedAsLiteral;
             } else if (("trim-directive-whitespaces" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: trimDirectiveWhitespaces
-                Boolean trimDirectiveWhitespaces = ("1".equals(elementReader.getElementText())||"true".equals(elementReader.getElementText()));
+                Boolean trimDirectiveWhitespaces = ("1".equals(elementReader.getElementText().trim())||"true".equals(elementReader.getElementText().trim()));
                 jspPropertyGroup.trimDirectiveWhitespaces = trimDirectiveWhitespaces;
             } else if (("default-content-type" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: defaultContentType
@@ -260,7 +260,7 @@ public class JspPropertyGroup$JAXB
                 jspPropertyGroup.buffer = buffer;
             } else if (("error-on-undeclared-namespace" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: errorOnUndeclaredNamespace
-                Boolean errorOnUndeclaredNamespace = ("1".equals(elementReader.getElementText())||"true".equals(elementReader.getElementText()));
+                Boolean errorOnUndeclaredNamespace = ("1".equals(elementReader.getElementText().trim())||"true".equals(elementReader.getElementText().trim()));
                 jspPropertyGroup.errorOnUndeclaredNamespace = errorOnUndeclaredNamespace;
             } else {
                 context.unexpectedElement(elementReader, new QName("http://java.sun.com/xml/ns/javaee", "description"), new QName("http://java.sun.com/xml/ns/javaee", "display-name"), new QName("http://java.sun.com/xml/ns/javaee", "icon"), new QName("http://java.sun.com/xml/ns/javaee", "url-pattern"), new QName("http://java.sun.com/xml/ns/javaee", "el-ignored"), new QName("http://java.sun.com/xml/ns/javaee", "page-encoding"), new QName("http://java.sun.com/xml/ns/javaee", "scripting-invalid"), new QName("http://java.sun.com/xml/ns/javaee", "is-xml"), new QName("http://java.sun.com/xml/ns/javaee", "include-prelude"), new QName("http://java.sun.com/xml/ns/javaee", "include-coda"), new QName("http://java.sun.com/xml/ns/javaee", "deferred-syntax-allowed-as-literal"), new QName("http://java.sun.com/xml/ns/javaee", "trim-directive-whitespaces"), new QName("http://java.sun.com/xml/ns/javaee", "default-content-type"), new QName("http://java.sun.com/xml/ns/javaee", "buffer"), new QName("http://java.sun.com/xml/ns/javaee", "error-on-undeclared-namespace"));

--- a/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/License$JAXB.java
+++ b/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/License$JAXB.java
@@ -111,7 +111,7 @@ public class License$JAXB
                 descriptions.add(descriptionsItem);
             } else if (("license-required" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: licenseRequired
-                Boolean licenseRequired = ("1".equals(elementReader.getElementText())||"true".equals(elementReader.getElementText()));
+                Boolean licenseRequired = ("1".equals(elementReader.getElementText().trim())||"true".equals(elementReader.getElementText().trim()));
                 license.licenseRequired = licenseRequired;
             } else {
                 context.unexpectedElement(elementReader, new QName("http://java.sun.com/xml/ns/javaee", "description"), new QName("http://java.sun.com/xml/ns/javaee", "license-required"));

--- a/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/ManagedBean$JAXB.java
+++ b/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/ManagedBean$JAXB.java
@@ -203,7 +203,7 @@ public class ManagedBean$JAXB
         for (XoXMLStreamReader elementReader: reader.getChildElements()) {
             if (("hidden" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: hidden
-                Boolean hidden = ("1".equals(elementReader.getElementText())||"true".equals(elementReader.getElementText()));
+                Boolean hidden = ("1".equals(elementReader.getElementText().trim())||"true".equals(elementReader.getElementText().trim()));
                 managedBean.hidden = hidden;
             } else if (("description" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: descriptions
@@ -383,7 +383,7 @@ public class ManagedBean$JAXB
                 managedBean.ejbClass = ejbClass;
             } else if (("session-type" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: sessionType
-                SessionType sessionType = parseSessionType(elementReader, context, elementReader.getElementText());
+                SessionType sessionType = parseSessionType(elementReader, context, elementReader.getElementText().trim());
                 if (sessionType!= null) {
                     managedBean.sessionType = sessionType;
                 }
@@ -409,11 +409,11 @@ public class ManagedBean$JAXB
                 timer.add(timerItem);
             } else if (("init-on-startup" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: initOnStartup
-                Boolean initOnStartup = ("1".equals(elementReader.getElementText())||"true".equals(elementReader.getElementText()));
+                Boolean initOnStartup = ("1".equals(elementReader.getElementText().trim())||"true".equals(elementReader.getElementText().trim()));
                 managedBean.initOnStartup = initOnStartup;
             } else if (("concurrency-management-type" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: concurrencyManagementType
-                ConcurrencyManagementType concurrencyManagementType = parseConcurrencyManagementType(elementReader, context, elementReader.getElementText());
+                ConcurrencyManagementType concurrencyManagementType = parseConcurrencyManagementType(elementReader, context, elementReader.getElementText().trim());
                 if (concurrencyManagementType!= null) {
                     managedBean.concurrencyManagementType = concurrencyManagementType;
                 }
@@ -470,7 +470,7 @@ public class ManagedBean$JAXB
                 asyncMethod.add(asyncMethodItem);
             } else if (("transaction-type" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: transactionType
-                TransactionType transactionType = parseTransactionType(elementReader, context, elementReader.getElementText());
+                TransactionType transactionType = parseTransactionType(elementReader, context, elementReader.getElementText().trim());
                 if (transactionType!= null) {
                     managedBean.transactionType = transactionType;
                 }
@@ -732,7 +732,7 @@ public class ManagedBean$JAXB
                 managedBean.securityIdentity = securityIdentity;
             } else if (("passivation-capable" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: passivationCapable
-                Boolean passivationCapable = ("1".equals(elementReader.getElementText())||"true".equals(elementReader.getElementText()));
+                Boolean passivationCapable = ("1".equals(elementReader.getElementText().trim())||"true".equals(elementReader.getElementText().trim()));
                 managedBean.passivationCapable = passivationCapable;
             } else if (("context-service" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: contextService

--- a/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/ManagedExecutor$JAXB.java
+++ b/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/ManagedExecutor$JAXB.java
@@ -117,11 +117,11 @@ public class ManagedExecutor$JAXB
                 managedExecutor.contextService = contextService;
             } else if (("hung-task-threshold" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: hungTaskThreshold
-                Long hungTaskThreshold = Long.valueOf(elementReader.getElementText());
+                Long hungTaskThreshold = Long.valueOf(elementReader.getElementText().trim());
                 managedExecutor.hungTaskThreshold = hungTaskThreshold;
             } else if (("max-async" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: maxAsync
-                Integer maxAsync = Integer.valueOf(elementReader.getElementText());
+                Integer maxAsync = Integer.valueOf(elementReader.getElementText().trim());
                 managedExecutor.maxAsync = maxAsync;
             } else if (("properties" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: properties

--- a/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/ManagedScheduledExecutor$JAXB.java
+++ b/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/ManagedScheduledExecutor$JAXB.java
@@ -117,11 +117,11 @@ public class ManagedScheduledExecutor$JAXB
                 managedScheduledExecutor.contextService = contextService;
             } else if (("hung-task-threshold" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: hungTaskThreshold
-                Long hungTaskThreshold = Long.valueOf(elementReader.getElementText());
+                Long hungTaskThreshold = Long.valueOf(elementReader.getElementText().trim());
                 managedScheduledExecutor.hungTaskThreshold = hungTaskThreshold;
             } else if (("max-async" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: maxAsync
-                Integer maxAsync = Integer.valueOf(elementReader.getElementText());
+                Integer maxAsync = Integer.valueOf(elementReader.getElementText().trim());
                 managedScheduledExecutor.maxAsync = maxAsync;
             } else if (("property" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: properties

--- a/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/ManagedThreadFactory$JAXB.java
+++ b/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/ManagedThreadFactory$JAXB.java
@@ -117,7 +117,7 @@ public class ManagedThreadFactory$JAXB
                 managedThreadFactory.contextService = contextService;
             } else if (("priority" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: priority
-                Integer priority = Integer.valueOf(elementReader.getElementText());
+                Integer priority = Integer.valueOf(elementReader.getElementText().trim());
                 managedThreadFactory.priority = priority;
             } else if (("property" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: properties

--- a/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/MessageDestinationRef$JAXB.java
+++ b/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/MessageDestinationRef$JAXB.java
@@ -144,7 +144,7 @@ public class MessageDestinationRef$JAXB
                 messageDestinationRef.messageDestinationType = messageDestinationType;
             } else if (("message-destination-usage" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: messageDestinationUsage
-                MessageDestinationUsage messageDestinationUsage = parseMessageDestinationUsage(elementReader, context, elementReader.getElementText());
+                MessageDestinationUsage messageDestinationUsage = parseMessageDestinationUsage(elementReader, context, elementReader.getElementText().trim());
                 if (messageDestinationUsage!= null) {
                     messageDestinationRef.messageDestinationUsage = messageDestinationUsage;
                 }

--- a/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/MessageDrivenBean$JAXB.java
+++ b/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/MessageDrivenBean$JAXB.java
@@ -276,7 +276,7 @@ public class MessageDrivenBean$JAXB
                 timer.add(timerItem);
             } else if (("transaction-type" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: transactionType
-                TransactionType transactionType = parseTransactionType(elementReader, context, elementReader.getElementText());
+                TransactionType transactionType = parseTransactionType(elementReader, context, elementReader.getElementText().trim());
                 if (transactionType!= null) {
                     messageDrivenBean.transactionType = transactionType;
                 }

--- a/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/Method$JAXB.java
+++ b/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/Method$JAXB.java
@@ -128,7 +128,7 @@ public class Method$JAXB
                 method.ejbName = ejbName;
             } else if (("method-intf" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: methodIntf
-                MethodIntf methodIntf = parseMethodIntf(elementReader, context, elementReader.getElementText());
+                MethodIntf methodIntf = parseMethodIntf(elementReader, context, elementReader.getElementText().trim());
                 if (methodIntf!= null) {
                     method.methodIntf = methodIntf;
                 }

--- a/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/MethodParamPartsMapping$JAXB.java
+++ b/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/MethodParamPartsMapping$JAXB.java
@@ -103,7 +103,7 @@ public class MethodParamPartsMapping$JAXB
         for (XoXMLStreamReader elementReader: reader.getChildElements()) {
             if (("param-position" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: paramPosition
-                BigInteger paramPosition = new BigInteger(elementReader.getElementText());
+                BigInteger paramPosition = new BigInteger(elementReader.getElementText().trim());
                 methodParamPartsMapping.paramPosition = paramPosition;
             } else if (("param-type" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: paramType

--- a/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/MultipartConfig$JAXB.java
+++ b/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/MultipartConfig$JAXB.java
@@ -106,15 +106,15 @@ public class MultipartConfig$JAXB
                 multipartConfig.location = location;
             } else if (("max-file-size" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: maxFileSize
-                Long maxFileSize = Long.valueOf(elementReader.getElementText());
+                Long maxFileSize = Long.valueOf(elementReader.getElementText().trim());
                 multipartConfig.maxFileSize = maxFileSize;
             } else if (("max-request-size" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: maxRequestSize
-                Long maxRequestSize = Long.valueOf(elementReader.getElementText());
+                Long maxRequestSize = Long.valueOf(elementReader.getElementText().trim());
                 multipartConfig.maxRequestSize = maxRequestSize;
             } else if (("file-size-threshold" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: fileSizeThreshold
-                Integer fileSizeThreshold = Integer.valueOf(elementReader.getElementText());
+                Integer fileSizeThreshold = Integer.valueOf(elementReader.getElementText().trim());
                 multipartConfig.fileSizeThreshold = fileSizeThreshold;
             } else {
                 context.unexpectedElement(elementReader, new QName("http://java.sun.com/xml/ns/javaee", "location"), new QName("http://java.sun.com/xml/ns/javaee", "max-file-size"), new QName("http://java.sun.com/xml/ns/javaee", "max-request-size"), new QName("http://java.sun.com/xml/ns/javaee", "file-size-threshold"));

--- a/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/OutboundResourceAdapter$JAXB.java
+++ b/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/OutboundResourceAdapter$JAXB.java
@@ -122,7 +122,7 @@ public class OutboundResourceAdapter$JAXB
                 connectionDefinition.add(connectionDefinitionItem);
             } else if (("transaction-support" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: transactionSupport
-                TransactionSupportType transactionSupport = parseTransactionSupportType(elementReader, context, elementReader.getElementText());
+                TransactionSupportType transactionSupport = parseTransactionSupportType(elementReader, context, elementReader.getElementText().trim());
                 if (transactionSupport!= null) {
                     outboundResourceAdapter.transactionSupport = transactionSupport;
                 }
@@ -140,7 +140,7 @@ public class OutboundResourceAdapter$JAXB
                 authenticationMechanism.add(authenticationMechanismItem);
             } else if (("reauthentication-support" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: reauthenticationSupport
-                Boolean reauthenticationSupport = ("1".equals(elementReader.getElementText())||"true".equals(elementReader.getElementText()));
+                Boolean reauthenticationSupport = ("1".equals(elementReader.getElementText().trim())||"true".equals(elementReader.getElementText().trim()));
                 outboundResourceAdapter.reauthenticationSupport = reauthenticationSupport;
             } else {
                 context.unexpectedElement(elementReader, new QName("http://java.sun.com/xml/ns/javaee", "connection-definition"), new QName("http://java.sun.com/xml/ns/javaee", "transaction-support"), new QName("http://java.sun.com/xml/ns/javaee", "authentication-mechanism"), new QName("http://java.sun.com/xml/ns/javaee", "reauthentication-support"));

--- a/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/PersistenceContextRef$JAXB.java
+++ b/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/PersistenceContextRef$JAXB.java
@@ -150,13 +150,13 @@ public class PersistenceContextRef$JAXB
                 persistenceContextRef.persistenceUnitName = persistenceUnitName;
             } else if (("persistence-context-type" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: persistenceContextType
-                PersistenceContextType persistenceContextType = parsePersistenceContextType(elementReader, context, elementReader.getElementText());
+                PersistenceContextType persistenceContextType = parsePersistenceContextType(elementReader, context, elementReader.getElementText().trim());
                 if (persistenceContextType!= null) {
                     persistenceContextRef.persistenceContextType = persistenceContextType;
                 }
             } else if (("persistence-context-synchronization" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: persistenceContextSynchronization
-                PersistenceContextSynchronization persistenceContextSynchronization = parsePersistenceContextSynchronization(elementReader, context, elementReader.getElementText());
+                PersistenceContextSynchronization persistenceContextSynchronization = parsePersistenceContextSynchronization(elementReader, context, elementReader.getElementText().trim());
                 if (persistenceContextSynchronization!= null) {
                     persistenceContextRef.persistenceContextSynchronization = persistenceContextSynchronization;
                 }

--- a/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/PortComponent$JAXB.java
+++ b/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/PortComponent$JAXB.java
@@ -166,11 +166,11 @@ public class PortComponent$JAXB
                 portComponent.wsdlPort = wsdlPort;
             } else if (("enable-mtom" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: enableMtom
-                Boolean enableMtom = ("1".equals(elementReader.getElementText())||"true".equals(elementReader.getElementText()));
+                Boolean enableMtom = ("1".equals(elementReader.getElementText().trim())||"true".equals(elementReader.getElementText().trim()));
                 portComponent.enableMtom = enableMtom;
             } else if (("mtom-threshold" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: mtomThreshold
-                Integer mtomThreshold = Integer.valueOf(elementReader.getElementText());
+                Integer mtomThreshold = Integer.valueOf(elementReader.getElementText().trim());
                 portComponent.mtomThreshold = mtomThreshold;
             } else if (("addressing" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: addressing

--- a/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/PortComponentRef$JAXB.java
+++ b/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/PortComponentRef$JAXB.java
@@ -117,11 +117,11 @@ public class PortComponentRef$JAXB
                 portComponentRef.serviceEndpointInterface = serviceEndpointInterface;
             } else if (("enable-mtom" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: enableMtom
-                Boolean enableMtom = ("1".equals(elementReader.getElementText())||"true".equals(elementReader.getElementText()));
+                Boolean enableMtom = ("1".equals(elementReader.getElementText().trim())||"true".equals(elementReader.getElementText().trim()));
                 portComponentRef.enableMtom = enableMtom;
             } else if (("mtom-threshold" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: mtomThreshold
-                Integer mtomThreshold = Integer.valueOf(elementReader.getElementText());
+                Integer mtomThreshold = Integer.valueOf(elementReader.getElementText().trim());
                 portComponentRef.mtomThreshold = mtomThreshold;
             } else if (("addressing" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: addressing

--- a/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/Query$JAXB.java
+++ b/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/Query$JAXB.java
@@ -114,7 +114,7 @@ public class Query$JAXB
                 query.queryMethod = queryMethod;
             } else if (("result-type-mapping" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: resultTypeMapping
-                ResultTypeMapping resultTypeMapping = parseResultTypeMapping(elementReader, context, elementReader.getElementText());
+                ResultTypeMapping resultTypeMapping = parseResultTypeMapping(elementReader, context, elementReader.getElementText().trim());
                 if (resultTypeMapping!= null) {
                     query.resultTypeMapping = resultTypeMapping;
                 }

--- a/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/RemoveMethod$JAXB.java
+++ b/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/RemoveMethod$JAXB.java
@@ -106,7 +106,7 @@ public class RemoveMethod$JAXB
                 removeMethod.beanMethod = beanMethod;
             } else if (("retain-if-exception" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: retainIfException
-                Boolean retainIfException = ("1".equals(elementReader.getElementText())||"true".equals(elementReader.getElementText()));
+                Boolean retainIfException = ("1".equals(elementReader.getElementText().trim())||"true".equals(elementReader.getElementText().trim()));
                 removeMethod.retainIfException = retainIfException;
             } else {
                 context.unexpectedElement(elementReader, new QName("http://java.sun.com/xml/ns/javaee", "bean-method"), new QName("http://java.sun.com/xml/ns/javaee", "retain-if-exception"));

--- a/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/ResourceRef$JAXB.java
+++ b/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/ResourceRef$JAXB.java
@@ -146,13 +146,13 @@ public class ResourceRef$JAXB
                 resourceRef.resType = resType;
             } else if (("res-auth" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: resAuth
-                ResAuth resAuth = parseResAuth(elementReader, context, elementReader.getElementText());
+                ResAuth resAuth = parseResAuth(elementReader, context, elementReader.getElementText().trim());
                 if (resAuth!= null) {
                     resourceRef.resAuth = resAuth;
                 }
             } else if (("res-sharing-scope" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: resSharingScope
-                ResSharingScope resSharingScope = parseResSharingScope(elementReader, context, elementReader.getElementText());
+                ResSharingScope resSharingScope = parseResSharingScope(elementReader, context, elementReader.getElementText().trim());
                 if (resSharingScope!= null) {
                     resourceRef.resSharingScope = resSharingScope;
                 }

--- a/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/RespectBinding$JAXB.java
+++ b/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/RespectBinding$JAXB.java
@@ -92,7 +92,7 @@ public class RespectBinding$JAXB
         for (XoXMLStreamReader elementReader: reader.getChildElements()) {
             if (("enabled" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: enabled
-                Boolean enabled = ("1".equals(elementReader.getElementText())||"true".equals(elementReader.getElementText()));
+                Boolean enabled = ("1".equals(elementReader.getElementText().trim())||"true".equals(elementReader.getElementText().trim()));
                 respectBinding.enabled = enabled;
             } else {
                 context.unexpectedElement(elementReader, new QName("http://java.sun.com/xml/ns/javaee", "enabled"));

--- a/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/Servlet$JAXB.java
+++ b/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/Servlet$JAXB.java
@@ -209,11 +209,11 @@ public class Servlet$JAXB
                 servlet.loadOnStartup = loadOnStartup;
             } else if (("enabled" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: enabled
-                Boolean enabled = ("1".equals(elementReader.getElementText())||"true".equals(elementReader.getElementText()));
+                Boolean enabled = ("1".equals(elementReader.getElementText().trim())||"true".equals(elementReader.getElementText().trim()));
                 servlet.enabled = enabled;
             } else if (("async-supported" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: asyncSupported
-                Boolean asyncSupported = ("1".equals(elementReader.getElementText())||"true".equals(elementReader.getElementText()));
+                Boolean asyncSupported = ("1".equals(elementReader.getElementText().trim())||"true".equals(elementReader.getElementText().trim()));
                 servlet.asyncSupported = asyncSupported;
             } else if (("run-as" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: runAs

--- a/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/SessionBean$JAXB.java
+++ b/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/SessionBean$JAXB.java
@@ -395,7 +395,7 @@ public class SessionBean$JAXB
                 sessionBean.ejbClass = ejbClass;
             } else if (("session-type" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: sessionType
-                SessionType sessionType = parseSessionType(elementReader, context, elementReader.getElementText());
+                SessionType sessionType = parseSessionType(elementReader, context, elementReader.getElementText().trim());
                 if (sessionType!= null) {
                     sessionBean.sessionType = sessionType;
                 }
@@ -421,11 +421,11 @@ public class SessionBean$JAXB
                 timer.add(timerItem);
             } else if (("init-on-startup" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: initOnStartup
-                Boolean initOnStartup = ("1".equals(elementReader.getElementText())||"true".equals(elementReader.getElementText()));
+                Boolean initOnStartup = ("1".equals(elementReader.getElementText().trim())||"true".equals(elementReader.getElementText().trim()));
                 sessionBean.initOnStartup = initOnStartup;
             } else if (("concurrency-management-type" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: concurrencyManagementType
-                ConcurrencyManagementType concurrencyManagementType = parseConcurrencyManagementType(elementReader, context, elementReader.getElementText());
+                ConcurrencyManagementType concurrencyManagementType = parseConcurrencyManagementType(elementReader, context, elementReader.getElementText().trim());
                 if (concurrencyManagementType!= null) {
                     sessionBean.concurrencyManagementType = concurrencyManagementType;
                 }
@@ -482,7 +482,7 @@ public class SessionBean$JAXB
                 asyncMethod.add(asyncMethodItem);
             } else if (("transaction-type" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: transactionType
-                TransactionType transactionType = parseTransactionType(elementReader, context, elementReader.getElementText());
+                TransactionType transactionType = parseTransactionType(elementReader, context, elementReader.getElementText().trim());
                 if (transactionType!= null) {
                     sessionBean.transactionType = transactionType;
                 }
@@ -744,7 +744,7 @@ public class SessionBean$JAXB
                 sessionBean.securityIdentity = securityIdentity;
             } else if (("passivation-capable" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: passivationCapable
-                Boolean passivationCapable = ("1".equals(elementReader.getElementText())||"true".equals(elementReader.getElementText()));
+                Boolean passivationCapable = ("1".equals(elementReader.getElementText().trim())||"true".equals(elementReader.getElementText().trim()));
                 sessionBean.passivationCapable = passivationCapable;
             } else if (("context-service" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: contextService

--- a/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/SessionConfig$JAXB.java
+++ b/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/SessionConfig$JAXB.java
@@ -107,7 +107,7 @@ public class SessionConfig$JAXB
         for (XoXMLStreamReader elementReader: reader.getChildElements()) {
             if (("session-timeout" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: sessionTimeout
-                Integer sessionTimeout = Integer.valueOf(elementReader.getElementText());
+                Integer sessionTimeout = Integer.valueOf(elementReader.getElementText().trim());
                 sessionConfig.sessionTimeout = sessionTimeout;
             } else if (("cookie-config" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: cookieConfig
@@ -115,7 +115,7 @@ public class SessionConfig$JAXB
                 sessionConfig.cookieConfig = cookieConfig;
             } else if (("tracking-mode" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: trackingMode
-                TrackingMode trackingModeItem = parseTrackingMode(elementReader, context, elementReader.getElementText());
+                TrackingMode trackingModeItem = parseTrackingMode(elementReader, context, elementReader.getElementText().trim());
                 if (trackingMode == null) {
                     trackingMode = sessionConfig.trackingMode;
                     if (trackingMode!= null) {

--- a/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/SingletonBean$JAXB.java
+++ b/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/SingletonBean$JAXB.java
@@ -379,7 +379,7 @@ public class SingletonBean$JAXB
                 singletonBean.ejbClass = ejbClass;
             } else if (("session-type" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: sessionType
-                SessionType sessionType = parseSessionType(elementReader, context, elementReader.getElementText());
+                SessionType sessionType = parseSessionType(elementReader, context, elementReader.getElementText().trim());
                 if (sessionType!= null) {
                     singletonBean.sessionType = sessionType;
                 }
@@ -405,11 +405,11 @@ public class SingletonBean$JAXB
                 timer.add(timerItem);
             } else if (("init-on-startup" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: initOnStartup
-                Boolean initOnStartup = ("1".equals(elementReader.getElementText())||"true".equals(elementReader.getElementText()));
+                Boolean initOnStartup = ("1".equals(elementReader.getElementText().trim())||"true".equals(elementReader.getElementText().trim()));
                 singletonBean.initOnStartup = initOnStartup;
             } else if (("concurrency-management-type" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: concurrencyManagementType
-                ConcurrencyManagementType concurrencyManagementType = parseConcurrencyManagementType(elementReader, context, elementReader.getElementText());
+                ConcurrencyManagementType concurrencyManagementType = parseConcurrencyManagementType(elementReader, context, elementReader.getElementText().trim());
                 if (concurrencyManagementType!= null) {
                     singletonBean.concurrencyManagementType = concurrencyManagementType;
                 }
@@ -466,7 +466,7 @@ public class SingletonBean$JAXB
                 asyncMethod.add(asyncMethodItem);
             } else if (("transaction-type" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: transactionType
-                TransactionType transactionType = parseTransactionType(elementReader, context, elementReader.getElementText());
+                TransactionType transactionType = parseTransactionType(elementReader, context, elementReader.getElementText().trim());
                 if (transactionType!= null) {
                     singletonBean.transactionType = transactionType;
                 }
@@ -728,7 +728,7 @@ public class SingletonBean$JAXB
                 singletonBean.securityIdentity = securityIdentity;
             } else if (("passivation-capable" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: passivationCapable
-                Boolean passivationCapable = ("1".equals(elementReader.getElementText())||"true".equals(elementReader.getElementText()));
+                Boolean passivationCapable = ("1".equals(elementReader.getElementText().trim())||"true".equals(elementReader.getElementText().trim()));
                 singletonBean.passivationCapable = passivationCapable;
             } else if (("context-service" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: contextService

--- a/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/StatefulBean$JAXB.java
+++ b/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/StatefulBean$JAXB.java
@@ -379,7 +379,7 @@ public class StatefulBean$JAXB
                 statefulBean.ejbClass = ejbClass;
             } else if (("session-type" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: sessionType
-                SessionType sessionType = parseSessionType(elementReader, context, elementReader.getElementText());
+                SessionType sessionType = parseSessionType(elementReader, context, elementReader.getElementText().trim());
                 if (sessionType!= null) {
                     statefulBean.sessionType = sessionType;
                 }
@@ -405,11 +405,11 @@ public class StatefulBean$JAXB
                 timer.add(timerItem);
             } else if (("init-on-startup" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: initOnStartup
-                Boolean initOnStartup = ("1".equals(elementReader.getElementText())||"true".equals(elementReader.getElementText()));
+                Boolean initOnStartup = ("1".equals(elementReader.getElementText().trim())||"true".equals(elementReader.getElementText().trim()));
                 statefulBean.initOnStartup = initOnStartup;
             } else if (("concurrency-management-type" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: concurrencyManagementType
-                ConcurrencyManagementType concurrencyManagementType = parseConcurrencyManagementType(elementReader, context, elementReader.getElementText());
+                ConcurrencyManagementType concurrencyManagementType = parseConcurrencyManagementType(elementReader, context, elementReader.getElementText().trim());
                 if (concurrencyManagementType!= null) {
                     statefulBean.concurrencyManagementType = concurrencyManagementType;
                 }
@@ -466,7 +466,7 @@ public class StatefulBean$JAXB
                 asyncMethod.add(asyncMethodItem);
             } else if (("transaction-type" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: transactionType
-                TransactionType transactionType = parseTransactionType(elementReader, context, elementReader.getElementText());
+                TransactionType transactionType = parseTransactionType(elementReader, context, elementReader.getElementText().trim());
                 if (transactionType!= null) {
                     statefulBean.transactionType = transactionType;
                 }
@@ -728,7 +728,7 @@ public class StatefulBean$JAXB
                 statefulBean.securityIdentity = securityIdentity;
             } else if (("passivation-capable" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: passivationCapable
-                Boolean passivationCapable = ("1".equals(elementReader.getElementText())||"true".equals(elementReader.getElementText()));
+                Boolean passivationCapable = ("1".equals(elementReader.getElementText().trim())||"true".equals(elementReader.getElementText().trim()));
                 statefulBean.passivationCapable = passivationCapable;
             } else if (("context-service" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: contextService

--- a/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/StatelessBean$JAXB.java
+++ b/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/StatelessBean$JAXB.java
@@ -379,7 +379,7 @@ public class StatelessBean$JAXB
                 statelessBean.ejbClass = ejbClass;
             } else if (("session-type" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: sessionType
-                SessionType sessionType = parseSessionType(elementReader, context, elementReader.getElementText());
+                SessionType sessionType = parseSessionType(elementReader, context, elementReader.getElementText().trim());
                 if (sessionType!= null) {
                     statelessBean.sessionType = sessionType;
                 }
@@ -405,11 +405,11 @@ public class StatelessBean$JAXB
                 timer.add(timerItem);
             } else if (("init-on-startup" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: initOnStartup
-                Boolean initOnStartup = ("1".equals(elementReader.getElementText())||"true".equals(elementReader.getElementText()));
+                Boolean initOnStartup = ("1".equals(elementReader.getElementText().trim())||"true".equals(elementReader.getElementText().trim()));
                 statelessBean.initOnStartup = initOnStartup;
             } else if (("concurrency-management-type" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: concurrencyManagementType
-                ConcurrencyManagementType concurrencyManagementType = parseConcurrencyManagementType(elementReader, context, elementReader.getElementText());
+                ConcurrencyManagementType concurrencyManagementType = parseConcurrencyManagementType(elementReader, context, elementReader.getElementText().trim());
                 if (concurrencyManagementType!= null) {
                     statelessBean.concurrencyManagementType = concurrencyManagementType;
                 }
@@ -466,7 +466,7 @@ public class StatelessBean$JAXB
                 asyncMethod.add(asyncMethodItem);
             } else if (("transaction-type" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: transactionType
-                TransactionType transactionType = parseTransactionType(elementReader, context, elementReader.getElementText());
+                TransactionType transactionType = parseTransactionType(elementReader, context, elementReader.getElementText().trim());
                 if (transactionType!= null) {
                     statelessBean.transactionType = transactionType;
                 }
@@ -728,7 +728,7 @@ public class StatelessBean$JAXB
                 statelessBean.securityIdentity = securityIdentity;
             } else if (("passivation-capable" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: passivationCapable
-                Boolean passivationCapable = ("1".equals(elementReader.getElementText())||"true".equals(elementReader.getElementText()));
+                Boolean passivationCapable = ("1".equals(elementReader.getElementText().trim())||"true".equals(elementReader.getElementText().trim()));
                 statelessBean.passivationCapable = passivationCapable;
             } else if (("context-service" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: contextService

--- a/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/Tag$JAXB.java
+++ b/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/Tag$JAXB.java
@@ -185,7 +185,7 @@ public class Tag$JAXB
                 tag.teiClass = teiClass;
             } else if (("body-content" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: bodyContent
-                BodyContent bodyContent = parseBodyContent(elementReader, context, elementReader.getElementText());
+                BodyContent bodyContent = parseBodyContent(elementReader, context, elementReader.getElementText().trim());
                 if (bodyContent!= null) {
                     tag.bodyContent = bodyContent;
                 }

--- a/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/Timeout$JAXB.java
+++ b/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/Timeout$JAXB.java
@@ -99,7 +99,7 @@ public class Timeout$JAXB
         for (XoXMLStreamReader elementReader: reader.getChildElements()) {
             if (("timeout" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: timeout
-                Long timeout1 = Long.valueOf(elementReader.getElementText());
+                Long timeout1 = Long.valueOf(elementReader.getElementText().trim());
                 timeout.timeout = timeout1;
             } else if (("unit" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: unit

--- a/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/Timer$JAXB.java
+++ b/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/Timer$JAXB.java
@@ -131,11 +131,11 @@ public class Timer$JAXB
                 timer.schedule = schedule;
             } else if (("start" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: start
-                XMLGregorianCalendar start = datatypeFactory.newXMLGregorianCalendar(elementReader.getElementText());
+                XMLGregorianCalendar start = datatypeFactory.newXMLGregorianCalendar(elementReader.getElementText().trim());
                 timer.start = start;
             } else if (("end" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: end
-                XMLGregorianCalendar end = datatypeFactory.newXMLGregorianCalendar(elementReader.getElementText());
+                XMLGregorianCalendar end = datatypeFactory.newXMLGregorianCalendar(elementReader.getElementText().trim());
                 timer.end = end;
             } else if (("timeout-method" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: timeoutMethod
@@ -143,7 +143,7 @@ public class Timer$JAXB
                 timer.timeoutMethod = timeoutMethod;
             } else if (("persistent" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: persistent
-                Boolean persistent = ("1".equals(elementReader.getElementText())||"true".equals(elementReader.getElementText()));
+                Boolean persistent = ("1".equals(elementReader.getElementText().trim())||"true".equals(elementReader.getElementText().trim()));
                 timer.persistent = persistent;
             } else if (("timezone" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: timezone

--- a/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/UserDataConstraint$JAXB.java
+++ b/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/UserDataConstraint$JAXB.java
@@ -113,7 +113,7 @@ public class UserDataConstraint$JAXB
                 descriptions.add(descriptionsItem);
             } else if (("transport-guarantee" == elementReader.getLocalName())&&("http://java.sun.com/xml/ns/javaee" == elementReader.getNamespaceURI())) {
                 // ELEMENT: transportGuarantee
-                TransportGuarantee transportGuarantee = parseTransportGuarantee(elementReader, context, elementReader.getElementText());
+                TransportGuarantee transportGuarantee = parseTransportGuarantee(elementReader, context, elementReader.getElementText().trim());
                 if (transportGuarantee!= null) {
                     userDataConstraint.transportGuarantee = transportGuarantee;
                 }

--- a/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/WebApp$JAXB.java
+++ b/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/WebApp$JAXB.java
@@ -209,7 +209,7 @@ public class WebApp$JAXB
                 webApp.id = id;
             } else if (("metadata-complete" == attribute.getLocalName())&&(("" == attribute.getNamespace())||(attribute.getNamespace() == null))) {
                 // ATTRIBUTE: metadataComplete
-                Boolean metadataComplete = ("1".equals(attribute.getValue())||"true".equals(attribute.getValue()));
+                Boolean metadataComplete = ("1".equals(attribute.getValue().trim())||"true".equals(attribute.getValue().trim()));
                 webApp.metadataComplete = metadataComplete;
             } else if (("version" == attribute.getLocalName())&&(("" == attribute.getNamespace())||(attribute.getNamespace() == null))) {
                 // ATTRIBUTE: version

--- a/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/WebFragment$JAXB.java
+++ b/container/openejb-jee-accessors/src/main/java/org/apache/openejb/jee/WebFragment$JAXB.java
@@ -206,7 +206,7 @@ public class WebFragment$JAXB
                 webFragment.id = id;
             } else if (("metadata-complete" == attribute.getLocalName())&&(("" == attribute.getNamespace())||(attribute.getNamespace() == null))) {
                 // ATTRIBUTE: metadataComplete
-                Boolean metadataComplete = ("1".equals(attribute.getValue())||"true".equals(attribute.getValue()));
+                Boolean metadataComplete = ("1".equals(attribute.getValue().trim())||"true".equals(attribute.getValue().trim()));
                 webFragment.metadataComplete = metadataComplete;
             } else if (("version" == attribute.getLocalName())&&(("" == attribute.getNamespace())||(attribute.getNamespace() == null))) {
                 // ATTRIBUTE: version

--- a/container/openejb-jee-accessors/src/test/java/org/apache/openejb/sxc/WebAppSessionTimeoutTest.java
+++ b/container/openejb-jee-accessors/src/test/java/org/apache/openejb/sxc/WebAppSessionTimeoutTest.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.openejb.sxc;
+
+import org.apache.openejb.jee.WebApp;
+import org.junit.Test;
+
+import java.net.URL;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class WebAppSessionTimeoutTest {
+
+    /**
+     * TOMEE-4589: session-timeout is an xsd:integer whose lexical value is whitespace
+     * collapsed, so a value surrounded by newlines/indentation is valid and must parse.
+     */
+    @Test
+    public void sessionTimeoutWithWhitespace() throws Exception {
+        final URL url = getClass().getClassLoader().getResource("web-session-timeout-whitespace.xml");
+        final WebApp webApp = WebXml.unmarshal(url);
+        assertNotNull(webApp);
+        assertEquals(1, webApp.getSessionConfig().size());
+        assertEquals(Integer.valueOf(30), webApp.getSessionConfig().get(0).getSessionTimeout());
+    }
+}

--- a/container/openejb-jee-accessors/src/test/resources/web-session-timeout-whitespace.xml
+++ b/container/openejb-jee-accessors/src/test/resources/web-session-timeout-whitespace.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
+  <session-config>
+    <session-timeout>
+      30
+    </session-timeout>
+  </session-config>
+</web-app>

--- a/pom.xml
+++ b/pom.xml
@@ -226,7 +226,7 @@
     <version.xmlsec>4.0.3</version.xmlsec>
     <version.krazo>2.0.2</version.krazo>
     <version.jose4j>0.9.6</version.jose4j>
-    <version.sxc>0.9</version.sxc>
+    <version.sxc>0.10</version.sxc>
 
     <!-- JDBC Drivers -->
     <version.derby>10.15.2.0</version.derby>


### PR DESCRIPTION
session-timeout (and the other xsd:integer / numeric / temporal / enum descriptor values) use a whitespace="collapse" facet, so a value such as

```
  <session-timeout>
      30
  </session-timeout>
```

is valid and must parse. The SXC-generated accessors fed the raw element text straight into Integer.valueOf()/etc. for wrapper, temporal, decimal and enum types, which failed with NumberFormatException.

Bump SXC to 0.10 (which collapses whitespace in the generator) and regenerate the affected accessors, applying only the resulting .trim() additions so the change stays limited to the fix. Adds a regression test.