### PR TITLE
TOMEE-4643 - discover Feature/DynamicFeature from META-INF/services

### DIFF
--- a/server/openejb-cxf-rs/src/main/java/org/apache/openejb/server/cxf/rs/CxfRsHttpListener.java
+++ b/server/openejb-cxf-rs/src/main/java/org/apache/openejb/server/cxf/rs/CxfRsHttpListener.java
@@ -119,6 +119,7 @@ import jakarta.ws.rs.ApplicationPath;
 import jakarta.ws.rs.RuntimeType;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.client.ClientRequestFilter;
+import jakarta.ws.rs.container.DynamicFeature;
 import jakarta.ws.rs.core.Application;
 import jakarta.ws.rs.core.MultivaluedHashMap;
 import jakarta.ws.rs.core.MultivaluedMap;
@@ -146,6 +147,8 @@ import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.ServiceConfigurationError;
+import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.logging.Level;
@@ -166,6 +169,8 @@ public class CxfRsHttpListener implements RsHttpListener {
     public static final String STATIC_RESOURCE_KEY = CXF_JAXRS_PREFIX + "static-resources-list";
     public static final String STATIC_SUB_RESOURCE_RESOLUTION_KEY = "staticSubresourceResolution";
     public static final String RESOURCE_COMPARATOR_KEY = CXF_JAXRS_PREFIX + "resourceComparator";
+    // spec defined, see the "Services" section of the Jakarta RESTful Web Services specification
+    private static final String LOAD_SERVICES_PROPERTY = "jakarta.ws.rs.loadServices";
 
     private static final String GLOBAL_PROVIDERS = SystemInstance.get().getProperty(PROVIDERS_KEY);
     public static final boolean TRY_STATIC_RESOURCES = "true".equalsIgnoreCase(SystemInstance.get().getProperty("openejb.jaxrs.static-first", "true"));
@@ -1304,6 +1309,10 @@ public class CxfRsHttpListener implements RsHttpListener {
             }
         }
 
+        if (!ignoreAutoProviders && isServiceLoadingEnabled(application)) {
+            addServiceLoaderProviders(additionalProviders, Thread.currentThread().getContextClassLoader());
+        }
+
         List<Object> providers = null;
         if (providersConfig != null) {
             providers = ServiceInfos.resolve(services, providersConfig.toArray(new String[providersConfig.size()]), OpenEJBProviderFactory.INSTANCE);
@@ -1333,6 +1342,65 @@ public class CxfRsHttpListener implements RsHttpListener {
         if (!providers.isEmpty()) {
             factory.setProviders(providers);
         }
+    }
+
+    /**
+     * Service loading is enabled unless the Application subclass maps
+     * {@code jakarta.ws.rs.loadServices} to {@link Boolean#FALSE}, see the "Services" section of
+     * the Jakarta RESTful Web Services specification (Providers / Lifecycle and Environment).
+     */
+    static boolean isServiceLoadingEnabled(final Application application) {
+        if (application == null) {
+            return true;
+        }
+        final Map<String, Object> properties = application.getProperties();
+        return properties == null || !Boolean.FALSE.equals(properties.get(LOAD_SERVICES_PROPERTY));
+    }
+
+    /**
+     * REST 3.1 requires Feature and DynamicFeature implementations declared in
+     * META-INF/services to be picked up through the JDK ServiceLoader at deploy time.
+     *
+     * CXF does not implement this lookup itself - it relies on the container to hand it the
+     * already resolved providers, which is why the CXF TCK run stays green on GlassFish. TomEE
+     * builds the provider list on its own, so without this scan such features never register.
+     *
+     * @see <a href="https://issues.apache.org/jira/browse/TOMEE-4643">TOMEE-4643</a>
+     */
+    static void addServiceLoaderProviders(final Collection<Object> additionalProviders, final ClassLoader loader) {
+        for (final Class<?> spi : asList(jakarta.ws.rs.core.Feature.class, DynamicFeature.class)) {
+            // a single broken entry must not discard the remaining providers of this type,
+            // so failures are caught per entry instead of around the whole iteration
+            final Iterator<?> it = ServiceLoader.load(spi, loader).iterator();
+            while (true) {
+                final Object impl;
+                try {
+                    if (!it.hasNext()) {
+                        break;
+                    }
+                    impl = it.next();
+                } catch (final ServiceConfigurationError | LinkageError e) {
+                    LOGGER.warning("Can't load a " + spi.getName() + " implementation from META-INF/services", e);
+                    continue;
+                }
+
+                final Class<?> implClass = impl.getClass();
+                if (alreadyRegistered(additionalProviders, implClass)) {
+                    continue;
+                }
+                additionalProviders.add(impl);
+                LOGGER.info("Registered " + spi.getSimpleName() + " " + implClass.getName() + " found in META-INF/services");
+            }
+        }
+    }
+
+    private static boolean alreadyRegistered(final Collection<Object> providers, final Class<?> clazz) {
+        for (final Object provider : providers) {
+            if (provider == clazz || clazz.equals(provider.getClass())) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private boolean isProvider(final Class<?> clazz) {

--- a/server/openejb-cxf-rs/src/test/java/org/apache/openejb/server/cxf/rs/ServiceLoaderProviderDiscoveryTest.java
+++ b/server/openejb-cxf-rs/src/test/java/org/apache/openejb/server/cxf/rs/ServiceLoaderProviderDiscoveryTest.java
@@ -1,0 +1,205 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.openejb.server.cxf.rs;
+
+import jakarta.ws.rs.container.DynamicFeature;
+import jakarta.ws.rs.container.ResourceInfo;
+import jakarta.ws.rs.core.Application;
+import jakarta.ws.rs.core.Feature;
+import jakarta.ws.rs.core.FeatureContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonMap;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * REST 3.1 requires {@link Feature} and {@link DynamicFeature} implementations declared through
+ * META-INF/services to be discovered with the JDK ServiceLoader at deploy time. CXF does not do
+ * this on its own, so TomEE performs the lookup while assembling the provider list.
+ *
+ * The services descriptors are written to a throwaway directory and read through a dedicated
+ * classloader, so the discovery is exercised without registering these features into the other
+ * tests of this module.
+ *
+ * @see <a href="https://issues.apache.org/jira/browse/TOMEE-4643">TOMEE-4643</a>
+ */
+public class ServiceLoaderProviderDiscoveryTest {
+    @Rule
+    public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    private ClassLoader classLoaderDeclaring(final Class<?>... services) throws Exception {
+        final Map<Class<?>, List<String>> perSpi = new LinkedHashMap<>();
+        for (final Class<?> service : services) {
+            final Class<?> spi = Feature.class.isAssignableFrom(service) ? Feature.class : DynamicFeature.class;
+            perSpi.computeIfAbsent(spi, k -> new ArrayList<>()).add(service.getName());
+        }
+        return classLoaderDeclaringNames(perSpi);
+    }
+
+    /**
+     * Writes one descriptor per SPI, listing every entry given for it. Entries do not have to
+     * resolve to a real class - that is how the malformed-descriptor cases are set up.
+     */
+    private ClassLoader classLoaderDeclaringNames(final Map<Class<?>, List<String>> perSpi) throws Exception {
+        final File classes = temporaryFolder.newFolder();
+        final File descriptors = new File(classes, "META-INF/services");
+        assertTrue(descriptors.mkdirs());
+
+        for (final Map.Entry<Class<?>, List<String>> entry : perSpi.entrySet()) {
+            Files.write(new File(descriptors, entry.getKey().getName()).toPath(),
+                    String.join("\n", entry.getValue()).getBytes(StandardCharsets.UTF_8));
+        }
+
+        return new URLClassLoader(new URL[]{classes.toURI().toURL()},
+                ServiceLoaderProviderDiscoveryTest.class.getClassLoader());
+    }
+
+    @Test
+    public void featureIsDiscovered() throws Exception {
+        final List<Object> providers = new ArrayList<>();
+        CxfRsHttpListener.addServiceLoaderProviders(providers, classLoaderDeclaring(AFeature.class));
+
+        assertEquals(1, providers.size());
+        assertTrue(providers.get(0) instanceof AFeature);
+    }
+
+    @Test
+    public void dynamicFeatureIsDiscovered() throws Exception {
+        final List<Object> providers = new ArrayList<>();
+        CxfRsHttpListener.addServiceLoaderProviders(providers, classLoaderDeclaring(ADynamicFeature.class));
+
+        assertEquals(1, providers.size());
+        assertTrue(providers.get(0) instanceof ADynamicFeature);
+    }
+
+    @Test
+    public void bothKindsAreDiscovered() throws Exception {
+        final List<Object> providers = new ArrayList<>();
+        CxfRsHttpListener.addServiceLoaderProviders(providers,
+                classLoaderDeclaring(AFeature.class, ADynamicFeature.class));
+
+        assertEquals(2, providers.size());
+    }
+
+    @Test
+    public void alreadyRegisteredProvidersAreNotDuplicated() throws Exception {
+        final List<Object> providers = new ArrayList<>();
+        providers.add(new AFeature());
+        CxfRsHttpListener.addServiceLoaderProviders(providers, classLoaderDeclaring(AFeature.class));
+
+        assertEquals(1, providers.size());
+    }
+
+    @Test
+    public void noDescriptorAddsNothing() throws Exception {
+        final List<Object> providers = new ArrayList<>();
+        CxfRsHttpListener.addServiceLoaderProviders(providers, classLoaderDeclaring());
+
+        assertTrue(providers.isEmpty());
+    }
+
+    /**
+     * A single unusable entry must not discard the remaining providers declared for the same SPI.
+     */
+    @Test
+    public void brokenEntryDoesNotDiscardTheOthers() throws Exception {
+        final List<Object> providers = new ArrayList<>();
+        CxfRsHttpListener.addServiceLoaderProviders(providers, classLoaderDeclaringNames(
+                singletonMap(Feature.class, asList(
+                        "does.not.Exist",
+                        ThrowingFeature.class.getName(),
+                        AFeature.class.getName()))));
+
+        assertEquals(1, providers.size());
+        assertTrue(providers.get(0) instanceof AFeature);
+    }
+
+    /**
+     * The spec disables service loading when the Application maps jakarta.ws.rs.loadServices
+     * to Boolean.FALSE.
+     */
+    @Test
+    public void serviceLoadingCanBeDisabledByTheApplication() {
+        assertFalse(CxfRsHttpListener.isServiceLoadingEnabled(
+                new ConfigurableApplication(singletonMap("jakarta.ws.rs.loadServices", Boolean.FALSE))));
+    }
+
+    @Test
+    public void serviceLoadingIsEnabledByDefault() {
+        assertTrue(CxfRsHttpListener.isServiceLoadingEnabled(new Application()));
+        assertTrue(CxfRsHttpListener.isServiceLoadingEnabled(null));
+        assertTrue(CxfRsHttpListener.isServiceLoadingEnabled(
+                new ConfigurableApplication(singletonMap("jakarta.ws.rs.loadServices", Boolean.TRUE))));
+        assertTrue(CxfRsHttpListener.isServiceLoadingEnabled(
+                new ConfigurableApplication(emptyMap())));
+    }
+
+    public static class ConfigurableApplication extends Application {
+        private final Map<String, Object> properties;
+
+        public ConfigurableApplication(final Map<String, Object> properties) {
+            this.properties = properties;
+        }
+
+        @Override
+        public Map<String, Object> getProperties() {
+            return properties;
+        }
+    }
+
+    public static class ThrowingFeature implements Feature {
+        public ThrowingFeature() {
+            throw new IllegalStateException("should be skipped, not fatal");
+        }
+
+        @Override
+        public boolean configure(final FeatureContext context) {
+            return true;
+        }
+    }
+
+    public static class AFeature implements Feature {
+        @Override
+        public boolean configure(final FeatureContext context) {
+            return true;
+        }
+    }
+
+    public static class ADynamicFeature implements DynamicFeature {
+        @Override
+        public void configure(final ResourceInfo resourceInfo, final FeatureContext context) {
+            // no-op
+        }
+    }
+}

--- a/tck/jax-rs/jax-rs-tests/pom.xml
+++ b/tck/jax-rs/jax-rs-tests/pom.xml
@@ -144,12 +144,6 @@
                                 <!-- We have an own module for signature-Tests-->
                                 <exclude>**/JAXRSSigTestIT.java</exclude>
 
-                                <!-- TODO: TOMEE-4321 / CXF-9005
-                                 ee.jakarta.tck.ws.rs.jaxrs31.spec.extensions.JAXRSClientIT#featureIsRegisteredTest
-                                 ee.jakarta.tck.ws.rs.jaxrs31.spec.extensions.JAXRSClientIT#dynamicFeatureIsRegisteredTest
-                                -->
-                                <exclude>**/jaxrs31/spec/extensions/JAXRSClientIT.java</exclude>
-
                                 <!-- TODO: TOMEE-4436 - JAX-RS 3.1 mandates a default JSON provider, which is added by CXF by default.
                                  We skip that registration via 'openejb.jaxrs.skip.jakarta.json.providers.registration'.
                                  However, the TCK tests expect the provider to be registered in some (!) cases, so we exclude them f or now.


### PR DESCRIPTION
Jakarta REST requires `Feature` and `DynamicFeature` implementations declared in `META-INF/services` to be registered through the JDK `ServiceLoader` at deploy time ("Services", Providers / Lifecycle and Environment).

CXF does not implement this lookup itself — it relies on the container to hand it already resolved providers, which is why the CXF TCK run stays green on GlassFish. TomEE assembles its provider list on its own, so features packaged this way never registered.

## Changes

- `CxfRsHttpListener` scans both SPIs while assembling the provider list.
- Service loading is skipped when the `Application` maps `jakarta.ws.rs.loadServices` to `Boolean.FALSE`, as the spec mandates, and the existing `cxf.jaxrs.skip-provider-scanning` property is still honoured.
- Entries are loaded one at a time so a single broken descriptor entry is logged and skipped instead of discarding the remaining providers of that type.
- Discovered instances flow through the existing `providers(...)` path, so the `@ConstrainedTo` and deactivation checks still apply.
- Drops the now-passing TCK exclusion for `jaxrs31/spec/extensions/JAXRSClientIT`.

## Testing

- New `ServiceLoaderProviderDiscoveryTest` (8 tests) exercises discovery through a throwaway `URLClassLoader`, so it does not register these features into other tests in the module. Each assertion was confirmed to fail when the corresponding production change is reverted.
- `ee.jakarta.tck.ws.rs.jaxrs31.spec.extensions.JAXRSClientIT` passes 2/2 unexcluded against a rebuilt TomEE plus distribution; the wider `jaxrs31.**` slice passes 4/4.
- Full `openejb-cxf-rs` suite: 123 tests, the only failure being `EJBExceptionMapperTest.security`, which fails identically on a clean checkout of `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)