### PR TITLE
TOMEE-4654 - Allow the component naming context to be made read-only

### DIFF
--- a/arquillian/arquillian-tomee-embedded/src/test/java/org/apache/openejb/arquillian/embedded/EmbeddedTomEEContainerTest.java
+++ b/arquillian/arquillian-tomee-embedded/src/test/java/org/apache/openejb/arquillian/embedded/EmbeddedTomEEContainerTest.java
@@ -35,6 +35,7 @@ import jakarta.ejb.EJB;
 import java.net.URL;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 
 @RunWith(Arquillian.class)
@@ -71,19 +72,26 @@ public class EmbeddedTomEEContainerTest {
         assertEquals("foo", read);
     }
     
+    /**
+     * EE.5.3.4 and Enterprise Beans 10.4.4 require the component naming context to be read only, so
+     * createSubcontext must not succeed from within a bean. Depending on
+     * openejb.jndiExceptionOnFailedWrite the container either throws
+     * OperationNotSupportedException or ignores the write and returns null; both are refusals, what
+     * must not happen is the subcontext being created.
+     */
     @Test
-    public void testEjbCanCreateSubContextByDefault() throws Exception {
+    public void testEjbCannotCreateSubContextByDefault() throws Exception {
     	String originalValue = System.getProperty(javax.naming.Context.INITIAL_CONTEXT_FACTORY);
     	if(originalValue == null) {
     		System.setProperty(javax.naming.Context.INITIAL_CONTEXT_FACTORY, InitContextFactory.class.getName());
     	}
         try {
 	        String result = ejb.createSubContext();
-	        assertEquals("Cannot create sub context", "created", result);
+	        assertNotEquals("Sub context creation must be refused on a read-only naming context", "created", result);
         } finally {
         	if(originalValue == null) {
         		System.clearProperty(javax.naming.Context.INITIAL_CONTEXT_FACTORY);
-        	} 
+        	}
         }
     }
 }

--- a/arquillian/arquillian-tomee-embedded/src/test/java/org/apache/openejb/arquillian/embedded/EmbeddedTomEEContainerTest.java
+++ b/arquillian/arquillian-tomee-embedded/src/test/java/org/apache/openejb/arquillian/embedded/EmbeddedTomEEContainerTest.java
@@ -35,7 +35,6 @@ import jakarta.ejb.EJB;
 import java.net.URL;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 
 @RunWith(Arquillian.class)
@@ -73,21 +72,19 @@ public class EmbeddedTomEEContainerTest {
     }
     
     /**
-     * EE.5.3.4 and Enterprise Beans 10.4.4 require the component naming context to be read only, so
-     * createSubcontext must not succeed from within a bean. Depending on
-     * openejb.jndiExceptionOnFailedWrite the container either throws
-     * OperationNotSupportedException or ignores the write and returns null; both are refusals, what
-     * must not happen is the subcontext being created.
+     * EE.5.3.4 and Enterprise Beans 10.4.4 require the component naming context to be read only, but
+     * TomEE only enforces that when openejb.forceReadOnlyAppNamingContext is turned on, so that
+     * applications writing into their own naming context keep working. Without it the write succeeds.
      */
     @Test
-    public void testEjbCannotCreateSubContextByDefault() throws Exception {
+    public void testEjbCanCreateSubContextByDefault() throws Exception {
     	String originalValue = System.getProperty(javax.naming.Context.INITIAL_CONTEXT_FACTORY);
     	if(originalValue == null) {
     		System.setProperty(javax.naming.Context.INITIAL_CONTEXT_FACTORY, InitContextFactory.class.getName());
     	}
         try {
 	        String result = ejb.createSubContext();
-	        assertNotEquals("Sub context creation must be refused on a read-only naming context", "created", result);
+	        assertEquals("created", result);
         } finally {
         	if(originalValue == null) {
         		System.clearProperty(javax.naming.Context.INITIAL_CONTEXT_FACTORY);

--- a/container/openejb-core/src/main/java/org/apache/openejb/AppContext.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/AppContext.java
@@ -30,6 +30,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * @version $Rev$ $Date$
@@ -42,6 +43,8 @@ public class AppContext extends DeploymentContext {
     private final Context appJndiContext;
     private final boolean standaloneModule;
     private boolean cdiEnabled;
+    private boolean readOnlyAppNamingContext;
+    private final AtomicInteger pendingLateModules = new AtomicInteger();
     private WebBeansContext webBeansContext;
     private final Collection<Injection> injections = new HashSet<>();
     private final Map<String, Object> bindings = new HashMap<>();
@@ -57,6 +60,41 @@ public class AppContext extends DeploymentContext {
         this.globalJndiContext = globalJndiContext;
         this.appJndiContext = appJndiContext;
         this.standaloneModule = standaloneModule;
+    }
+
+    /**
+     * Whether the component naming contexts of this application must be marked read only once its
+     * deployments have been created, as required by EE.5.3.4 and Enterprise Beans 10.4.4. The flag is
+     * recorded when the application is configured but only applied after the container's own bindings
+     * are done, so that modules deployed later - the web modules of an ear, for instance - are covered
+     * too.
+     */
+    public boolean isReadOnlyAppNamingContext() {
+        return readOnlyAppNamingContext;
+    }
+
+    public void setReadOnlyAppNamingContext(final boolean readOnlyAppNamingContext) {
+        this.readOnlyAppNamingContext = readOnlyAppNamingContext;
+    }
+
+    /**
+     * How many modules are still to be deployed after createApplication returns - the web modules of
+     * an ear, which TomcatWebAppBuilder starts one by one. The application scoped naming context stays
+     * writable until the last of them is in, so the container can keep binding into it.
+     */
+    public void setPendingLateModules(final int count) {
+        pendingLateModules.set(count);
+    }
+
+    /**
+     * Consumes one deployment pass.
+     *
+     * @return true when no further module can bind into the application naming context
+     */
+    public boolean lastModuleDeployed() {
+        // the count is how many passes are still to come after this one, so a pass only closes the
+        // application context when there is nothing left to consume
+        return pendingLateModules.get() <= 0 || pendingLateModules.getAndDecrement() <= 0;
     }
 
     public Collection<Injection> getInjections() {

--- a/container/openejb-core/src/main/java/org/apache/openejb/assembler/classic/Assembler.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/assembler/classic/Assembler.java
@@ -1094,7 +1094,7 @@ public class Assembler extends AssemblerTool implements org.apache.openejb.spi.A
                 logger.info("createApplication.success", appInfo.path);
 
                 //required by spec EE.5.3.4
-                if(setAppNamingContextReadOnly(allDeployments)) {
+                if(setAppNamingContextReadOnly(appContext, allDeployments)) {
                     logger.info("createApplication.naming", appInfo.path);
                 }
 
@@ -1117,20 +1117,31 @@ public class Assembler extends AssemblerTool implements org.apache.openejb.spi.A
         }
     }
 
-    boolean setAppNamingContextReadOnly(final List<BeanContext> allDeployments) {
-        if("true".equals(SystemInstance.get().getProperty(FORCE_READ_ONLY_APP_NAMING, "false"))) {
+    boolean setAppNamingContextReadOnly(final AppContext appContext, final List<BeanContext> allDeployments) {
+        if("true".equals(SystemInstance.get().getProperty(FORCE_READ_ONLY_APP_NAMING, "true"))) {
             for(BeanContext beanContext : allDeployments) {
-                Context ctx = beanContext.getJndiContext();
-             
-                if(IvmContext.class.isInstance(ctx)) {
-                    IvmContext.class.cast(ctx).setReadOnly(true);
-                } else if(ContextHandler.class.isInstance(ctx)) {
-                    ContextHandler.class.cast(ctx).setReadOnly();
+                markReadOnly(beanContext.getJndiContext());
+            }
+
+            // servlets, JSF beans and other web components resolve java:comp/java:module/java:app through the
+            // web and app contexts rather than through a BeanContext, so they need the same treatment
+            if(appContext != null) {
+                for(final WebContext webContext : appContext.getWebContexts()) {
+                    markReadOnly(webContext.getJndiEnc());
                 }
+                markReadOnly(appContext.getAppJndiContext());
             }
             return true;
         }
         return false;
+    }
+
+    private static void markReadOnly(final Context ctx) {
+        if(IvmContext.class.isInstance(ctx)) {
+            IvmContext.class.cast(ctx).setReadOnly(true);
+        } else if(ContextHandler.class.isInstance(ctx)) {
+            ContextHandler.class.cast(ctx).setReadOnly();
+        }
     }
 
     private List<String> getDuplicates(final AppInfo appInfo) {

--- a/container/openejb-core/src/main/java/org/apache/openejb/assembler/classic/Assembler.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/assembler/classic/Assembler.java
@@ -283,7 +283,7 @@ public class Assembler extends AssemblerTool implements org.apache.openejb.spi.A
     public static final String TIMER_STORE_CLASS = "timerStore.class";
     private static final ReentrantLock lock = new ReentrantLock(true);
     public static final String OPENEJB_TIMERS_ON = "openejb.timers.on";
-    static final String FORCE_READ_ONLY_APP_NAMING = "openejb.forceReadOnlyAppNamingContext";
+    public static final String FORCE_READ_ONLY_APP_NAMING = "openejb.forceReadOnlyAppNamingContext";
 
     public static final Class<?>[] VALIDATOR_FACTORY_INTERFACES = new Class<?>[]{ValidatorFactory.class, Serializable.class};
     public static final Class<?>[] VALIDATOR_INTERFACES = new Class<?>[]{Validator.class};
@@ -1155,12 +1155,16 @@ public class Assembler extends AssemblerTool implements org.apache.openejb.spi.A
     }
 
     /**
-     * The application scoped opt-out wins over the container wide one so that a single legacy
-     * application writing into its own naming context does not force the whole container off the
-     * behaviour the specification requires.
+     * Off by default: making the component naming context read only is what the specification
+     * requires, but turning it on for everyone would break the applications that write into their
+     * own naming context after deployment. It stays opt-in until that can be a release wide
+     * behaviour change.
+     *
+     * The application scoped setting wins over the container wide one so a single application can
+     * opt in or out without the whole container following it.
      */
     private static boolean isReadOnlyAppNaming(final AppInfo appInfo) {
-        final String globalDefault = SystemInstance.get().getProperty(FORCE_READ_ONLY_APP_NAMING, "true");
+        final String globalDefault = SystemInstance.get().getProperty(FORCE_READ_ONLY_APP_NAMING, "false");
         final String value = appInfo == null
                 ? globalDefault
                 : appInfo.properties.getProperty(FORCE_READ_ONLY_APP_NAMING, globalDefault);

--- a/container/openejb-core/src/main/java/org/apache/openejb/assembler/classic/Assembler.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/assembler/classic/Assembler.java
@@ -35,6 +35,7 @@ import org.apache.openejb.Extensions;
 import org.apache.openejb.Injection;
 import org.apache.openejb.JndiConstants;
 import org.apache.openejb.MethodContext;
+import org.apache.openejb.ModuleContext;
 import org.apache.openejb.NoSuchApplicationException;
 import org.apache.openejb.OpenEJBException;
 import org.apache.openejb.OpenEJBRuntimeException;
@@ -835,6 +836,11 @@ public class Assembler extends AssemblerTool implements org.apache.openejb.spi.A
                 }
 
                 final AppContext appContext = new AppContext(appInfo.appId, SystemInstance.get(), classLoader, globalJndiContext, appJndiContext, appInfo.standaloneModule);
+                //required by spec EE.5.3.4, applied once the deployments exist - see setAppNamingContextReadOnly
+                appContext.setReadOnlyAppNamingContext(isReadOnlyAppNaming(appInfo));
+                // isSkip defers the web modules of an ear to the web app builders, so the application
+                // naming context has to stay writable until the last of them has been started
+                appContext.setPendingLateModules(appInfo.webAppAlone ? 0 : appInfo.webApps.size());
                 for (final Entry<Object, Object> entry : appInfo.properties.entrySet()) {
                     if (! Module.class.isInstance(entry.getValue())) {
                         appContext.getProperties().put(entry.getKey(), entry.getValue());
@@ -1093,11 +1099,6 @@ public class Assembler extends AssemblerTool implements org.apache.openejb.spi.A
                 systemInstance.fireEvent(new AssemblerAfterApplicationCreated(appInfo, appContext, allDeployments));
                 logger.info("createApplication.success", appInfo.path);
 
-                //required by spec EE.5.3.4
-                if(setAppNamingContextReadOnly(appContext, allDeployments)) {
-                    logger.info("createApplication.naming", appInfo.path);
-                }
-
                 return appContext;
             } catch (final ValidationException | DeploymentException ve) {
                 throw ve;
@@ -1117,29 +1118,59 @@ public class Assembler extends AssemblerTool implements org.apache.openejb.spi.A
         }
     }
 
-    boolean setAppNamingContextReadOnly(final AppContext appContext, final List<BeanContext> allDeployments) {
-        if("true".equals(SystemInstance.get().getProperty(FORCE_READ_ONLY_APP_NAMING, "true"))) {
-            for(BeanContext beanContext : allDeployments) {
-                markReadOnly(beanContext.getJndiContext());
-            }
-
-            // servlets, JSF beans and other web components resolve java:comp/java:module/java:app through the
-            // web and app contexts rather than through a BeanContext, so they need the same treatment
-            if(appContext != null) {
-                for(final WebContext webContext : appContext.getWebContexts()) {
-                    markReadOnly(webContext.getJndiEnc());
-                }
-                markReadOnly(appContext.getAppJndiContext());
-            }
-            return true;
+    /**
+     * Marks the component naming contexts of the deployments that were just created read only, as
+     * required by EE.5.3.4 and Enterprise Beans 10.4.4.
+     *
+     * This runs at the end of {@link #startEjbs} rather than at the end of {@link #createApplication}
+     * on purpose, for two reasons.
+     *
+     * The web modules of an ear are skipped by {@link #isSkip} and deployed later, from
+     * TomcatWebAppBuilder, so marking in createApplication would both miss their java:comp and make
+     * the container's own bindings - JndiBuilder binds app/&lt;module&gt;/&lt;bean&gt; into the app context -
+     * fail with OperationNotSupportedException on that later pass. And the containers themselves bind
+     * comp/EJBContext, comp/WebServiceContext and comp/TimerService into each bean enc while
+     * deploying, which happens in startEjbs, after initEjbs has returned.
+     *
+     * The bean contexts are closed as soon as their own deployment pass is done. The shared
+     * application context has to wait until no further module can bind into it, which for an ear
+     * means its last web module.
+     *
+     * @return true if anything was marked read only
+     */
+    boolean setAppNamingContextReadOnly(final List<BeanContext> allDeployments) {
+        final AppContext appContext = appContextOf(allDeployments);
+        if (appContext == null || !appContext.isReadOnlyAppNamingContext()) {
+            return false;
         }
-        return false;
+
+        for (final BeanContext beanContext : allDeployments) {
+            markReadOnly(beanContext.getJndiContext());
+        }
+
+        if (appContext.lastModuleDeployed()) {
+            markReadOnly(appContext.getAppJndiContext());
+        }
+        return true;
+    }
+
+    /**
+     * The application scoped opt-out wins over the container wide one so that a single legacy
+     * application writing into its own naming context does not force the whole container off the
+     * behaviour the specification requires.
+     */
+    private static boolean isReadOnlyAppNaming(final AppInfo appInfo) {
+        final String globalDefault = SystemInstance.get().getProperty(FORCE_READ_ONLY_APP_NAMING, "true");
+        final String value = appInfo == null
+                ? globalDefault
+                : appInfo.properties.getProperty(FORCE_READ_ONLY_APP_NAMING, globalDefault);
+        return Boolean.parseBoolean(value);
     }
 
     private static void markReadOnly(final Context ctx) {
-        if(IvmContext.class.isInstance(ctx)) {
+        if (IvmContext.class.isInstance(ctx)) {
             IvmContext.class.cast(ctx).setReadOnly(true);
-        } else if(ContextHandler.class.isInstance(ctx)) {
+        } else if (ContextHandler.class.isInstance(ctx)) {
             ContextHandler.class.cast(ctx).setReadOnly();
         }
     }
@@ -1720,7 +1751,23 @@ public class Assembler extends AssemblerTool implements org.apache.openejb.spi.A
                     throw new OpenEJBException("Error starting '" + deployment.getEjbName() + "'.  Exception: " + t.getClass() + ": " + t.getMessage(), t);
                 }
             }
+
+            // the containers bind comp/EJBContext and friends into the bean encs while deploying, so
+            // the naming contexts can only be closed for writing once all of that is done
+            if (setAppNamingContextReadOnly(allDeployments)) {
+                logger.info("createApplication.naming", appContextOf(allDeployments).getId());
+            }
         }
+    }
+
+    private static AppContext appContextOf(final List<BeanContext> allDeployments) {
+        for (final BeanContext beanContext : allDeployments) {
+            final ModuleContext moduleContext = beanContext.getModuleContext();
+            if (moduleContext != null && moduleContext.getAppContext() != null) {
+                return moduleContext.getAppContext();
+            }
+        }
+        return null;
     }
 
     @SuppressWarnings("unchecked")

--- a/container/openejb-core/src/test/java/org/apache/openejb/assembler/classic/AppNamingReadOnlyTest.java
+++ b/container/openejb-core/src/test/java/org/apache/openejb/assembler/classic/AppNamingReadOnlyTest.java
@@ -43,10 +43,10 @@ public class AppNamingReadOnlyTest extends TestCase {
         System.setProperty(Assembler.FORCE_READ_ONLY_APP_NAMING, Boolean.TRUE.toString());
         try {
         	List<BeanContext> mockBeanContextsList = getMockBeanContextsList();
-        	
+
         	Assembler assembler = new Assembler();
-        	assembler.setAppNamingContextReadOnly(mockBeanContextsList);
-        	
+        	assembler.setAppNamingContextReadOnly(null, mockBeanContextsList);
+
         	Context beanNamingContext = mockBeanContextsList.get(0).getJndiContext();
         	//may return null or throw exception depending on openejb.jndiExceptionOnFailedWrite value;
         	//this test is not intended to test read-only behavior (null/exception); it should check whether naming context is marked as read only 
@@ -68,18 +68,45 @@ public class AppNamingReadOnlyTest extends TestCase {
         }
     }
     
-    //check TOMEE behavior is backward compatible
-    public void testAppNamingContextWritableByDefault() throws SystemException, URISyntaxException, NamingException {
+    //read-only is the spec-mandated default (EE.5.3.4, Enterprise Beans 10.4.4)
+    public void testAppNamingContextReadOnlyByDefault() throws SystemException, URISyntaxException {
 
-    	List<BeanContext> mockBeanContextsList = getMockBeanContextsList();
-    	
-    	Assembler assembler = new Assembler();
-    	assembler.setAppNamingContextReadOnly(mockBeanContextsList);
-    	
-    	Context beanNamingContext = mockBeanContextsList.get(0).getJndiContext();
-		Context subContext = beanNamingContext.createSubcontext("sub");
-		
-		assertNotNull(subContext);
+        List<BeanContext> mockBeanContextsList = getMockBeanContextsList();
+
+        Assembler assembler = new Assembler();
+        assertTrue(assembler.setAppNamingContextReadOnly(null, mockBeanContextsList));
+
+        Context beanNamingContext = mockBeanContextsList.get(0).getJndiContext();
+        try {
+            assertNull(beanNamingContext.createSubcontext("sub"));
+        } catch (OperationNotSupportedException e) {
+            //ok
+        } catch (NamingException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    //the legacy writable behavior is still available as an explicit opt-out
+    public void testAppNamingContextWritableWhenDisabled() throws SystemException, URISyntaxException, NamingException {
+
+        String originalValue = System.getProperty(Assembler.FORCE_READ_ONLY_APP_NAMING);
+        System.setProperty(Assembler.FORCE_READ_ONLY_APP_NAMING, Boolean.FALSE.toString());
+        try {
+            List<BeanContext> mockBeanContextsList = getMockBeanContextsList();
+
+            Assembler assembler = new Assembler();
+            assertFalse(assembler.setAppNamingContextReadOnly(null, mockBeanContextsList));
+
+            Context beanNamingContext = mockBeanContextsList.get(0).getJndiContext();
+            assertNotNull(beanNamingContext.createSubcontext("sub"));
+        } finally {
+            if(originalValue == null) {
+                System.clearProperty(Assembler.FORCE_READ_ONLY_APP_NAMING);
+            } else {
+                System.setProperty(Assembler.FORCE_READ_ONLY_APP_NAMING, originalValue);
+            }
+            SystemInstance.reset();
+        }
     }
     
     private List<BeanContext> getMockBeanContextsList() throws SystemException, URISyntaxException {

--- a/container/openejb-core/src/test/java/org/apache/openejb/assembler/classic/AppNamingReadOnlyTest.java
+++ b/container/openejb-core/src/test/java/org/apache/openejb/assembler/classic/AppNamingReadOnlyTest.java
@@ -98,10 +98,11 @@ public class AppNamingReadOnlyTest extends TestCase {
         assertTrue(appContext.lastModuleDeployed());
     }
 
-    // read-only is the spec-mandated default (EE.5.3.4, Enterprise Beans 10.4.4)
-    public void testAppNamingContextReadOnlyByDefault() throws SystemException, URISyntaxException {
+    // opting in gives the read only component naming context the specification requires
+    // (EE.5.3.4, Enterprise Beans 10.4.4)
+    public void testAppNamingContextReadOnlyWhenEnabled() throws SystemException, URISyntaxException {
         final List<BeanContext> beanContexts = getMockBeanContextsList();
-        // the flag is what createApplication derives from the properties, defaulting to true
+        // the flag is what createApplication derives from the properties
         appContext.setReadOnlyAppNamingContext(true);
 
         final Assembler assembler = new Assembler();
@@ -110,8 +111,8 @@ public class AppNamingReadOnlyTest extends TestCase {
         assertWriteRefused(beanContexts.get(0).getJndiContext());
     }
 
-    // the legacy writable behavior is still available as an explicit opt-out
-    public void testAppNamingContextWritableWhenDisabled() throws SystemException, URISyntaxException, NamingException {
+    // the naming context stays writable unless the application opts in
+    public void testAppNamingContextWritableByDefault() throws SystemException, URISyntaxException, NamingException {
         final List<BeanContext> beanContexts = getMockBeanContextsList();
         appContext.setReadOnlyAppNamingContext(false);
 

--- a/container/openejb-core/src/test/java/org/apache/openejb/assembler/classic/AppNamingReadOnlyTest.java
+++ b/container/openejb-core/src/test/java/org/apache/openejb/assembler/classic/AppNamingReadOnlyTest.java
@@ -36,89 +36,119 @@ import org.apache.openejb.loader.SystemInstance;
 import junit.framework.TestCase;
 
 public class AppNamingReadOnlyTest extends TestCase {
-	
-	public void testReadOnlyAppNamingContext() throws SystemException, URISyntaxException {
-    	
-        String originalValue = System.getProperty(Assembler.FORCE_READ_ONLY_APP_NAMING);
-        System.setProperty(Assembler.FORCE_READ_ONLY_APP_NAMING, Boolean.TRUE.toString());
-        try {
-        	List<BeanContext> mockBeanContextsList = getMockBeanContextsList();
 
-        	Assembler assembler = new Assembler();
-        	assembler.setAppNamingContextReadOnly(null, mockBeanContextsList);
+    private AppContext appContext;
 
-        	Context beanNamingContext = mockBeanContextsList.get(0).getJndiContext();
-        	//may return null or throw exception depending on openejb.jndiExceptionOnFailedWrite value;
-        	//this test is not intended to test read-only behavior (null/exception); it should check whether naming context is marked as read only 
-        	try {
-				Context subContext = beanNamingContext.createSubcontext("sub");
-				assertNull(subContext);
-			} catch (OperationNotSupportedException e) {
-				//ok
-			} catch (NamingException e) {
-				throw new AssertionError();
-			}
-        } finally {
-            if(originalValue == null) {
-                System.clearProperty(Assembler.FORCE_READ_ONLY_APP_NAMING);
-            } else {
-                System.setProperty(Assembler.FORCE_READ_ONLY_APP_NAMING, originalValue);
-            }
-            SystemInstance.reset();
-        }
+    @Override
+    protected void tearDown() throws Exception {
+        SystemInstance.reset();
+        super.tearDown();
     }
-    
-    //read-only is the spec-mandated default (EE.5.3.4, Enterprise Beans 10.4.4)
+
+    public void testReadOnlyAppNamingContext() throws SystemException, URISyntaxException {
+        final List<BeanContext> beanContexts = getMockBeanContextsList();
+        appContext.setReadOnlyAppNamingContext(true);
+
+        final Assembler assembler = new Assembler();
+        assertTrue(assembler.setAppNamingContextReadOnly(beanContexts));
+
+        assertWriteRefused(beanContexts.get(0).getJndiContext());
+    }
+
+    // the shared application context must stay writable while further modules can still bind into it
+    public void testAppContextStaysWritableUntilTheLastModule() throws Exception {
+        final List<BeanContext> beanContexts = getMockBeanContextsList();
+        appContext.setReadOnlyAppNamingContext(true);
+        // one web module still to come, as for an ear whose war is started by TomcatWebAppBuilder
+        appContext.setPendingLateModules(1);
+
+        final Assembler assembler = new Assembler();
+        assertTrue(assembler.setAppNamingContextReadOnly(beanContexts));
+
+        // the bean context is closed straight away, it can no longer receive bindings
+        assertWriteRefused(beanContexts.get(0).getJndiContext());
+
+        // but the application context still accepts the container's own bindings, as JndiBuilder
+        // does for the ejb modules of an ear's web modules, which deploy later
+        assertNotNull(appContext.getAppJndiContext().createSubcontext("app/late"));
+
+        // and once the last module is in, it closes too
+        assertTrue(assembler.setAppNamingContextReadOnly(beanContexts));
+        assertWriteRefused(appContext.getAppJndiContext());
+    }
+
+    // an ear with two web modules only closes its application context on the third pass: the one
+    // createApplication does, then one per web module started by the web app builder
+    public void testAppContextWaitsForEveryLateModule() throws Exception {
+        getMockBeanContextsList();
+        appContext.setPendingLateModules(2);
+
+        assertFalse("createApplication pass must not close the app context", appContext.lastModuleDeployed());
+        assertFalse("first web module must not close the app context", appContext.lastModuleDeployed());
+        assertTrue("last web module closes the app context", appContext.lastModuleDeployed());
+        // and it stays closed for any further call
+        assertTrue(appContext.lastModuleDeployed());
+    }
+
+    // a standalone module is fully deployed in one pass, so it closes immediately
+    public void testStandaloneModuleClosesOnTheFirstPass() throws Exception {
+        getMockBeanContextsList();
+        appContext.setPendingLateModules(0);
+
+        assertTrue(appContext.lastModuleDeployed());
+    }
+
+    // read-only is the spec-mandated default (EE.5.3.4, Enterprise Beans 10.4.4)
     public void testAppNamingContextReadOnlyByDefault() throws SystemException, URISyntaxException {
+        final List<BeanContext> beanContexts = getMockBeanContextsList();
+        // the flag is what createApplication derives from the properties, defaulting to true
+        appContext.setReadOnlyAppNamingContext(true);
 
-        List<BeanContext> mockBeanContextsList = getMockBeanContextsList();
+        final Assembler assembler = new Assembler();
+        assertTrue(assembler.setAppNamingContextReadOnly(beanContexts));
 
-        Assembler assembler = new Assembler();
-        assertTrue(assembler.setAppNamingContextReadOnly(null, mockBeanContextsList));
+        assertWriteRefused(beanContexts.get(0).getJndiContext());
+    }
 
-        Context beanNamingContext = mockBeanContextsList.get(0).getJndiContext();
+    // the legacy writable behavior is still available as an explicit opt-out
+    public void testAppNamingContextWritableWhenDisabled() throws SystemException, URISyntaxException, NamingException {
+        final List<BeanContext> beanContexts = getMockBeanContextsList();
+        appContext.setReadOnlyAppNamingContext(false);
+
+        final Assembler assembler = new Assembler();
+        assertFalse(assembler.setAppNamingContextReadOnly(beanContexts));
+
+        assertNotNull(beanContexts.get(0).getJndiContext().createSubcontext("sub"));
+    }
+
+    /**
+     * A read only context either throws OperationNotSupportedException or silently ignores the write,
+     * depending on openejb.jndiExceptionOnFailedWrite. This only checks that the context is marked.
+     */
+    private void assertWriteRefused(final Context context) {
         try {
-            assertNull(beanNamingContext.createSubcontext("sub"));
-        } catch (OperationNotSupportedException e) {
-            //ok
-        } catch (NamingException e) {
+            assertNull(context.createSubcontext("sub"));
+        } catch (final OperationNotSupportedException e) {
+            // ok
+        } catch (final NamingException e) {
             throw new AssertionError(e);
         }
     }
 
-    //the legacy writable behavior is still available as an explicit opt-out
-    public void testAppNamingContextWritableWhenDisabled() throws SystemException, URISyntaxException, NamingException {
-
-        String originalValue = System.getProperty(Assembler.FORCE_READ_ONLY_APP_NAMING);
-        System.setProperty(Assembler.FORCE_READ_ONLY_APP_NAMING, Boolean.FALSE.toString());
-        try {
-            List<BeanContext> mockBeanContextsList = getMockBeanContextsList();
-
-            Assembler assembler = new Assembler();
-            assertFalse(assembler.setAppNamingContextReadOnly(null, mockBeanContextsList));
-
-            Context beanNamingContext = mockBeanContextsList.get(0).getJndiContext();
-            assertNotNull(beanNamingContext.createSubcontext("sub"));
-        } finally {
-            if(originalValue == null) {
-                System.clearProperty(Assembler.FORCE_READ_ONLY_APP_NAMING);
-            } else {
-                System.setProperty(Assembler.FORCE_READ_ONLY_APP_NAMING, originalValue);
-            }
-            SystemInstance.reset();
-        }
-    }
-    
     private List<BeanContext> getMockBeanContextsList() throws SystemException, URISyntaxException {
-    	IvmContext context = new IvmContext();
-    	
-    	AppContext mockAppContext = new AppContext("appId", SystemInstance.get(),  this.getClass().getClassLoader(), context, context, false);
-    	ModuleContext mockModuleContext =  new ModuleContext("moduleId", new URI(""), "uniqueId", mockAppContext, context, this.getClass().getClassLoader());
-    	BeanContext mockBeanContext = new BeanContext("test", context, mockModuleContext, this.getClass(), this.getClass(), new HashMap<>());
-    	
-    	List<BeanContext> beanContextsList = new ArrayList<>();
-    	beanContextsList.add(mockBeanContext);
-    	
-    	return beanContextsList;
+        final IvmContext beanJndiContext = new IvmContext();
+        final IvmContext appJndiContext = new IvmContext();
+
+        appContext = new AppContext("appId", SystemInstance.get(), this.getClass().getClassLoader(),
+                appJndiContext, appJndiContext, false);
+        final ModuleContext mockModuleContext = new ModuleContext("moduleId", new URI(""), "uniqueId", appContext,
+                beanJndiContext, this.getClass().getClassLoader());
+        final BeanContext mockBeanContext = new BeanContext("test", beanJndiContext, mockModuleContext,
+                this.getClass(), this.getClass(), new HashMap<>());
+
+        final List<BeanContext> beanContextsList = new ArrayList<>();
+        beanContextsList.add(mockBeanContext);
+
+        return beanContextsList;
     }
 }

--- a/container/openejb-core/src/test/java/org/apache/openejb/core/ivm/naming/JavaCompReadOnlyTest.java
+++ b/container/openejb-core/src/test/java/org/apache/openejb/core/ivm/naming/JavaCompReadOnlyTest.java
@@ -1,0 +1,123 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.openejb.core.ivm.naming;
+
+import junit.framework.TestCase;
+import org.apache.openejb.AppContext;
+import org.apache.openejb.BeanContext;
+import org.apache.openejb.assembler.classic.Assembler;
+import org.apache.openejb.assembler.classic.SecurityServiceInfo;
+import org.apache.openejb.assembler.classic.TransactionServiceInfo;
+import org.apache.openejb.config.AppModule;
+import org.apache.openejb.config.ConfigurationFactory;
+import org.apache.openejb.config.EjbModule;
+import org.apache.openejb.jee.EjbJar;
+import org.apache.openejb.jee.SingletonBean;
+import org.apache.openejb.loader.SystemInstance;
+
+import javax.naming.Context;
+import javax.naming.OperationNotSupportedException;
+
+/**
+ * The Enterprise Beans spec (10.4.4) and EE.5.3.4 require the component naming context to be read-only:
+ * writes against java:comp and friends must not take effect.
+ */
+public class JavaCompReadOnlyTest extends TestCase {
+
+    private AppContext deploy() throws Exception {
+        final ConfigurationFactory config = new ConfigurationFactory();
+        final Assembler assembler = new Assembler();
+
+        assembler.createTransactionManager(config.configureService(TransactionServiceInfo.class));
+        assembler.createSecurityService(config.configureService(SecurityServiceInfo.class));
+
+        final EjbJar ejbJar = new EjbJar("testmodule");
+        ejbJar.addEnterpriseBean(new SingletonBean(Bean.class));
+
+        final AppModule module = new AppModule(new EjbModule(ejbJar));
+        return assembler.createApplication(config.configureApplication(module));
+    }
+
+    public void testCompContextRefusesWrites() throws Exception {
+        final AppContext app = deploy();
+        try {
+            final BeanContext bean = app.getBeanContexts().get(0);
+            final Context comp = bean.getJndiContext();
+
+            assertWriteRefused(comp, "bind", () -> comp.bind("newName", "newValue"));
+            assertWriteRefused(comp, "rebind", () -> comp.rebind("newName", "newValue"));
+            assertWriteRefused(comp, "rename", () -> comp.rename("comp", "renameTo"));
+            assertWriteRefused(comp, "unbind", () -> comp.unbind("comp"));
+            assertWriteRefused(comp, "destroySubcontext", () -> comp.destroySubcontext("comp"));
+
+            // createSubcontext either throws or returns null, depending on jndiExceptionOnFailedWrite
+            try {
+                assertNull(comp.createSubcontext("newName"));
+            } catch (final OperationNotSupportedException expected) {
+                // ok
+            }
+
+            // nothing the writes attempted may be observable afterwards
+            assertNotBound(comp, "newName");
+            assertNotBound(comp, "renameTo");
+
+            // and the pre-existing binding must have survived unbind/rename/destroySubcontext
+            assertTrue(comp.lookup("comp") instanceof Context);
+        } finally {
+            SystemInstance.reset();
+        }
+    }
+
+    public void testAppContextRefusesWrites() throws Exception {
+        final AppContext app = deploy();
+        try {
+            final Context appCtx = app.getAppJndiContext();
+
+            assertWriteRefused(appCtx, "bind", () -> appCtx.bind("newName", "newValue"));
+            assertNotBound(appCtx, "newName");
+            assertTrue(appCtx.lookup("app") instanceof Context);
+        } finally {
+            SystemInstance.reset();
+        }
+    }
+
+    private interface Write {
+        void run() throws Exception;
+    }
+
+    private void assertWriteRefused(final Context ctx, final String operation, final Write write) {
+        try {
+            write.run();
+            fail(operation + " should have been refused on a read-only naming context");
+        } catch (final OperationNotSupportedException expected) {
+            // ok
+        } catch (final Exception e) {
+            throw new AssertionError("unexpected exception from " + operation, e);
+        }
+    }
+
+    private void assertNotBound(final Context ctx, final String name) throws Exception {
+        try {
+            assertNull(name + " must not be bound", ctx.lookup(name));
+        } catch (final javax.naming.NameNotFoundException expected) {
+            // ok
+        }
+    }
+
+    public static class Bean {
+    }
+}

--- a/container/openejb-core/src/test/java/org/apache/openejb/core/ivm/naming/JavaCompReadOnlyTest.java
+++ b/container/openejb-core/src/test/java/org/apache/openejb/core/ivm/naming/JavaCompReadOnlyTest.java
@@ -35,11 +35,14 @@ import javax.naming.OperationNotSupportedException;
 
 /**
  * The Enterprise Beans spec (10.4.4) and EE.5.3.4 require the component naming context to be read-only:
- * writes against java:comp and friends must not take effect.
+ * writes against java:comp and friends must not take effect. TomEE only does this when
+ * openejb.forceReadOnlyAppNamingContext is turned on, so the deployments here opt in explicitly.
  */
 public class JavaCompReadOnlyTest extends TestCase {
 
     private AppContext deploy() throws Exception {
+        SystemInstance.get().setProperty(Assembler.FORCE_READ_ONLY_APP_NAMING, Boolean.TRUE.toString());
+
         final ConfigurationFactory config = new ConfigurationFactory();
         final Assembler assembler = new Assembler();
 

--- a/container/openejb-core/src/test/java/org/apache/openejb/core/ivm/naming/JavaCompReadOnlyTest.java
+++ b/container/openejb-core/src/test/java/org/apache/openejb/core/ivm/naming/JavaCompReadOnlyTest.java
@@ -30,6 +30,7 @@ import org.apache.openejb.jee.SingletonBean;
 import org.apache.openejb.loader.SystemInstance;
 
 import javax.naming.Context;
+import javax.naming.NameNotFoundException;
 import javax.naming.OperationNotSupportedException;
 
 /**
@@ -53,8 +54,8 @@ public class JavaCompReadOnlyTest extends TestCase {
     }
 
     public void testCompContextRefusesWrites() throws Exception {
-        final AppContext app = deploy();
         try {
+            final AppContext app = deploy();
             final BeanContext bean = app.getBeanContexts().get(0);
             final Context comp = bean.getJndiContext();
 
@@ -63,33 +64,30 @@ public class JavaCompReadOnlyTest extends TestCase {
             assertWriteRefused(comp, "rename", () -> comp.rename("comp", "renameTo"));
             assertWriteRefused(comp, "unbind", () -> comp.unbind("comp"));
             assertWriteRefused(comp, "destroySubcontext", () -> comp.destroySubcontext("comp"));
+            assertWriteRefused(comp, "createSubcontext", () -> comp.createSubcontext("newName"));
 
-            // createSubcontext either throws or returns null, depending on jndiExceptionOnFailedWrite
-            try {
-                assertNull(comp.createSubcontext("newName"));
-            } catch (final OperationNotSupportedException expected) {
-                // ok
-            }
-
-            // nothing the writes attempted may be observable afterwards
+            // none of the attempted writes may be observable afterwards
             assertNotBound(comp, "newName");
             assertNotBound(comp, "renameTo");
 
-            // and the pre-existing binding must have survived unbind/rename/destroySubcontext
-            assertTrue(comp.lookup("comp") instanceof Context);
+            // and what was already bound must have survived rename, unbind and destroySubcontext
+            assertTrue("comp must still be bound", comp.lookup("comp") instanceof Context);
         } finally {
             SystemInstance.reset();
         }
     }
 
     public void testAppContextRefusesWrites() throws Exception {
-        final AppContext app = deploy();
         try {
+            final AppContext app = deploy();
             final Context appCtx = app.getAppJndiContext();
 
             assertWriteRefused(appCtx, "bind", () -> appCtx.bind("newName", "newValue"));
+            assertWriteRefused(appCtx, "rebind", () -> appCtx.rebind("newName", "newValue"));
+            assertWriteRefused(appCtx, "createSubcontext", () -> appCtx.createSubcontext("newName"));
+
             assertNotBound(appCtx, "newName");
-            assertTrue(appCtx.lookup("app") instanceof Context);
+            assertTrue("app must still be bound", appCtx.lookup("app") instanceof Context);
         } finally {
             SystemInstance.reset();
         }
@@ -99,12 +97,16 @@ public class JavaCompReadOnlyTest extends TestCase {
         void run() throws Exception;
     }
 
+    /**
+     * A read only context may either throw OperationNotSupportedException or silently ignore the
+     * write, depending on openejb.jndiExceptionOnFailedWrite. Both are accepted here; that the write
+     * did not take effect is asserted separately by {@link #assertNotBound}.
+     */
     private void assertWriteRefused(final Context ctx, final String operation, final Write write) {
         try {
             write.run();
-            fail(operation + " should have been refused on a read-only naming context");
         } catch (final OperationNotSupportedException expected) {
-            // ok
+            // ok, the context refused the write outright
         } catch (final Exception e) {
             throw new AssertionError("unexpected exception from " + operation, e);
         }
@@ -113,7 +115,7 @@ public class JavaCompReadOnlyTest extends TestCase {
     private void assertNotBound(final Context ctx, final String name) throws Exception {
         try {
             assertNull(name + " must not be bound", ctx.lookup(name));
-        } catch (final javax.naming.NameNotFoundException expected) {
+        } catch (final NameNotFoundException expected) {
             // ok
         }
     }


### PR DESCRIPTION
## What

Adds working support for the read-only `java:comp` component naming context that the Enterprise Beans spec (10.4.4) and EE.5.3.4 require, behind `openejb.forceReadOnlyAppNamingContext`. The default stays **writable**, so this changes nothing for existing applications; the TCK turns the flag on for its runs.

## Why

The `IvmContext` read-only enforcement has existed since d5b3b93d4f (2017) — `checkReadOnly()` throws `OperationNotSupportedException` and `setReadOnly()` cascades through the name tree — but nothing ever turned it on, and turning it on at the obvious place did not work. This makes the switch actually usable.

Per review discussion, enabling it by default is a behavioural change that would break applications writing into their own ENC after deployment, so it remains opt-in until that can be a release-wide change. TomEE therefore still deviates from the spec out of the box; this PR provides the mechanism and the TCK coverage rather than flipping the behaviour for everyone.

## Changes

- **`Assembler`**: `openejb.forceReadOnlyAppNamingContext` is read from `appInfo.properties` first with the system property as fallback (as `OPENEJB_TIMERS_ON` and friends do), so it can be set per application or container-wide, and parsed with `Boolean.parseBoolean` so `=FALSE` is honoured. Default `false`.
- **Lifecycle** — where the marking happens is the substance of this PR. The intent is recorded on the `AppContext` when the application is configured and applied at the end of `startEjbs`:
  - `isSkip` defers the EJB modules of an EAR's web modules to the web app builders, which call `initEjbs`/`startEjbs` *after* `createApplication` has returned. Marking in `createApplication` makes `JndiBuilder`'s `app/<module>/<bean>` bindings fail with `OperationNotSupportedException` on that later pass, while the `java:comp` of exactly those modules is never closed at all.
  - The containers bind `comp/EJBContext`, `comp/WebServiceContext` and `comp/TimerService` into each bean ENC from `SingletonInstanceManager.deploy()`/`StatelessInstanceManager.deploy()`, which run in `startEjbs` — so marking at the end of `initEjbs` breaks singleton and stateless deployment outright.
  - The shared application context is only closed once no further module can bind into it, tracked by a count of the late modules still to come.
- **`AppContext`**: carries the read-only intent and the pending-late-module count.
- **Tests**: new `JavaCompReadOnlyTest` opts into the flag, deploys a real application and asserts every write op is refused on `java:comp` and `java:app`, that nothing written becomes observable, and that pre-existing bindings survive; `AppNamingReadOnlyTest` covers the enabled and default paths plus the late-module deferral.

## Verification

- `openejb-core` full suite: 4096 tests, the only 6 failures are pre-existing security-test failures that reproduce on a clean `main`. (`ConnectionFactoryTxTest` failed once with a null injected `ConnectionFactory` and passed on a repeat full run plus 5 isolated runs; `InjectionProcessor` performs no ENC writes, so read-only cannot affect injection — a pre-existing flake against the shared ActiveMQ broker.)
- Jakarta EE 11 Web Profile TCK `enterprise-beans-30` with the flag enabled: the `naming/context` write assertions pass in both the EJB and web (servlet / filtered-servlet / JSF) vehicles.

## Reviewer notes

- The matching tomee-tck harness change (enabling the flag and un-excluding the write tests) is a separate PR in `apache/tomee-tck`.
- There is deliberately no `WebContext` handling: `WebContext.jndiEnc` holds an `InitialContext` or a `WebInitialContext` proxy, never an `IvmContext`/`ContextHandler`, so marking it would be a no-op.
- The TCK run surfaced a **separate, pre-existing** read-side bug (TOMEE-4658): in web components TomEE hands out Tomcat's `org.apache.naming.NamingContext` instead of `IvmContext`, so `java:comp/env` lists extra `comp`/`module` entries and `close()` fails. Orthogonal to this change and not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)