### PR TITLE
TOMEE-4650 - Guard undeploy against an already-closed EntityManagerFactory

### DIFF
--- a/container/openejb-core/src/main/java/org/apache/openejb/assembler/classic/ReloadableEntityManagerFactory.java
+++ b/container/openejb-core/src/main/java/org/apache/openejb/assembler/classic/ReloadableEntityManagerFactory.java
@@ -279,7 +279,8 @@ public class ReloadableEntityManagerFactory implements EntityManagerFactory, Ser
 
     @Override
     public synchronized void close() {
-        if (delegate != null) {
+        // the application may have closed the EMF itself, closing it twice is an error
+        if (delegate != null && delegate.isOpen()) {
             delegate.close();
         }
     }

--- a/container/openejb-core/src/test/java/org/apache/openejb/assembler/classic/ReloadableEntityManagerFactoryCloseTest.java
+++ b/container/openejb-core/src/test/java/org/apache/openejb/assembler/classic/ReloadableEntityManagerFactoryCloseTest.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.openejb.assembler.classic;
+
+import jakarta.persistence.EntityManagerFactory;
+import org.apache.openejb.persistence.PersistenceUnitInfoImpl;
+import org.apache.openejb.util.reflection.Reflections;
+import org.junit.Test;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * An application may close a container-managed {@code EntityManagerFactory} itself. Undeploy
+ * must then not call {@code close()} on it a second time, which the providers reject with
+ * "Attempting to execute an operation on a closed EntityManagerFactory" and which made
+ * {@code Assembler.destroyApplication} report an undeploy error.
+ *
+ * @see <a href="https://issues.apache.org/jira/browse/TOMEE-4650">TOMEE-4650</a>
+ */
+public class ReloadableEntityManagerFactoryCloseTest {
+
+    @Test
+    public void closeIsNotPropagatedToAnAlreadyClosedDelegate() {
+        final AtomicInteger closeCalls = new AtomicInteger();
+        final EntityManagerFactory delegate = closeCountingEntityManagerFactory(closeCalls);
+
+        final ReloadableEntityManagerFactory remf = newReloadableEntityManagerFactory(delegate);
+
+        // the application closes the EMF itself
+        remf.close();
+        assertEquals(1, closeCalls.get());
+
+        // undeploy closes it again, which must be a no-op
+        remf.close();
+        assertEquals("close() must not be propagated to an already closed EntityManagerFactory",
+                1, closeCalls.get());
+    }
+
+    private ReloadableEntityManagerFactory newReloadableEntityManagerFactory(final EntityManagerFactory delegate) {
+        final PersistenceUnitInfoImpl unitInfo = new PersistenceUnitInfoImpl();
+        unitInfo.setPersistenceUnitName("close-test-unit");
+        unitInfo.setProperties(new Properties());
+        // keep the constructor from eagerly building the real EMF
+        unitInfo.setLazilyInitialized(true);
+
+        final EntityManagerFactoryCallable callable = new EntityManagerFactoryCallable(
+                "org.apache.openjpa.persistence.PersistenceProviderImpl", unitInfo,
+                getClass().getClassLoader(), null, false);
+
+        final ReloadableEntityManagerFactory remf =
+                new ReloadableEntityManagerFactory(getClass().getClassLoader(), callable, unitInfo);
+        Reflections.set(remf, "delegate", delegate);
+        return remf;
+    }
+
+    /**
+     * A minimal {@code EntityManagerFactory} counting {@code close()} calls and reporting
+     * itself as closed afterwards, as the providers do.
+     */
+    private EntityManagerFactory closeCountingEntityManagerFactory(final AtomicInteger closeCalls) {
+        final boolean[] open = {true};
+
+        final InvocationHandler handler = (final Object proxy, final Method method, final Object[] args) -> {
+            switch (method.getName()) {
+                case "close":
+                    closeCalls.incrementAndGet();
+                    open[0] = false;
+                    return null;
+                case "isOpen":
+                    return open[0];
+                default:
+                    return null;
+            }
+        };
+
+        return EntityManagerFactory.class.cast(Proxy.newProxyInstance(
+                getClass().getClassLoader(),
+                new Class<?>[]{EntityManagerFactory.class},
+                handler));
+    }
+}


### PR DESCRIPTION
Fixes [TOMEE-4650](https://issues.apache.org/jira/browse/TOMEE-4650).

Scope reduced per review — this PR is now **only** the `close()` guard. The `JpaCDIExtension` work has been dropped from this branch, preserved on `claude/tomee-4650-jpa-cdi-extension`, and tracked as [TOMEE-4661](https://issues.apache.org/jira/browse/TOMEE-4661).

## What changed

When an application closes a container-managed `EntityManagerFactory` itself, TomEE's undeploy path called `close()` on it again, and `Assembler.destroyApplication` then failed with *"Attempting to execute an operation on a closed EntityManagerFactory"*. The test method itself passed; only the undeploy step after it errored.

`ReloadableEntityManagerFactory.close()` now checks `isOpen()` before delegating. The check reads the non-lazy `delegate` field rather than `delegate()`, so it does not force initialisation of a persistence unit that was never used.

This covers the `entityManagerFactoryCloseExceptions` TCK vehicles (`ClientPmservletTest` / `ClientPuservletTest`).

## Tests

`ReloadableEntityManagerFactoryCloseTest` verifies a second `close()` is a no-op. Confirmed it fails against the unpatched code (2 close calls instead of 1).

Also re-ran `ProducedExtendedEmTest` and `ResourceLocalCdiEmTest` — both green.

## Follow-up

The Jakarta Persistence 3.2 CDI qualifier-bean half of the original ticket is **not** in this PR. The review correctly identified that it caused an `AmbiguousResolutionException` against the `@Produces EntityManager` pattern; I reproduced that failure in `ProducedExtendedEmTest` before splitting. TOMEE-4661 carries the full review findings and will come back as its own PR.

The TCK exclusion removals in `apache/tomee-tck` also remain outstanding: `persistence-javatest.txt` can be cleared once this merges; `persistence-servlet.txt` must wait for TOMEE-4661.

🤖 Generated with [Claude Code](https://claude.com/claude-code)